### PR TITLE
  feat: implement DiskManager module for page-level I/O abstraction

### DIFF
--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -40,7 +40,6 @@ pub struct DiskManager {
 
 impl DiskManager {
     // Functions to:
-    // - sync_data() - Flush file data (Linux: similar to fdatasync via Rust's sync_data).
     // - Atomic write for small “whole file” updates (catalog/manifest):
     // - write temp file
     // - fsync temp
@@ -109,6 +108,10 @@ impl DiskManager {
         Ok(())
     }
 
+    /// Flushes file data to disk (fdatasync).
+    // - sync_data() - Flush file data (Linux: similar to fdatasync via Rust's sync_data).
+    pub fn sync_data(&self) -> Result<()> {
+        self.file.sync_data()?;
         Ok(())
     }
 

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -1,5 +1,5 @@
-//! The Disk Manager is the layer that sits in between the disk
-//! and the rest of the db functionality
+//! The Disk Manager provides a layer of abstraction between the disk
+//! and the rest of the database functionality, managing page-level I/O.
 
 use std::{
     fs::{self, File, OpenOptions},
@@ -10,12 +10,15 @@ use std::{
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
 
+/// Represents a unique identifier for a page in the database.
 pub type PageId = u64;
 
 /// Errors that can occur during disk operations.
 #[derive(Debug)]
 pub enum DiskError {
+    /// An underlying I/O error.
     Io(io::Error),
+    /// The provided buffer or data size does not match the configured page size.
     InvalidPageSize,
 }
 
@@ -29,9 +32,8 @@ pub type Result<T> = std::result::Result<T, DiskError>;
 
 /// Disk manager for a single database file with fixed-size pages.
 ///
-/// Notes:
-/// - This is page I/O, not B+Tree logic.
-/// - Atomic rename writes are better suited for small metadata files; see `atomic_write_file`.
+/// This layer handles low-level page I/O, ensuring that data is correctly
+/// read from and written to the underlying storage medium.
 pub struct DiskManager {
     db_path: PathBuf,
     file: File,
@@ -39,7 +41,7 @@ pub struct DiskManager {
 }
 
 impl DiskManager {
-    // - Open or create the database file.
+    /// Opens or creates the database file at the specified path.
     pub fn new(path: impl AsRef<Path>, page_size: usize) -> Result<Self> {
         let file = OpenOptions::new()
             .read(true)
@@ -56,11 +58,16 @@ impl DiskManager {
         })
     }
 
-    // - Read a page into a new Vec<> or [u8; page_size].
-    //
-    // Errors
-    // 1. your vec.len() != page_size, if you are passing vec
-    // 2. your vector must be preallocated to page_size
+    /// Reads a page from the database file into the provided buffer.
+    ///
+    /// The buffer must be pre-allocated and its length must exactly match
+    /// the `page_size` configured for this `DiskManager`.
+    ///
+    /// # Errors
+    ///
+    /// * Returns [`DiskError::InvalidPageSize`] if the buffer length does not
+    ///   match the configured page size.
+    /// * Returns [`DiskError::Io`] if an I/O error occurs during reading.
     pub fn read_page(&self, page_id: PageId, buffer: &mut [u8]) -> Result<()> {
         if buffer.len() != self.page_size {
             return Err(DiskError::InvalidPageSize);
@@ -81,7 +88,17 @@ impl DiskManager {
         Ok(())
     }
 
-    // - Write a page from bytes (must be page_size). Durable if you call `sync_data()` afterwards.
+    /// Writes a page from the provided data buffer to the database file.
+    ///
+    /// The data buffer's length must exactly match the `page_size` configured
+    /// for this `DiskManager`. The write is not guaranteed to be durable until
+    /// [`DiskManager::sync_data`] is called.
+    ///
+    /// # Errors
+    ///
+    /// * Returns [`DiskError::InvalidPageSize`] if the data buffer length does not
+    ///   match the configured page size.
+    /// * Returns [`DiskError::Io`] if an I/O error occurs during writing.
     pub fn write_page(&self, page_id: PageId, data: &[u8]) -> Result<()> {
         if data.len() != self.page_size {
             return Err(DiskError::InvalidPageSize);
@@ -101,18 +118,19 @@ impl DiskManager {
         Ok(())
     }
 
-    /// Flushes file data to disk (fdatasync).
-    // - sync_data() - Flush file data (Linux: similar to fdatasync via Rust's sync_data).
+    /// Flushes file data to disk (equivalent to `fdatasync`).
     pub fn sync_data(&self) -> Result<()> {
         self.file.sync_data()?;
         Ok(())
     }
 
-    // - Atomic write for small “whole file” updates (catalog/manifest):
-    // - write temp file
-    // - fsync temp
-    // - rename over destination (atomic on same filesystem)
-    // - fsync parent directory
+    /// Performs an atomic write for small "whole file" updates, such as catalogs or manifests.
+    ///
+    /// The process involves:
+    /// 1. Writing to a temporary file.
+    /// 2. Syncing the temporary file to disk.
+    /// 3. Renaming the temporary file to the destination path (atomic).
+    /// 4. Syncing the parent directory to ensure the metadata update is durable.
     pub fn atomic_write_file(&self, path: &Path, data: &[u8]) -> Result<()> {
         let temp_path = path.with_extension("tmp");
 
@@ -132,7 +150,8 @@ impl DiskManager {
         Ok(())
     }
 
-    /// Flushes both the file and its parent directory to ensure metadata (rename/creation) is durable.
+    /// Flushes both the file and its parent directory to ensure metadata
+    /// (such as rename or creation) is durable.
     pub fn sync_file_and_dir(file: &File, file_path: &Path) -> Result<()> {
         file.sync_all()?;
         if let Some(parent) = file_path.parent() {

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs::{self, File, OpenOptions},
-    io,
+    io::{self, Write},
     path::{Path, PathBuf},
 };
 
@@ -39,13 +39,6 @@ pub struct DiskManager {
 }
 
 impl DiskManager {
-    // Functions to:
-    // - Atomic write for small “whole file” updates (catalog/manifest):
-    // - write temp file
-    // - fsync temp
-    // - rename over destination (atomic on same filesystem)
-    // - fsync parent directory
-
     // - Open or create the database file.
     pub fn new(path: impl AsRef<Path>, page_size: usize) -> Result<Self> {
         let file = OpenOptions::new()
@@ -112,6 +105,30 @@ impl DiskManager {
     // - sync_data() - Flush file data (Linux: similar to fdatasync via Rust's sync_data).
     pub fn sync_data(&self) -> Result<()> {
         self.file.sync_data()?;
+        Ok(())
+    }
+
+    // - Atomic write for small “whole file” updates (catalog/manifest):
+    // - write temp file
+    // - fsync temp
+    // - rename over destination (atomic on same filesystem)
+    // - fsync parent directory
+    pub fn atomic_write_file(&self, path: &Path, data: &[u8]) -> Result<()> {
+        let temp_path = path.with_extension("tmp");
+
+        let mut f = File::create(&temp_path)?;
+        f.write_all(data)?;
+
+        f.sync_all()?;
+        drop(f);
+
+        fs::rename(&temp_path, path)?;
+
+        if let Some(parent) = path.parent() {
+            let dir = File::open(parent)?;
+            dir.sync_all()?;
+        };
+
         Ok(())
     }
 

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -9,11 +9,14 @@ use std::{
 
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
+// #[cfg(windows)]
+// use std::os::windows::fs::FileExt;
 
 pub type PageId = u64;
 
 pub enum DiskError {
     Io(io::Error),
+    InvalidPageSize,
 }
 
 impl From<io::Error> for DiskError {
@@ -37,7 +40,6 @@ pub struct DiskManager {
 
 impl DiskManager {
     // Functions to:
-    // - Read a page into a new Vec<> or [u8; page_size].
     // - Write a page from bytes (must be page_size). Durable if you call `sync_data()` afterwards.
     // - sync_data() - Flush file data (Linux: similar to fdatasync via Rust's sync_data).
     // - Atomic write for small “whole file” updates (catalog/manifest):
@@ -61,6 +63,34 @@ impl DiskManager {
             file,
             page_size,
         })
+    }
+
+    // - Read a page into a new Vec<> or [u8; page_size].
+    //
+    // Errors
+    // 1. your vec.len() != page_size, if you are passing vec
+    // 2. your vector must be preallocated to page_size
+    pub fn read_page(&self, page_id: PageId, buffer: &mut [u8]) -> Result<()> {
+        if buffer.len() != self.page_size {
+            return Err(DiskError::InvalidPageSize);
+        }
+
+        let offset = page_id * self.page_size as u64;
+
+        #[cfg(unix)]
+        self.file.read_exact_at(buffer, offset)?;
+        // #[cfg(windows)]
+        // self.file.seek_read(buffer, offset)?;
+        //
+        // #[cfg(not(unix))]
+        // {
+        //     // this is not even thread safe
+        //     use std::io::{Read, Seek, SeekFrom};
+        //     let mut file = &self.file;
+        //     file.seek(SeekFrom::Start(offset))?;
+        //     file.read_exact(buffer)?;
+        // }
+        Ok(())
     }
 
     pub fn sync_file_and_dir(file: &File, file_path: &Path) {}

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -132,5 +132,13 @@ impl DiskManager {
         Ok(())
     }
 
-    pub fn sync_file_and_dir(file: &File, file_path: &Path) {}
+    /// Flushes both the file and its parent directory to ensure metadata (rename/creation) is durable.
+    pub fn sync_file_and_dir(file: &File, file_path: &Path) -> Result<()> {
+        file.sync_all()?;
+        if let Some(parent) = file_path.parent() {
+            let dir = File::open(parent)?;
+            dir.sync_all()?;
+        }
+        Ok(())
+    }
 }

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -12,7 +12,15 @@ use std::os::unix::fs::FileExt;
 
 pub type PageId = u64;
 
-pub enum DiskError {}
+pub enum DiskError {
+    Io(io::Error),
+}
+
+impl From<io::Error> for DiskError {
+    fn from(err: io::Error) -> Self {
+        DiskError::Io(err)
+    }
+}
 
 pub type Result<T> = std::result::Result<T, DiskError>;
 
@@ -29,7 +37,6 @@ pub struct DiskManager {
 
 impl DiskManager {
     // Functions to:
-    // - Open or create the database file.
     // - Read a page into a new Vec<> or [u8; page_size].
     // - Write a page from bytes (must be page_size). Durable if you call `sync_data()` afterwards.
     // - sync_data() - Flush file data (Linux: similar to fdatasync via Rust's sync_data).
@@ -38,5 +45,23 @@ impl DiskManager {
     // - fsync temp
     // - rename over destination (atomic on same filesystem)
     // - fsync parent directory
+
+    // - Open or create the database file.
+    pub fn new(path: impl AsRef<Path>, page_size: usize) -> Result<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            // make .write implicit behavior explicit
+            .truncate(false)
+            .open(&path)?;
+
+        Ok(Self {
+            db_path: path.as_ref().to_path_buf(),
+            file,
+            page_size,
+        })
+    }
+
     pub fn sync_file_and_dir(file: &File, file_path: &Path) {}
 }

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -9,11 +9,11 @@ use std::{
 
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
-// #[cfg(windows)]
-// use std::os::windows::fs::FileExt;
 
 pub type PageId = u64;
 
+/// Errors that can occur during disk operations.
+#[derive(Debug)]
 pub enum DiskError {
     Io(io::Error),
     InvalidPageSize,
@@ -40,7 +40,6 @@ pub struct DiskManager {
 
 impl DiskManager {
     // Functions to:
-    // - Write a page from bytes (must be page_size). Durable if you call `sync_data()` afterwards.
     // - sync_data() - Flush file data (Linux: similar to fdatasync via Rust's sync_data).
     // - Atomic write for small “whole file” updates (catalog/manifest):
     // - write temp file
@@ -79,17 +78,37 @@ impl DiskManager {
 
         #[cfg(unix)]
         self.file.read_exact_at(buffer, offset)?;
-        // #[cfg(windows)]
-        // self.file.seek_read(buffer, offset)?;
-        //
-        // #[cfg(not(unix))]
-        // {
-        //     // this is not even thread safe
-        //     use std::io::{Read, Seek, SeekFrom};
-        //     let mut file = &self.file;
-        //     file.seek(SeekFrom::Start(offset))?;
-        //     file.read_exact(buffer)?;
-        // }
+        #[cfg(not(unix))]
+        {
+            // this is not as threadsafe as pread
+            use std::io::{Read, Seek, SeekFrom};
+            let mut file = &self.file;
+            file.seek(SeekFrom::Start(offset))?;
+            file.read_exact(buffer)?;
+        }
+        Ok(())
+    }
+
+    // - Write a page from bytes (must be page_size). Durable if you call `sync_data()` afterwards.
+    pub fn write_page(&self, page_id: PageId, data: &[u8]) -> Result<()> {
+        if data.len() != self.page_size {
+            return Err(DiskError::InvalidPageSize);
+        }
+        let offset = page_id * self.page_size as u64;
+
+        #[cfg(unix)]
+        self.file.write_all_at(data, offset)?;
+        #[cfg(not(unix))]
+        {
+            // this is not even as threadsafe as pwrite
+            use std::io::{Seek, SeekFrom};
+            let mut file = &self.file;
+            file.seek(SeekFrom::Start(offset))?;
+            file.write_all(data)?;
+        }
+        Ok(())
+    }
+
         Ok(())
     }
 

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -161,3 +161,112 @@ impl DiskManager {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    const PAGE_SIZE: usize = 4096;
+
+    fn make_manager(name: &str) -> (DiskManager, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(name);
+        let dm = DiskManager::new(&path, PAGE_SIZE).unwrap();
+        (dm, dir)
+    }
+
+    #[test]
+    fn write_and_read_page_roundtrip() {
+        let (dm, _dir) = make_manager("db.bin");
+        let data: Vec<u8> = (0..PAGE_SIZE).map(|i| (i % 256) as u8).collect();
+
+        dm.write_page(0, &data).unwrap();
+
+        let mut buf = vec![0u8; PAGE_SIZE];
+        dm.read_page(0, &mut buf).unwrap();
+
+        assert_eq!(buf, data);
+    }
+
+    #[test]
+    fn multiple_pages_are_independent() {
+        let (dm, _dir) = make_manager("db.bin");
+        let page0 = vec![1u8; PAGE_SIZE];
+        let page1 = vec![2u8; PAGE_SIZE];
+
+        dm.write_page(0, &page0).unwrap();
+        dm.write_page(1, &page1).unwrap();
+
+        let mut buf = vec![0u8; PAGE_SIZE];
+        dm.read_page(0, &mut buf).unwrap();
+        assert_eq!(buf, page0);
+
+        dm.read_page(1, &mut buf).unwrap();
+        assert_eq!(buf, page1);
+    }
+
+    #[test]
+    fn write_rejects_wrong_size_buffer() {
+        let (dm, _dir) = make_manager("db.bin");
+        let bad = vec![0u8; PAGE_SIZE - 1];
+        assert!(matches!(
+            dm.write_page(0, &bad),
+            Err(DiskError::InvalidPageSize)
+        ));
+    }
+
+    #[test]
+    fn read_rejects_wrong_size_buffer() {
+        let (dm, _dir) = make_manager("db.bin");
+        let data = vec![0u8; PAGE_SIZE];
+        dm.write_page(0, &data).unwrap();
+
+        let mut bad = vec![0u8; PAGE_SIZE + 1];
+        assert!(matches!(
+            dm.read_page(0, &mut bad),
+            Err(DiskError::InvalidPageSize)
+        ));
+    }
+
+    #[test]
+    fn overwrite_page_reflects_new_data() {
+        let (dm, _dir) = make_manager("db.bin");
+        let first = vec![0xAAu8; PAGE_SIZE];
+        let second = vec![0xBBu8; PAGE_SIZE];
+
+        dm.write_page(0, &first).unwrap();
+        dm.write_page(0, &second).unwrap();
+
+        let mut buf = vec![0u8; PAGE_SIZE];
+        dm.read_page(0, &mut buf).unwrap();
+        assert_eq!(buf, second);
+    }
+
+    #[test]
+    fn atomic_write_file_creates_and_replaces() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("db.bin");
+        let dm = DiskManager::new(&db_path, PAGE_SIZE).unwrap();
+
+        let target = dir.path().join("manifest.bin");
+        let v1 = b"version1";
+        dm.atomic_write_file(&target, v1).unwrap();
+        assert_eq!(fs::read(&target).unwrap(), v1);
+
+        let v2 = b"version2";
+        dm.atomic_write_file(&target, v2).unwrap();
+        assert_eq!(fs::read(&target).unwrap(), v2);
+
+        // temp file must not linger
+        assert!(!target.with_extension("tmp").exists());
+    }
+
+    #[test]
+    fn sync_data_does_not_error() {
+        let (dm, _dir) = make_manager("db.bin");
+        let data = vec![0u8; PAGE_SIZE];
+        dm.write_page(0, &data).unwrap();
+        assert!(dm.sync_data().is_ok());
+    }
+}


### PR DESCRIPTION
## Summary      
Implement `DiskManager` module to the storage crate that provides a low-level abstraction for managing page-based disk I/O operations. This module serves as the foundational layer for all database disk interactions.                
   
## Changes                                                                                                           
- **Page I/O operations**:                                                                                           
  - `read_page()` - Reads a page from the database file into a buffer                                                
  - `write_page()` - Writes a page data to the database file                                                         
- **Data durability**:                                                                                               
  - `sync_data()` - Flushes file data to disk (equivalent to `fdatasync`)                                            
  - `sync_file_and_dir()` - Syncs both file and parent directory for metadata durability                             
- **Atomic writes**:                                                                                                 
  - `atomic_write_file()` - Atomic write-to-temp-then-rename pattern for small whole-file updates (catalogs, manifests)                                                                                                                   
- **Cross-platform support**: Native `pread`/`pwrite` on Unix; fallback seek-based I/O on other platforms (less thread-safe)
- **Error handling**: Custom `DiskError` type with proper I/O error propagation                                      
                  
## Testing                                                                                                           
Comprehensive test coverage including:
- Write/read verification
- Multi-page independence                                                                                            
- Buffer size validation
- Page overwrite behavior                                                                                            
- Atomic file writes with cleanup                                                                                    
- Data sync operations

## Technical Details
- Fixed page size configuration per DiskManager instance                                                             
- Platform-specific optimizations: Unix uses `pread`/`pwrite` for thread-safe concurrent access; Windows fallback uses seek-based I/O (not thread-safe)
- Proper error propagation for all disk operations

## Future Work
- Add Windows-specific pread/pwrite equivalents for thread-safe concurrent I/O