### PR TITLE
implement index layer and integrate with buffer pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ version = "0.1.0"
 dependencies = [
  "common",
  "crc32fast",
+ "db-core",
  "tempfile",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ members = ["crates/*"]
 clap = { version = "4", features = ["derive"] }
 common = { path = "crates/common" }
 thiserror = "1"
+db-core = { path = "crates/db-core"}

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -3,3 +3,6 @@ pub const MAX_FRAMES: usize = 80;
 pub const INVALID_FRAME_ID: u64 = u64::MAX;
 pub const NUM_SHARDS: usize = 8;
 pub const SHARD_MASK: u64 = (NUM_SHARDS - 1) as u64;
+
+
+pub const MAX_KEY_SIZE: usize = 512;

--- a/crates/db-core/src/lib.rs
+++ b/crates/db-core/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod transaction;

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -1,0 +1,313 @@
+//! MVCC transaction primitives — snapshot-based visibility and conflict detection.
+//!
+//! Every read and write in the B+Tree operates against a [`Transaction`] that
+//! bundles the transaction's identity (`txn_id`) with its point-in-time view
+//! of the database ([`Snapshot`]). This ensures consistent visibility: a
+//! transaction sees exactly the data that was committed before its snapshot
+//! was taken, and nothing from in-progress or future transactions.
+//!
+//! ## Visibility Rule (PostgreSQL Semantics)
+//!
+//! A record with `(xmin, xmax)` is visible to a transaction holding `snap` if:
+//!
+//! 1. The creating transaction (`xmin`) is committed from `snap`'s perspective.
+//! 2. The record has not been deleted/replaced (`xmax == 0`), OR the deleting
+//!    transaction (`xmax`) has NOT committed from `snap`'s perspective.
+//!
+//! ## Conflict Detection (First-Writer-Wins)
+//!
+//! Before modifying a record (setting its `xmax`), the caller must check that
+//! no other in-progress transaction has already claimed it. If `xmax` is set
+//! by an active transaction, the current transaction loses (returns
+//! `WriteConflict`). The first transaction to set `xmax` wins.
+
+/// A transaction's identity and its point-in-time view of the database.
+///
+/// All B+Tree operations (`get`, `insert`, `delete`, `update`, `range`)
+/// take a `&Transaction` to determine visibility and ownership.
+#[derive(Debug, Clone)]
+pub struct Transaction {
+    /// This transaction's unique, monotonically increasing ID.
+    pub txn_id: u64,
+    /// The snapshot taken at the start of this transaction.
+    pub snapshot: Snapshot,
+}
+
+impl Transaction {
+    /// Creates a transaction that sees all committed data.
+    ///
+    /// Uses `txn_id = 1` (not 0, because xmax=0 means "live") and
+    /// `Snapshot::latest()`. Suitable for single-threaded use or when
+    /// no transaction manager is wired.
+    pub fn auto() -> Self {
+        Self {
+            txn_id: 1,
+            snapshot: Snapshot::latest(),
+        }
+    }
+}
+
+/// A point-in-time view of transaction state.
+///
+/// Captures which transactions were in-progress when the snapshot was taken.
+/// Used to determine whether a record's `xmin`/`xmax` represent committed
+/// or uncommitted changes.
+///
+/// # Fields
+///
+/// - `xmin`: All transactions with ID < `xmin` are guaranteed finished
+///   (committed or aborted). Their effects are fully resolved.
+/// - `xmax`: All transactions with ID >= `xmax` have not yet started.
+///   Their effects are invisible.
+/// - `active`: Transaction IDs between `xmin` and `xmax` that were still
+///   in-progress when this snapshot was taken. Their uncommitted writes
+///   are invisible to the holder of this snapshot.
+#[derive(Debug, Clone)]
+pub struct Snapshot {
+    pub xmin: u64,
+    pub xmax: u64,
+    pub active: Vec<u64>,
+}
+
+impl Snapshot {
+    /// A snapshot that sees all committed data and treats all deletions as
+    /// visible. Equivalent to "read the latest state."
+    ///
+    /// With this snapshot:
+    /// - Every `xmin < u64::MAX` → committed → creator visible
+    /// - Every `xmax != 0` with `xmax < u64::MAX` → committed → record deleted
+    /// - `xmax == 0` → record live
+    pub fn latest() -> Self {
+        Self {
+            xmin: u64::MAX,
+            xmax: u64::MAX,
+            active: vec![],
+        }
+    }
+
+    /// Is the given transaction considered committed from this snapshot's
+    /// perspective?
+    ///
+    /// A transaction is committed if:
+    /// - Its ID is below `xmin` (finished before snapshot was taken), OR
+    /// - Its ID is between `xmin` and `xmax` AND not in the active list
+    ///   (it started before the snapshot but already committed).
+    ///
+    /// # Future work
+    /// This currently infers commit status from the snapshot alone. A real
+    /// implementation must consult the CLOG (commit-status table) to
+    /// distinguish committed from aborted transactions.
+    pub fn is_committed(&self, txn_id: u64) -> bool {
+        if txn_id == 0 {
+            return true; // txn_id 0 is the "auto" transaction, always committed
+        }
+        if txn_id < self.xmin {
+            return true; // finished before snapshot
+        }
+        if txn_id >= self.xmax {
+            return false; // not yet started
+        }
+        // Between xmin and xmax: committed if NOT in active list
+        !self.active.contains(&txn_id)
+        // TODO! consult CLOG for actual commit/abort status
+    }
+
+    /// Is the given transaction still in-progress from this snapshot's
+    /// perspective?
+    pub fn is_in_progress(&self, txn_id: u64) -> bool {
+        if txn_id == 0 {
+            return false;
+        }
+        if txn_id < self.xmin {
+            return false;
+        }
+        if txn_id >= self.xmax {
+            return true; // not yet started → treat as in-progress
+        }
+        self.active.contains(&txn_id)
+    }
+}
+
+/// Determines whether a record with `(rec_xmin, rec_xmax)` is visible to
+/// a reader holding the given snapshot.
+///
+/// # Visibility semantics
+///
+/// A record is visible if:
+/// 1. Its creator (`xmin`) has committed from the snapshot's perspective.
+/// 2. It has not been deleted (`xmax == 0`), OR the deleter (`xmax`) has
+///    NOT committed from the snapshot's perspective (the deletion hasn't
+///    "happened" for this reader).
+///
+/// # Examples
+///
+/// ```text
+/// snap = { xmin: 10, xmax: 20, active: [12, 15] }
+///
+/// Record (xmin=5,  xmax=0)  → visible   (creator committed, not deleted)
+/// Record (xmin=5,  xmax=8)  → invisible (deleted by committed txn 8)
+/// Record (xmin=12, xmax=0)  → invisible (creator in-progress, uncommitted)
+/// Record (xmin=5,  xmax=15) → visible   (deleter in-progress, deletion not final)
+/// Record (xmin=25, xmax=0)  → invisible (creator hasn't started yet)
+/// ```
+pub fn is_visible(rec_xmin: u64, rec_xmax: u64, snap: &Snapshot) -> bool {
+    // Step 1: The creating transaction must be committed.
+    if !snap.is_committed(rec_xmin) {
+        return false;
+    }
+
+    // Step 2: If not deleted/replaced, the record is visible.
+    if rec_xmax == 0 {
+        return true;
+    }
+
+    // Step 3: If the deleting transaction committed, the record is gone.
+    if snap.is_committed(rec_xmax) {
+        return false;
+    }
+
+    // The deleter hasn't committed → the deletion hasn't "happened" from
+    // our perspective → the record is still visible.
+    true
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snap(xmin: u64, xmax: u64, active: &[u64]) -> Snapshot {
+        Snapshot { xmin, xmax, active: active.to_vec() }
+    }
+
+    // ── Snapshot::latest() ────────────────────────────────────────────────
+
+    #[test]
+    fn latest_sees_live_record() {
+        let s = Snapshot::latest();
+        // xmin=5 committed (5 < MAX), xmax=0 → visible
+        assert!(is_visible(5, 0, &s));
+    }
+
+    #[test]
+    fn latest_hides_deleted_record() {
+        let s = Snapshot::latest();
+        // xmin=5 committed, xmax=10 committed (10 < MAX) → invisible
+        assert!(!is_visible(5, 10, &s));
+    }
+
+    #[test]
+    fn latest_auto_txn_visible() {
+        let s = Snapshot::latest();
+        // xmin=0 (auto txn), xmax=0 → visible
+        assert!(is_visible(0, 0, &s));
+    }
+
+    // ── Committed vs in-progress ─────────────────────────────────────────
+
+    #[test]
+    fn committed_creator_visible() {
+        let s = snap(10, 20, &[12, 15]);
+        // xmin=5 < 10 → committed → visible
+        assert!(is_visible(5, 0, &s));
+    }
+
+    #[test]
+    fn in_progress_creator_invisible() {
+        let s = snap(10, 20, &[12, 15]);
+        // xmin=12 in active list → not committed → invisible
+        assert!(!is_visible(12, 0, &s));
+    }
+
+    #[test]
+    fn future_creator_invisible() {
+        let s = snap(10, 20, &[]);
+        // xmin=25 >= xmax=20 → not started → invisible
+        assert!(!is_visible(25, 0, &s));
+    }
+
+    #[test]
+    fn committed_between_xmin_xmax_visible() {
+        let s = snap(10, 20, &[12, 15]);
+        // xmin=13: between 10 and 20, NOT in active → committed → visible
+        assert!(is_visible(13, 0, &s));
+    }
+
+    // ── Deletion visibility ──────────────────────────────────────────────
+
+    #[test]
+    fn committed_deletion_hides_record() {
+        let s = snap(10, 20, &[12, 15]);
+        // xmin=5 committed, xmax=8 committed (8 < 10) → deleted → invisible
+        assert!(!is_visible(5, 8, &s));
+    }
+
+    #[test]
+    fn in_progress_deletion_keeps_record_visible() {
+        let s = snap(10, 20, &[12, 15]);
+        // xmin=5 committed, xmax=15 in active → deletion not final → visible
+        assert!(is_visible(5, 15, &s));
+    }
+
+    #[test]
+    fn future_deletion_keeps_record_visible() {
+        let s = snap(10, 20, &[]);
+        // xmin=5 committed, xmax=25 >= xmax → future → visible
+        assert!(is_visible(5, 25, &s));
+    }
+
+    // ── is_committed / is_in_progress ────────────────────────────────────
+
+    #[test]
+    fn is_committed_below_xmin() {
+        let s = snap(10, 20, &[]);
+        assert!(s.is_committed(5));
+    }
+
+    #[test]
+    fn is_committed_in_active() {
+        let s = snap(10, 20, &[12]);
+        assert!(!s.is_committed(12));
+    }
+
+    #[test]
+    fn is_committed_between_not_active() {
+        let s = snap(10, 20, &[12]);
+        assert!(s.is_committed(15)); // between 10 and 20, not in active
+    }
+
+    #[test]
+    fn is_in_progress_in_active() {
+        let s = snap(10, 20, &[12]);
+        assert!(s.is_in_progress(12));
+    }
+
+    #[test]
+    fn is_in_progress_future() {
+        let s = snap(10, 20, &[]);
+        assert!(s.is_in_progress(25)); // >= xmax → treat as in-progress
+    }
+
+    #[test]
+    fn is_in_progress_committed() {
+        let s = snap(10, 20, &[]);
+        assert!(!s.is_in_progress(5)); // < xmin → finished
+    }
+
+    // ── Transaction::auto() ──────────────────────────────────────────────
+
+    #[test]
+    fn auto_txn_id_is_nonzero() {
+        let txn = Transaction::auto();
+        assert_ne!(txn.txn_id, 0); // must be non-zero so xmax=txn_id means "dead"
+    }
+
+    #[test]
+    fn auto_snapshot_is_latest() {
+        let txn = Transaction::auto();
+        assert_eq!(txn.snapshot.xmin, u64::MAX);
+        assert_eq!(txn.snapshot.xmax, u64::MAX);
+        assert!(txn.snapshot.active.is_empty());
+    }
+}

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2024"
 common.workspace = true
 crc32fast = "1.5.0"
 thiserror.workspace = true
-
+db-core.workspace = true
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1,58 +1,1192 @@
-//! Functionality for managing B+Tree
-//! Sort according to a key, add nodes, traverse the tree
-//! to find result to a query, etc.
+//! B+Tree index — Lehman-Yao optimistic locking with MVCC.
 //!
-//! Responsibilities (this module):
-//! - Provide a stable API: get/insert/delete/range_scan.
-//! - Navigate from root -> leaf using internal pages.
-//! - Modify leaf/internal pages.
-//! - Interact with BufferPool for page I/O and with WAL via BufferPool (WAL-before-page flush).
+//! ## Concurrency model
+//! Optimistic descent with shared latches only. Exclusive latch on the leaf
+//! for mutation. Snapshot-based MVCC visibility determines which record
+//! versions a transaction can see. First-writer-wins conflict detection
+//! prevents lost updates.
 
-use std::sync::Arc;
+use std::cmp::Ordering;
+use std::marker::PhantomData;
+use std::ops::{Bound, RangeBounds};
+use std::sync::{Arc, Mutex};
 
-use crate::{buffer_pool::BufferPoolManager, page::PageId};
+use common::{Key, Value, MAX_KEY_SIZE};
+
+use crate::buffer_pool::{BufferPoolError, BufferPoolManager, PageReadGuard, PageWriteGuard};
+use crate::page::{
+    InternalPageAccessor, InternalPageBuilder, InternalPageMutator,
+    LeafPageAccessor, LeafPageBuilder, LeafPageMutator,
+    PageId, INTERNAL, LEAF,
+};
+
+use db_core::transaction::{Transaction, Snapshot, is_visible}; 
+// ── Error type ────────────────────────────────────────────────────────────────
 
 #[derive(Debug)]
-pub enum IndexError {}
+pub enum IndexError {
+    KeyNotFound,
+    KeyTooLarge { size: usize, max: usize },
+    /// Insert attempted on a key that already has a visible version.
+    DuplicateKey,
+    /// Another in-progress transaction has already modified this record.
+    /// First-writer-wins: the current transaction should abort.
+    WriteConflict,
+    UnexpectedPageType { expected: u8, found: u8 },
+    BufferPool(BufferPoolError),
+}
+
+impl From<BufferPoolError> for IndexError {
+    fn from(e: BufferPoolError) -> Self {
+        IndexError::BufferPool(e)
+    }
+}
 
 pub type Result<T> = std::result::Result<T, IndexError>;
 
-/// Comparator for keys.
-/// Since B Tree is sorted by comparison of keys
-/// a method is needed to compare keys
-pub trait KeyCmp: Send + Sync + 'static {
-    fn cmp(&self, a: &[u8], b: &[u8]) -> std::cmp::Ordering;
+// ── SplitResult ───────────────────────────────────────────────────────────────
+
+struct SplitResult {
+    separator_key: Vec<u8>,
+    new_page_id: PageId,
 }
 
-/// Persistent metadata for an index.
-#[derive(Debug, Clone, Copy)]
-pub struct BTreeMeta {
-    pub root: PageId,
+// ── BTStack ───────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Copy)]
+struct BTStackEntry {
+    page_id: PageId,
 }
 
-/// B+Tree index (keys -> inline row bytes).
-pub struct BTreeIndex {
+type BTStack = Vec<BTStackEntry>;
+
+// ── BTreeIndex ────────────────────────────────────────────────────────────────
+
+pub struct BTreeIndex<K: Key, V: Value> {
     pool: Arc<BufferPoolManager>,
-    meta: BTreeMeta,
+    root: Mutex<PageId>,
+    _key: PhantomData<K>,
+    _val: PhantomData<V>,
 }
 
-impl BTreeIndex {
-    pub fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>> {
-        todo!()
+impl<K: Key, V: Value> BTreeIndex<K, V> {
+
+    // ── Constructors ──────────────────────────────────────────────────────────
+
+    pub fn open(pool: Arc<BufferPoolManager>, root_id: PageId) -> Self {
+        Self { pool, root: Mutex::new(root_id), _key: PhantomData, _val: PhantomData }
     }
 
-    /// Insert (key -> row_bytes).
-    pub fn insert(&self, key: &[u8], row: &[u8]) -> Result<()> {
-        todo!()
+    pub fn create(pool: Arc<BufferPoolManager>) -> Result<(Self, PageId)> {
+        let mut guard = pool.new_page()?;
+        let page_id = guard.page_id;
+        LeafPageBuilder::<K, V>::new(page_id, &mut guard[..]);
+        drop(guard);
+        Ok((Self::open(pool, page_id), page_id))
     }
 
-    /// Delete a key.
-    pub fn delete(&self, key: &[u8]) -> Result<()> {
-        todo!()
+    pub fn root_page_id(&self) -> PageId {
+        *self.root.lock().unwrap()
     }
 
-    /// Traverse internal nodes to find the leaf that should contain `key`.
-    fn find_leaf(&self, mut pid: PageId, key: &[u8]) -> Result<PageId> {
-        todo!()
+    // ── Public API ────────────────────────────────────────────────────────────
+
+    /// Look up `key` and return the value visible to `txn`, or `None`.
+    pub fn get(&self, key: &K::SelfType<'_>, txn: &Transaction) -> Result<Option<Vec<u8>>> {
+        let root_pid = *self.root.lock().unwrap();
+        let leaf_pid = self.find_leaf(root_pid, key)?;
+        let key_bytes = K::as_bytes(key);
+
+        // Shared latch on leaf + rightlink correction.
+        let mut page = self.pool.fetch_page(leaf_pid)?;
+        loop {
+            let acc = LeafPageAccessor::<K, V>::new(&page[..]);
+            if let Some(hk) = acc.high_key_bytes() {
+                if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                    let right = acc.rightlink().unwrap();
+                    drop(page);
+                    page = self.pool.fetch_page(right)?;
+                    continue;
+                }
+            }
+            break;
+        }
+
+        let acc = LeafPageAccessor::<K, V>::new(&page[..]);
+        match self.find_visible_slot(&acc, key, &txn.snapshot) {
+            Some(slot) => {
+                let val = acc.get_value(slot);
+                Ok(Some(V::as_bytes(&val).as_ref().to_vec()))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Insert a new `(key, value)` pair. Returns `DuplicateKey` if a visible
+    /// version already exists under `txn`'s snapshot.
+    pub fn insert(
+        &self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+        txn: &Transaction,
+    ) -> Result<()> {
+        let key_bytes = K::as_bytes(key);
+        let key_len = key_bytes.as_ref().len();
+
+        if key_len > MAX_KEY_SIZE {
+            return Err(IndexError::KeyTooLarge { size: key_len, max: MAX_KEY_SIZE });
+        }
+
+        let root_pid = *self.root.lock().unwrap();
+        let mut stack = BTStack::new();
+        let mut pid = root_pid;
+
+        // ── Phase 1: Optimistic descent (shared latches only) ────────────
+        let leaf_pid = loop {
+            let page = self.pool.fetch_page(pid)?;
+            match page[0] {
+                INTERNAL => {
+                    let acc = InternalPageAccessor::<K>::new(&page[..]);
+                    if let Some(hk) = acc.high_key_bytes() {
+                        if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                            let right = acc.rightlink().unwrap();
+                            drop(page);
+                            pid = right;
+                            continue;
+                        }
+                    }
+                    let (_, child_pid) = acc.find_child(key);
+                    stack.push(BTStackEntry { page_id: pid });
+                    drop(page);
+                    pid = child_pid;
+                }
+                LEAF => { drop(page); break pid; }
+                found => return Err(IndexError::UnexpectedPageType { expected: LEAF, found }),
+            }
+        };
+
+        // ── Phase 2: Exclusive latch on leaf + rightlink correction ──────
+        let mut leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
+        loop {
+            let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+            if let Some(hk) = acc.high_key_bytes() {
+                if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                    let right = acc.rightlink().unwrap();
+                    drop(leaf_guard);
+                    leaf_guard = self.pool.fetch_page_mut(right)?;
+                    continue;
+                }
+            }
+            break;
+        }
+
+        // ── Phase 3: Conflict detection + insert ─────────────────────────
+        let (slot, exact) = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).position(key);
+
+        if exact {
+            // Key exists — check for conflicts among duplicate versions.
+            let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+            self.check_insert_conflict(&acc, slot, key, txn)?;
+        }
+
+        // Insert new record.
+        let result = LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+            .insert(slot, key, value);
+
+        match result {
+            Ok(()) => {
+                // Set xmin to the inserting transaction.
+                LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+                    .set_xmin(slot, txn.txn_id);
+                return Ok(());
+            }
+            Err(_) => {
+                return self.split_and_insert(leaf_guard, key, value, txn.txn_id, &mut stack);
+            }
+        }
+    }
+
+    /// Delete `key` by setting xmax on the visible version.
+    pub fn delete(&self, key: &K::SelfType<'_>, txn: &Transaction) -> Result<()> {
+        let root_pid = *self.root.lock().unwrap();
+        let key_bytes = K::as_bytes(key);
+        let mut pid = root_pid;
+
+        // Optimistic descent.
+        let leaf_pid = loop {
+            let page = self.pool.fetch_page(pid)?;
+            match page[0] {
+                INTERNAL => {
+                    let acc = InternalPageAccessor::<K>::new(&page[..]);
+                    if let Some(hk) = acc.high_key_bytes() {
+                        if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                            let right = acc.rightlink().unwrap();
+                            drop(page);
+                            pid = right;
+                            continue;
+                        }
+                    }
+                    let (_, child_pid) = acc.find_child(key);
+                    drop(page);
+                    pid = child_pid;
+                }
+                LEAF => { drop(page); break pid; }
+                found => return Err(IndexError::UnexpectedPageType { expected: LEAF, found }),
+            }
+        };
+
+        // Exclusive latch + rightlink correction.
+        let mut leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
+        loop {
+            let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+            if let Some(hk) = acc.high_key_bytes() {
+                if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                    let right = acc.rightlink().unwrap();
+                    drop(leaf_guard);
+                    leaf_guard = self.pool.fetch_page_mut(right)?;
+                    continue;
+                }
+            }
+            break;
+        }
+
+        // Find visible version.
+        let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+        let visible_slot = self.find_visible_slot(&acc, key, &txn.snapshot)
+            .ok_or(IndexError::KeyNotFound)?;
+
+        // Conflict check: has another in-progress txn already set xmax?
+        let rec_xmax = acc.get_xmax(visible_slot);
+        self.check_write_conflict(rec_xmax, txn)?;
+
+        // Set xmax to mark this version as deleted by our transaction.
+        LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+            .set_xmax(visible_slot, txn.txn_id);
+
+        Ok(())
+    }
+
+    /// Update `key` with `new_value`. Atomically sets xmax on the old version
+    /// and inserts a new version — both under the same exclusive latch.
+    pub fn update(
+        &self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+        txn: &Transaction,
+    ) -> Result<()> {
+        let key_bytes = K::as_bytes(key);
+        let key_len = key_bytes.as_ref().len();
+
+        if key_len > MAX_KEY_SIZE {
+            return Err(IndexError::KeyTooLarge { size: key_len, max: MAX_KEY_SIZE });
+        }
+
+        let root_pid = *self.root.lock().unwrap();
+        let mut stack = BTStack::new();
+        let mut pid = root_pid;
+
+        // Optimistic descent.
+        let leaf_pid = loop {
+            let page = self.pool.fetch_page(pid)?;
+            match page[0] {
+                INTERNAL => {
+                    let acc = InternalPageAccessor::<K>::new(&page[..]);
+                    if let Some(hk) = acc.high_key_bytes() {
+                        if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                            let right = acc.rightlink().unwrap();
+                            drop(page);
+                            pid = right;
+                            continue;
+                        }
+                    }
+                    let (_, child_pid) = acc.find_child(key);
+                    stack.push(BTStackEntry { page_id: pid });
+                    drop(page);
+                    pid = child_pid;
+                }
+                LEAF => { drop(page); break pid; }
+                found => return Err(IndexError::UnexpectedPageType { expected: LEAF, found }),
+            }
+        };
+
+        // Exclusive latch + rightlink correction.
+        let mut leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
+        loop {
+            let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+            if let Some(hk) = acc.high_key_bytes() {
+                if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                    let right = acc.rightlink().unwrap();
+                    drop(leaf_guard);
+                    leaf_guard = self.pool.fetch_page_mut(right)?;
+                    continue;
+                }
+            }
+            break;
+        }
+
+        // Find visible version under same exclusive latch.
+        let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+        let visible_slot = self.find_visible_slot(&acc, key, &txn.snapshot)
+            .ok_or(IndexError::KeyNotFound)?;
+
+        // Conflict check.
+        let rec_xmax = acc.get_xmax(visible_slot);
+        self.check_write_conflict(rec_xmax, txn)?;
+
+        // ── ATOMIC: set xmax on old + insert new (same latch) ────────────
+        LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+            .set_xmax(visible_slot, txn.txn_id);
+
+        // Find insert position for the new version.
+        let (slot, _) = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).position(key);
+        let result = LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+            .insert(slot, key, value);
+
+        match result {
+            Ok(()) => {
+                LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+                    .set_xmin(slot, txn.txn_id);
+                return Ok(());
+            }
+            Err(_) => {
+                return self.split_and_insert(leaf_guard, key, value, txn.txn_id, &mut stack);
+            }
+        }
+    }
+
+    /// Return a lazy iterator over entries visible to `txn`.
+    pub fn range<R>(&self, range: R, txn: &Transaction) -> RangeScan<'_, K, V>
+    where
+        K: 'static,
+        R: RangeBounds<K::SelfType<'static>>,
+    {
+        let root_pid = *self.root.lock().unwrap();
+
+        let (current_leaf, start_slot) = match range.start_bound() {
+            Bound::Included(k) => {
+                let leaf_pid = self.find_leaf(root_pid, k).expect("find_leaf failed");
+                let page = self.pool.fetch_page(leaf_pid).expect("fetch_page failed");
+                let (slot, _) = LeafPageAccessor::<K, V>::new(&page[..]).position(k);
+                (Some(leaf_pid), slot)
+            }
+            Bound::Excluded(k) => {
+                let leaf_pid = self.find_leaf(root_pid, k).expect("find_leaf failed");
+                let page = self.pool.fetch_page(leaf_pid).expect("fetch_page failed");
+                let (slot, exact) = LeafPageAccessor::<K, V>::new(&page[..]).position(k);
+                (Some(leaf_pid), if exact { slot + 1 } else { slot })
+            }
+            Bound::Unbounded => {
+                let leaf_pid = self.find_leftmost_leaf(root_pid).expect("find_leftmost failed");
+                (Some(leaf_pid), 0)
+            }
+        };
+
+        let (end_key, end_inclusive) = match range.end_bound() {
+            Bound::Included(k) => (Some(K::as_bytes(k).as_ref().to_vec()), true),
+            Bound::Excluded(k) => (Some(K::as_bytes(k).as_ref().to_vec()), false),
+            Bound::Unbounded   => (None, false),
+        };
+
+        RangeScan {
+            pool: &self.pool,
+            current_leaf,
+            slot: start_slot,
+            end_key,
+            end_inclusive,
+            snapshot: txn.snapshot.clone(),
+            _key: PhantomData,
+            _val: PhantomData,
+        }
+    }
+
+    // ── MVCC helpers ──────────────────────────────────────────────────────────
+
+    /// Scan among duplicate keys to find the version visible under `snap`.
+    ///
+    /// `position()` may return any slot among duplicates (binary search
+    /// doesn't guarantee the first). We scan backward to the first duplicate,
+    /// then forward through all of them looking for a visible version.
+    fn find_visible_slot(
+        &self,
+        acc: &LeafPageAccessor<'_, K, V>,
+        key: &K::SelfType<'_>,
+        snap: &Snapshot,
+    ) -> Option<usize> {
+        let key_bytes = K::as_bytes(key);
+        let key_ref = key_bytes.as_ref();
+        let (start, found) = acc.position(key);
+        if !found { return None; }
+
+        // Scan backward to find the first duplicate.
+        let mut first = start;
+        while first > 0 {
+            let prev_key_val = acc.get_key(first - 1);
+            let prev_key = K::as_bytes(&prev_key_val);
+            if K::compare(prev_key.as_ref(), key_ref) != Ordering::Equal {
+                break;
+            }
+            first -= 1;
+        }
+
+        // Scan forward from the first duplicate.
+        let n = acc.num_pairs() as usize;
+        let mut i = first;
+        while i < n {
+            let rec_key_val = acc.get_key(i);
+            let rec_key = K::as_bytes(&rec_key_val);
+            if K::compare(rec_key.as_ref(), key_ref) != Ordering::Equal {
+                break;
+            }
+            if is_visible(acc.get_xmin(i), acc.get_xmax(i), snap) {
+                return Some(i);
+            }
+            i += 1;
+        }
+        None
+    }
+
+    /// Check for insert conflicts among duplicate versions of `key`.
+    ///
+    /// Returns `DuplicateKey` if a visible version exists.
+    /// Returns `WriteConflict` if an in-progress txn has an uncommitted
+    /// insert (xmin in-progress) or uncommitted delete (xmax in-progress).
+    fn check_insert_conflict(
+        &self,
+        acc: &LeafPageAccessor<'_, K, V>,
+        start_slot: usize,
+        key: &K::SelfType<'_>,
+        txn: &Transaction,
+    ) -> Result<()> {
+        let key_bytes = K::as_bytes(key);
+        let key_ref = key_bytes.as_ref();
+        let n = acc.num_pairs() as usize;
+
+        // Scan backward to first duplicate (position may land anywhere).
+        let mut i = start_slot;
+        while i > 0 {
+            let prev_key_val = acc.get_key(i - 1);
+            let prev_key = K::as_bytes(&prev_key_val);
+            if K::compare(prev_key.as_ref(), key_ref) != Ordering::Equal { break; }
+            i -= 1;
+        }
+
+        while i < n {
+            let rec_key_val = acc.get_key(i);
+            let rec_key = K::as_bytes(&rec_key_val);
+            if K::compare(rec_key.as_ref(), key_ref) != Ordering::Equal {
+                break;
+            }
+
+            let xmin = acc.get_xmin(i);
+            let xmax = acc.get_xmax(i);
+
+            // If xmin is in-progress (uncommitted insert by another txn),
+            // that txn might commit → would create a duplicate.
+            if xmin != txn.txn_id && txn.snapshot.is_in_progress(xmin) {
+                // TODO! wait-for-commit: block until xmin txn commits/aborts
+                return Err(IndexError::WriteConflict);
+            }
+
+            // If the record is visible to us, it's a duplicate.
+            if is_visible(xmin, xmax, &txn.snapshot) {
+                return Err(IndexError::DuplicateKey);
+            }
+
+            // If xmax is in-progress (another txn is deleting this version),
+            // that deletion might abort → the record would reappear as live.
+            if xmax != 0 && xmax != txn.txn_id && txn.snapshot.is_in_progress(xmax) {
+                // TODO! wait-for-commit: block until xmax txn commits/aborts
+                return Err(IndexError::WriteConflict);
+            }
+
+            i += 1;
+        }
+        Ok(())
+    }
+
+    /// First-writer-wins conflict check before setting xmax on a record.
+    fn check_write_conflict(&self, rec_xmax: u64, txn: &Transaction) -> Result<()> {
+        if rec_xmax == 0 {
+            return Ok(()); // nobody has touched this version
+        }
+        if rec_xmax == txn.txn_id {
+            return Ok(()); // we already modified it (re-entrant)
+        }
+        if txn.snapshot.is_in_progress(rec_xmax) {
+            // Another active txn claimed this version → first writer wins → we lose.
+            return Err(IndexError::WriteConflict);
+        }
+        // The modifier committed → version is already dead.
+        // Caller will get KeyNotFound since find_visible_slot won't find it.
+        Ok(())
+    }
+
+    // ── Tree navigation ───────────────────────────────────────────────────────
+
+    fn find_leaf(&self, start_pid: PageId, key: &K::SelfType<'_>) -> Result<PageId> {
+        let mut pid = start_pid;
+        let mut parent_latch: Option<PageReadGuard<'_>> = None;
+
+        loop {
+            // acquired read guard on fetched page 
+            let page = self.pool.fetch_page(pid)?;
+            // dropped parent latch 
+            drop(parent_latch.take());
+
+            match page[0] {
+                INTERNAL => {
+                    let acc = InternalPageAccessor::<K>::new(&page[..]);
+                    // rightlink correction in case split happened before we acquired lock on child 
+                    if let Some(hk) = acc.high_key_bytes() {
+                        let key_b = K::as_bytes(key);
+                        if K::compare(key_b.as_ref(), hk) != Ordering::Less {
+                            let right = acc.rightlink().unwrap();
+                            drop(page);
+                            pid = right;
+                            continue;
+                        }
+                    }
+                    let (_, child_pid) = acc.find_child(key);
+                    parent_latch = Some(page);
+                    pid = child_pid;
+                }
+                LEAF => { drop(page); return Ok(pid); }
+                found => {
+                    drop(page);
+                    return Err(IndexError::UnexpectedPageType { expected: LEAF, found });
+                }
+            }
+        }
+    }
+
+    fn find_leftmost_leaf(&self, start_pid: PageId) -> Result<PageId> {
+        let mut pid = start_pid;
+        loop {
+            let page = self.pool.fetch_page(pid)?;
+            match page[0] {
+                INTERNAL => {
+                    let child = InternalPageAccessor::<K>::new(&page[..]).child_page_at(0);
+                    drop(page);
+                    pid = child;
+                }
+                LEAF => { drop(page); return Ok(pid); }
+                found => {
+                    drop(page);
+                    return Err(IndexError::UnexpectedPageType { expected: LEAF, found });
+                }
+            }
+        }
+    }
+
+    // ── Split ─────────────────────────────────────────────────────────────────
+
+    /// Split a full leaf then insert `(key, value)` into the correct half.
+    /// Takes ownership of `leaf_guard` so it can be dropped when inserting
+    /// into the right page. Propagates the new separator up via `stack`.
+    fn split_and_insert(
+        &self,
+        mut leaf_guard: PageWriteGuard<'_>,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+        txn_id: u64,
+        stack: &mut BTStack,
+    ) -> Result<()> {
+        let key_bytes = K::as_bytes(key);
+        let leaf_pid_actual = leaf_guard.page_id;
+        let split = self.split_leaf_ly(&mut leaf_guard)?;
+
+        let target_pid = if K::compare(key_bytes.as_ref(), split.separator_key.as_slice()) != Ordering::Less {
+            split.new_page_id
+        } else {
+            leaf_pid_actual
+        };
+
+        if target_pid == leaf_pid_actual {
+            let (s, _) = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).position(key);
+            LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+                .insert(s, key, value)
+                .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+            LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
+                .set_xmin(s, txn_id);
+        } else {
+            drop(leaf_guard);
+            let mut right = self.pool.fetch_page_mut(target_pid)?;
+            let (s, _) = LeafPageAccessor::<K, V>::new(&right[..]).position(key);
+            LeafPageMutator::<K, V>::new(&mut right[..])
+                .insert(s, key, value)
+                .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+            LeafPageMutator::<K, V>::new(&mut right[..])
+                .set_xmin(s, txn_id);
+        }
+
+        self.insert_separator_via_stack(stack, split.separator_key, split.new_page_id)
+    }
+
+    fn split_leaf_ly(
+        &self,
+        leaf_guard: &mut crate::buffer_pool::PageWriteGuard<'_>,
+    ) -> Result<SplitResult> {
+        let leaf_pid = leaf_guard.page_id;
+        let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+        let n = acc.num_pairs() as usize;
+
+        // Find a split point where the key CHANGES.
+        // Start at n/2 and scan forward until we hit a different key.
+        // This ensures all versions of the same key stay on the same page.
+        let mid = {
+            let target = n / 2;
+            let target_key = K::as_bytes(&acc.get_key(target)).as_ref().to_vec();
+            let mut split_at = target;
+            // Scan forward past all slots with the same key as target.
+            while split_at < n {
+                let key_val = acc.get_key(split_at);
+                let k = K::as_bytes(&key_val);
+                if K::compare(k.as_ref(), &target_key) != Ordering::Equal {
+                    break;
+                }
+                split_at += 1;
+            }
+            // If we reached the end (all remaining keys are duplicates),
+            // try scanning backward from target instead.
+            if split_at >= n {
+                split_at = target;
+                while split_at > 0 {
+                    let key_val = acc.get_key(split_at - 1);
+                    let k = K::as_bytes(&key_val);
+                    if K::compare(k.as_ref(), &target_key) != Ordering::Equal {
+                        break;
+                    }
+                    split_at -= 1;
+                }
+            }
+            // If split_at is 0, the entire page has the same key
+            // (pathological case — can only happen if MAX versions of one key
+            // fill the page). Fall back to n/2 and accept the cross-page split.
+            if split_at == 0 { target } else { split_at }
+        };
+
+        let separator_key = K::as_bytes(&acc.get_key(mid)).as_ref().to_vec();
+        let old_rightlink = acc.rightlink();
+        let old_high_key: Option<Vec<u8>> = acc.high_key_bytes().map(|b| b.to_vec());
+
+        // Snapshot ALL entries (including dead versions) to preserve MVCC history.
+        let left_entries: Vec<(Vec<u8>, Vec<u8>, u64, u64)> = (0..mid)
+            .map(|i| {
+                let k = K::as_bytes(&acc.get_key(i)).as_ref().to_vec();
+                let v = V::as_bytes(&acc.get_value(i)).as_ref().to_vec();
+                (k, v, acc.get_xmin(i), acc.get_xmax(i))
+            })
+            .collect();
+
+        // Allocate right page.
+        let mut right_guard = self.pool.new_page()?;
+        let right_pid = right_guard.page_id;
+
+        {
+            let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+            let mut builder = LeafPageBuilder::<K, V>::new(right_pid, &mut right_guard[..]);
+            if let Some(ref hk) = old_high_key {
+                builder.set_high_key(hk);
+            }
+            builder.set_rightlink(old_rightlink);
+            builder.set_prev_page(Some(leaf_pid));
+            for i in mid..n {
+                builder.push_with_mvcc(
+                    &acc.get_key(i), &acc.get_value(i),
+                    acc.get_xmin(i), acc.get_xmax(i),
+                );
+            }
+            builder.finish();
+        }
+
+        drop(right_guard);
+        if let Some(old_right_pid) = old_rightlink {
+            let mut old_right = self.pool.fetch_page_mut(old_right_pid)?;
+            LeafPageMutator::<K, V>::new(&mut old_right[..]).set_prev_page(Some(right_pid));
+        }
+
+        // Rebuild left page from scratch (high_key changes slot base).
+        {
+            let lsn = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).lsn();
+            let prev = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).prev_page();
+            let mut builder = LeafPageBuilder::<K, V>::new(leaf_pid, &mut leaf_guard[..]);
+            builder.set_high_key(&separator_key);
+            builder.set_rightlink(Some(right_pid));
+            builder.set_prev_page(prev);
+            for (k, v, xmin, xmax) in &left_entries {
+                builder.push_with_mvcc(
+                    &K::from_bytes(k), &V::from_bytes(v), *xmin, *xmax,
+                );
+            }
+            let mut m = builder.finish();
+            m.set_lsn(lsn);
+        }
+
+        Ok(SplitResult { separator_key, new_page_id: right_pid })
+    }
+
+    fn insert_separator_via_stack(
+        &self,
+        stack: &mut BTStack,
+        mut sep_key: Vec<u8>,
+        mut right_pid: PageId,
+    ) -> Result<()> {
+        loop {
+            if stack.is_empty() {
+                let old_root_pid = *self.root.lock().unwrap();
+                let mut new_root_guard = self.pool.new_page()?;
+                let new_root_pid = new_root_guard.page_id;
+
+                let mut builder = InternalPageBuilder::<K>::new(new_root_pid, &mut new_root_guard[..]);
+                builder.push_first_child(old_root_pid);
+                builder.push_key_and_right_child(&K::from_bytes(&sep_key), right_pid);
+                builder.finish();
+                drop(new_root_guard);
+
+                *self.root.lock().unwrap() = new_root_pid;
+                return Ok(());
+            }
+
+            let entry = stack.pop().unwrap();
+            let mut parent_pid = entry.page_id;
+
+            let mut parent_guard = self.pool.fetch_page_mut(parent_pid)?;
+            loop {
+                let acc = InternalPageAccessor::<K>::new(&parent_guard[..]);
+                if let Some(hk) = acc.high_key_bytes() {
+                    if K::compare(&sep_key, hk) != Ordering::Less {
+                        let right = acc.rightlink().unwrap();
+                        drop(parent_guard);
+                        parent_pid = right;
+                        parent_guard = self.pool.fetch_page_mut(parent_pid)?;
+                        continue;
+                    }
+                }
+                break;
+            }
+
+            let acc = InternalPageAccessor::<K>::new(&parent_guard[..]);
+            if acc.can_fit(sep_key.len()) {
+                let (idx, _) = acc.find_child(&K::from_bytes(&sep_key));
+                InternalPageMutator::<K>::new(&mut parent_guard[..])
+                    .insert_key_and_right_child(idx, &K::from_bytes(&sep_key), right_pid)
+                    .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+                return Ok(());
+            }
+
+            let parent_split = self.split_internal_ly(
+                &mut parent_guard, &sep_key, right_pid,
+            )?;
+            drop(parent_guard);
+
+            sep_key = parent_split.separator_key;
+            right_pid = parent_split.new_page_id;
+        }
+    }
+
+    fn split_internal_ly(
+        &self,
+        guard: &mut crate::buffer_pool::PageWriteGuard<'_>,
+        sep_key: &[u8],
+        right_child: PageId,
+    ) -> Result<SplitResult> {
+        let internal_pid = guard.page_id;
+        let acc = InternalPageAccessor::<K>::new(&guard[..]);
+        let n = acc.num_keys() as usize;
+
+        let old_rightlink = acc.rightlink();
+        let old_high_key: Option<Vec<u8>> = acc.high_key_bytes().map(|b| b.to_vec());
+
+        let mut children: Vec<PageId> = (0..=n).map(|i| acc.child_page_at(i)).collect();
+        let mut keys: Vec<Vec<u8>> = (0..n)
+            .map(|i| K::as_bytes(&acc.key_at(i)).as_ref().to_vec())
+            .collect();
+
+        let insert_idx = {
+            let mut lo = 0usize;
+            let mut hi = keys.len();
+            while lo < hi {
+                let mid_i = lo + (hi - lo) / 2;
+                if K::compare(&keys[mid_i], sep_key) == Ordering::Greater {
+                    hi = mid_i;
+                } else {
+                    lo = mid_i + 1;
+                }
+            }
+            lo
+        };
+        keys.insert(insert_idx, sep_key.to_vec());
+        children.insert(insert_idx + 1, right_child);
+
+        let total_keys = keys.len();
+        let mid = total_keys / 2;
+        let push_up_key = keys[mid].clone();
+
+        let mut right_guard = self.pool.new_page()?;
+        let right_pid = right_guard.page_id;
+        {
+            let mut builder = InternalPageBuilder::<K>::new(right_pid, &mut right_guard[..]);
+            builder.push_first_child(children[mid + 1]);
+            for i in (mid + 1)..total_keys {
+                builder.push_key_and_right_child(&K::from_bytes(&keys[i]), children[i + 1]);
+            }
+            builder.set_rightlink(old_rightlink);
+            if let Some(ref hk) = old_high_key {
+                builder.set_high_key(hk);
+            }
+            builder.finish();
+        }
+        drop(right_guard);
+
+        {
+            let lsn = InternalPageAccessor::<K>::new(&guard[..]).lsn();
+            let mut builder = InternalPageBuilder::<K>::new(internal_pid, &mut guard[..]);
+            builder.set_rightlink(Some(right_pid));
+            builder.set_high_key(&push_up_key);
+            builder.push_first_child(children[0]);
+            for i in 0..mid {
+                builder.push_key_and_right_child(&K::from_bytes(&keys[i]), children[i + 1]);
+            }
+            let mut m = builder.finish();
+            m.set_lsn(lsn);
+        }
+
+        Ok(SplitResult { separator_key: push_up_key, new_page_id: right_pid })
+    }
+}
+
+// ── RangeScan ─────────────────────────────────────────────────────────────────
+
+pub struct RangeScan<'a, K: Key, V: Value> {
+    pool: &'a BufferPoolManager,
+    current_leaf: Option<PageId>,
+    slot: usize,
+    end_key: Option<Vec<u8>>,
+    end_inclusive: bool,
+    snapshot: Snapshot,
+    _key: PhantomData<K>,
+    _val: PhantomData<V>,
+}
+
+impl<'a, K: Key, V: Value> Iterator for RangeScan<'a, K, V> {
+    type Item = Result<(Vec<u8>, Vec<u8>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let leaf_pid = self.current_leaf?;
+            let page = match self.pool.fetch_page(leaf_pid) {
+                Ok(p) => p,
+                Err(e) => return Some(Err(e.into())),
+            };
+            let acc = LeafPageAccessor::<K, V>::new(&page[..]);
+            let n = acc.num_pairs() as usize;
+
+            while self.slot < n {
+                let xmin = acc.get_xmin(self.slot);
+                let xmax = acc.get_xmax(self.slot);
+
+                // Skip records not visible to our snapshot.
+                if !is_visible(xmin, xmax, &self.snapshot) {
+                    self.slot += 1;
+                    continue;
+                }
+
+                let k = K::as_bytes(&acc.get_key(self.slot)).as_ref().to_vec();
+                let v = V::as_bytes(&acc.get_value(self.slot)).as_ref().to_vec();
+
+                let in_range = match &self.end_key {
+                    None => true,
+                    Some(end) => {
+                        let cmp = K::compare(&k, end);
+                        if self.end_inclusive { cmp != Ordering::Greater }
+                        else { cmp == Ordering::Less }
+                    }
+                };
+
+                if !in_range {
+                    self.current_leaf = None;
+                    return None;
+                }
+
+                self.slot += 1;
+                return Some(Ok((k, v)));
+            }
+
+            self.current_leaf = acc.rightlink();
+            self.slot = 0;
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::buffer_pool::manager::BufferPoolManager;
+    use crate::disk::DiskManager;
+    use common::MAX_PAGE_SIZE;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn make_index() -> BTreeIndex<&'static [u8], &'static [u8]> {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        std::mem::forget(dir);
+        let disk = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
+        let pool = Arc::new(BufferPoolManager::new(disk));
+        let (index, _) = BTreeIndex::create(pool).unwrap();
+        index
+    }
+
+    fn auto() -> Transaction { Transaction::auto() }
+
+    fn leak_bytes(b: &[u8]) -> &'static [u8] {
+        Box::leak(b.to_vec().into_boxed_slice())
+    }
+
+    // ── Basic get / insert ────────────────────────────────────────────────
+
+    #[test]
+    fn get_missing_key_returns_none() {
+        let idx = make_index();
+        assert!(idx.get(&(&b"hello"[..]), &auto()).unwrap().is_none());
+    }
+
+    #[test]
+    fn insert_and_get_single_entry() {
+        let idx = make_index();
+        idx.insert(&(&b"key"[..]), &(&b"value"[..]), &auto()).unwrap();
+        let got = idx.get(&(&b"key"[..]), &auto()).unwrap().unwrap();
+        assert_eq!(got, b"value");
+    }
+
+    #[test]
+    fn insert_duplicate_returns_error() {
+        let idx = make_index();
+        idx.insert(&(&b"k"[..]), &(&b"v1"[..]), &auto()).unwrap();
+        match idx.insert(&(&b"k"[..]), &(&b"v2"[..]), &auto()) {
+            Err(IndexError::DuplicateKey) => {}
+            other => panic!("expected DuplicateKey, got {:?}", other),
+        }
+    }
+
+    // ── Update ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn update_returns_new_value() {
+        let idx = make_index();
+        idx.insert(&(&b"k"[..]), &(&b"v1"[..]), &auto()).unwrap();
+        idx.update(&(&b"k"[..]), &(&b"v2"[..]), &auto()).unwrap();
+        let got = idx.get(&(&b"k"[..]), &auto()).unwrap().unwrap();
+        assert_eq!(got, b"v2");
+    }
+
+    #[test]
+    fn update_missing_key_returns_error() {
+        let idx = make_index();
+        match idx.update(&(&b"nope"[..]), &(&b"v"[..]), &auto()) {
+            Err(IndexError::KeyNotFound) => {}
+            other => panic!("expected KeyNotFound, got {:?}", other),
+        }
+    }
+
+    // ── Delete ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn delete_missing_key_returns_error() {
+        let idx = make_index();
+        match idx.delete(&(&b"nope"[..]), &auto()) {
+            Err(IndexError::KeyNotFound) => {}
+            other => panic!("expected KeyNotFound, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn insert_then_delete() {
+        let idx = make_index();
+        idx.insert(&(&b"k"[..]), &(&b"v"[..]), &auto()).unwrap();
+        idx.delete(&(&b"k"[..]), &auto()).unwrap();
+        assert!(idx.get(&(&b"k"[..]), &auto()).unwrap().is_none());
+    }
+
+    #[test]
+    fn insert_after_delete() {
+        let idx = make_index();
+        idx.insert(&(&b"k"[..]), &(&b"v1"[..]), &auto()).unwrap();
+        idx.delete(&(&b"k"[..]), &auto()).unwrap();
+        // After delete, insert a new version — should succeed (old is dead).
+        let r = idx.insert(&(&b"k"[..]), &(&b"v2"[..]), &auto());
+        assert!(r.is_ok(), "insert after delete failed: {:?}", r.err());
+        let got = idx.get(&(&b"k"[..]), &auto()).unwrap();
+        assert!(got.is_some(), "get returned None after insert-after-delete");
+        assert_eq!(got.unwrap(), b"v2");
+    }
+
+    // ── Sequential inserts / splits ──────────────────────────────────────
+
+    #[test]
+    fn sequential_inserts_all_readable() {
+        let idx = make_index();
+        for i in 0u64..200 {
+            let k = i.to_be_bytes();
+            let v = (i * 10).to_be_bytes();
+            idx.insert(&(k.as_ref()), &(v.as_ref()), &auto()).unwrap();
+        }
+        for i in 0u64..200 {
+            let k = i.to_be_bytes();
+            let expected = (i * 10).to_be_bytes();
+            let got = idx.get(&(k.as_ref()), &auto()).unwrap()
+                .unwrap_or_else(|| panic!("key {} missing", i));
+            assert_eq!(got, expected.as_ref());
+        }
+    }
+
+    #[test]
+    fn large_insert_all_keys_readable() {
+        let idx = make_index();
+        for i in 0u32..2000 {
+            let k = i.to_be_bytes();
+            let v = (i + 1).to_be_bytes();
+            idx.insert(&(k.as_ref()), &(v.as_ref()), &auto()).unwrap();
+        }
+        for i in 0u32..2000 {
+            let k = i.to_be_bytes();
+            let expected = (i + 1).to_be_bytes();
+            let got = idx.get(&(k.as_ref()), &auto()).unwrap()
+                .unwrap_or_else(|| panic!("key {} missing", i));
+            assert_eq!(got, expected.as_ref());
+        }
+    }
+
+    #[test]
+    fn reverse_order_inserts_all_readable() {
+        let idx = make_index();
+        for i in (0u32..500).rev() {
+            let k = i.to_be_bytes();
+            idx.insert(&(k.as_ref()), &(k.as_ref()), &auto()).unwrap();
+        }
+        for i in 0u32..500 {
+            let k = i.to_be_bytes();
+            let got = idx.get(&(k.as_ref()), &auto()).unwrap()
+                .unwrap_or_else(|| panic!("key {} missing", i));
+            assert_eq!(got, k.as_ref());
+        }
+    }
+
+    // ── Delete bulk ──────────────────────────────────────────────────────
+
+    #[test]
+    fn delete_half_keys_remaining_readable() {
+        let idx = make_index();
+        for i in 0u32..200 {
+            let k = i.to_be_bytes();
+            idx.insert(&(k.as_ref()), &(k.as_ref()), &auto()).unwrap();
+        }
+        for i in (0u32..200).filter(|x| x % 2 == 0) {
+            let k = i.to_be_bytes();
+            idx.delete(&(k.as_ref()), &auto()).unwrap();
+        }
+        for i in (0u32..200).filter(|x| x % 2 == 1) {
+            let k = i.to_be_bytes();
+            idx.get(&(k.as_ref()), &auto()).unwrap()
+                .unwrap_or_else(|| panic!("odd key {} missing", i));
+        }
+        for i in (0u32..200).filter(|x| x % 2 == 0) {
+            let k = i.to_be_bytes();
+            assert!(idx.get(&(k.as_ref()), &auto()).unwrap().is_none());
+        }
+    }
+
+    // ── Update bulk ──────────────────────────────────────────────────────
+
+    #[test]
+    fn stress_update_all_keys() {
+        let idx = make_index();
+        let n = 200u32;
+        for i in 0..n {
+            let k = i.to_be_bytes();
+            idx.insert(&(k.as_ref()), &(k.as_ref()), &auto()).unwrap();
+        }
+        for i in 0..n {
+            let k = i.to_be_bytes();
+            let v = (i + 1000).to_be_bytes();
+            idx.update(&(k.as_ref()), &(v.as_ref()), &auto()).unwrap();
+        }
+        for i in 0..n {
+            let k = i.to_be_bytes();
+            let expected = (i + 1000).to_be_bytes();
+            let got = idx.get(&(k.as_ref()), &auto()).unwrap()
+                .unwrap_or_else(|| panic!("key {} missing after update", i));
+            assert_eq!(got, expected.as_ref());
+        }
+    }
+
+    // ── Range scan ───────────────────────────────────────────────────────
+
+    #[test]
+    fn range_scan_full() {
+        let idx = make_index();
+        for i in 0u32..100 {
+            let k = i.to_be_bytes();
+            idx.insert(&(k.as_ref()), &(k.as_ref()), &auto()).unwrap();
+        }
+        let results: Vec<_> = idx.range::<std::ops::RangeFull>(.., &auto())
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(results.len(), 100);
+    }
+
+    #[test]
+    fn range_scan_skips_deleted() {
+        let idx = make_index();
+        for i in 0u32..10 {
+            let k = i.to_be_bytes();
+            idx.insert(&(k.as_ref()), &(k.as_ref()), &auto()).unwrap();
+        }
+        for &i in &[3u32, 5, 7] {
+            let k = i.to_be_bytes();
+            idx.delete(&(k.as_ref()), &auto()).unwrap();
+        }
+        let results: Vec<_> = idx.range::<std::ops::RangeFull>(.., &auto())
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(results.len(), 7);
+    }
+
+    #[test]
+    fn range_scan_bounded() {
+        let idx = make_index();
+        for i in 0u32..100 {
+            let k = i.to_be_bytes();
+            idx.insert(&(k.as_ref()), &(k.as_ref()), &auto()).unwrap();
+        }
+        let start: &'static [u8] = leak_bytes(&10u32.to_be_bytes());
+        let end: &'static [u8] = leak_bytes(&20u32.to_be_bytes());
+        let results: Vec<_> = idx.range(start..end, &auto())
+            .map(|r| r.unwrap()).collect();
+        assert_eq!(results.len(), 10);
+    }
+
+    // ── Write conflict ───────────────────────────────────────────────────
+
+    #[test]
+    fn write_conflict_on_concurrent_delete() {
+        let idx = make_index();
+        idx.insert(&(&b"k"[..]), &(&b"v"[..]), &auto()).unwrap();
+
+        // Simulate: txn 10 deletes the key (xmax = 10).
+        let txn10 = Transaction { txn_id: 10, snapshot: Snapshot::latest() };
+        idx.delete(&(&b"k"[..]), &txn10).unwrap();
+
+        // txn 20 tries to delete the same key. Txn 10 is in txn20's active list.
+        let txn20 = Transaction {
+            txn_id: 20,
+            snapshot: Snapshot { xmin: 1, xmax: 30, active: vec![10] },
+        };
+        match idx.delete(&(&b"k"[..]), &txn20) {
+            Err(IndexError::WriteConflict) => {}
+            other => panic!("expected WriteConflict, got {:?}", other),
+        }
     }
 }

--- a/crates/storage/src/page/internal.rs
+++ b/crates/storage/src/page/internal.rs
@@ -1,19 +1,20 @@
 //! Internal (branch) page types for the B+Tree storage engine.
 //!
-//! ## Layout
+//! ## Layout (Lehman-Yao)
 //!
 //! ```text
 //! ┌─────────────────────────────────────────────────────────┐
 //! │ FIXED HEADER — 32 bytes (fully 8-byte aligned)          │
 //! ├────────┬───────────┬──────────────────────────────────  ┤
 //! │ Off  0 │ u8        │ page_type                           │
-//! │ Off  1 │ u8        │ flags (dirty, root, etc.)           │
+//! │ Off  1 │ u8        │ _reserved (0)                       │
 //! │ Off  2 │ u16       │ num_keys                            │
-//! │ Off  4 │ u32       │ ← padding: brings header to 8 bytes │
+//! │ Off  4 │ u16       │ high_key_len (0 = +∞ / rightmost)   │
+//! │ Off  6 │ u16       │ _padding                            │
 //! ├────────┼───────────┼───────────────────────────────────  ┤
 //! │ Off  8 │ u64       │ page_id          [8-byte aligned ✓] │
 //! │ Off 16 │ u64       │ lsn              [8-byte aligned ✓] │
-//! │ Off 24 │ u64       │ parent_page_id   [8-byte aligned ✓] │
+//! │ Off 24 │ u64       │ rightlink         [8-byte aligned ✓] │
 //! └────────┴───────────┴───────────────────────────────────  ┘
 //!
 //! ┌──────────────────────────────────────────────────────────┐
@@ -31,6 +32,12 @@
 //! │  key[i] spans [key_end[i-1], key_end[i])                 │
 //! │  (key_end[-1] == 0 by convention)                        │
 //! └──────────────────────────────────────────────────────────┘
+//!
+//! ┌──────────────────────────────────────────────────────────┐
+//! │ HIGH KEY — stored at page[PAGE_SIZE - high_key_len ..]   │
+//! │  The exclusive upper bound for keys on this page.        │
+//! │  If high_key_len == 0, this is the rightmost page (+∞).  │
+//! └──────────────────────────────────────────────────────────┘
 //! ```
 
 use std::cmp::Ordering;
@@ -46,10 +53,11 @@ use super::{
 
 // ── Internal-page-specific header offsets ────────────────────────────────────
 
-const OFF_INT_NUM_KEYS: usize = 2;   // u16
-// bytes 4..8: u32 padding to keep the 8-byte fields aligned
-const OFF_INT_PARENT:   usize = 24;  // u64
-const INT_HEADER_SIZE:  usize = 32;
+const OFF_INT_NUM_KEYS:     usize = 2;   // u16
+const OFF_INT_HIGH_KEY_LEN: usize = 4;   // u16
+// bytes 6..8: u16 padding
+const OFF_INT_RIGHTLINK:    usize = 24;  // u64
+const INT_HEADER_SIZE:      usize = 32;
 
 // ── Offset calculation helpers ────────────────────────────────────────────────
 
@@ -93,8 +101,7 @@ impl<'a, K: Key> InternalPageAccessor<'a, K> {
     /// Wraps a raw page buffer.
     ///
     /// # Panics
-    /// Panics if the page-type byte does not equal [`INTERNAL`]. This indicates
-    /// a programming error (wrong page handed to the wrong accessor).
+    /// Panics if the page-type byte does not equal [`INTERNAL`].
     pub fn new(data: &'a [u8]) -> Self {
         assert_eq!(
             read_u8(data, OFF_PAGE_TYPE), INTERNAL,
@@ -115,12 +122,31 @@ impl<'a, K: Key> InternalPageAccessor<'a, K> {
         read_u16(self.data, OFF_INT_NUM_KEYS)
     }
 
-    /// Returns the parent page ID, or `None` if this is the root.
-    pub fn parent_page_id(&self) -> Option<PageId> {
-        match read_u64(self.data, OFF_INT_PARENT) {
+    /// Returns the right sibling page ID, or `None` if this is the rightmost
+    /// page at this level.
+    pub fn rightlink(&self) -> Option<PageId> {
+        match read_u64(self.data, OFF_INT_RIGHTLINK) {
             0 => None,
             v => Some(v),
         }
+    }
+
+    /// Length of the high key in bytes. 0 means this is the rightmost page
+    /// at this level (high key is +infinity).
+    pub fn high_key_len(&self) -> u16 {
+        read_u16(self.data, OFF_INT_HIGH_KEY_LEN)
+    }
+
+    /// Raw high key bytes, or `None` if this is the rightmost page (+infinity).
+    pub fn high_key_bytes(&self) -> Option<&'a [u8]> {
+        let len = self.high_key_len() as usize;
+        if len == 0 { return None; }
+        Some(&self.data[super::PAGE_SIZE - len..super::PAGE_SIZE])
+    }
+
+    /// Deserialized high key, or `None` if rightmost (+infinity).
+    pub fn high_key(&self) -> Option<K::SelfType<'a>> {
+        self.high_key_bytes().map(K::from_bytes)
     }
 
     pub fn child_page_at(&self, i: usize) -> PageId {
@@ -151,23 +177,27 @@ impl<'a, K: Key> InternalPageAccessor<'a, K> {
                 Ordering::Less | Ordering::Equal => low = mid + 1,
             }
         }
-        // `low` is the index of the first separator > search_key,
-        // which equals the child index to descend into.
         (low, self.child_page_at(low))
     }
 
-    /// Contiguous free bytes remaining in this page.
+    /// Contiguous free bytes remaining in this page (accounting for high key).
     pub fn free_bytes(&self) -> usize {
-        super::PAGE_SIZE - self.used_bytes()
+        super::PAGE_SIZE
+            .saturating_sub(self.used_bytes())
+            .saturating_sub(self.high_key_len() as usize)
     }
 
     /// Returns `true` if a new key of `key_len` bytes would fit on this page.
     pub fn can_fit(&self, key_len: usize) -> bool {
-        // One more key+child needs:
-        //   8 bytes  → child page ID (Section A)
-        //   4 bytes  → key_end entry (Section B)
-        //   key_len  → raw key bytes (Section C)
         self.free_bytes() >= 8 + 4 + key_len
+    }
+
+    /// Returns `true` if more than half the page is currently free.
+    ///
+    /// Used by the rebalance/vacuum paths to check whether a sibling can donate
+    /// entries or whether a parent needs rebalancing after a merge.
+    pub fn is_underfull(&self) -> bool {
+        self.free_bytes() * 2 > super::PAGE_SIZE
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -223,8 +253,19 @@ impl<'a, K: Key> InternalPageMutator<'a, K> {
         write_u64(self.data, OFF_LSN, lsn);
     }
 
-    pub fn set_parent_page_id(&mut self, parent: Option<PageId>) {
-        write_u64(self.data, OFF_INT_PARENT, parent.unwrap_or(0));
+    pub fn set_rightlink(&mut self, right: Option<PageId>) {
+        write_u64(self.data, OFF_INT_RIGHTLINK, right.unwrap_or(0));
+    }
+
+    /// Write the high key. `key_bytes` is stored at the end of the page.
+    /// Pass an empty slice (or call with `&[]`) for the rightmost page (+infinity).
+    pub fn set_high_key(&mut self, key_bytes: &[u8]) {
+        let len = key_bytes.len();
+        write_u16(self.data, OFF_INT_HIGH_KEY_LEN, len as u16);
+        if len > 0 {
+            let start = super::PAGE_SIZE - len;
+            self.data[start..super::PAGE_SIZE].copy_from_slice(key_bytes);
+        }
     }
 
     /// Update a child pointer in-place (e.g. after a split assigns a new ID).
@@ -283,11 +324,59 @@ impl<'a, K: Key> InternalPageMutator<'a, K> {
         self.rewrite(&children, &keys);
     }
 
+    // ── Separator helpers ─────────────────────────────────────────────────────
+
+    /// Replace `key[index]` with `new_key`, leaving children unchanged.
+    pub fn update_separator_at(&mut self, index: usize, new_key: &K::SelfType<'_>) {
+        let (children, mut keys) = self.snapshot();
+        keys[index] = K::as_bytes(new_key).as_ref().to_vec();
+        self.rewrite(&children, &keys);
+    }
+
+    /// Insert `new_key` before `key[0]` and `new_leftmost_child` before `child[0]`.
+    pub fn prepend_separator(&mut self, new_key: &K::SelfType<'_>, new_leftmost_child: PageId) {
+        let (mut children, mut keys) = self.snapshot();
+        children.insert(0, new_leftmost_child);
+        keys.insert(0, K::as_bytes(new_key).as_ref().to_vec());
+        self.rewrite(&children, &keys);
+    }
+
+    // ── Truncate ──────────────────────────────────────────────────────────────
+
+    /// Shrink this page to `num_keys` separator keys (and `num_keys + 1` children).
+    ///
+    /// All header fields (`page_id`, `lsn`, `rightlink`, `high_key`) are preserved
+    /// because [`Self::rewrite`] only touches `num_keys` and Sections A/B/C.
+    ///
+    /// No-op if `num_keys >= current num_keys`.
+    pub fn truncate_to(&mut self, num_keys: usize) {
+        let n = read_u16(self.data, OFF_INT_NUM_KEYS) as usize;
+        if num_keys >= n {
+            return;
+        }
+
+        let children: Vec<PageId> = (0..=num_keys)
+            .map(|i| read_u64(self.data, int_child_offset(i)))
+            .collect();
+
+        let base = int_key_data_base(n);
+        let keys: Vec<Vec<u8>> = (0..num_keys)
+            .map(|i| {
+                let start = if i == 0 {
+                    0
+                } else {
+                    read_u32(self.data, int_key_end_offset(n, i - 1)) as usize
+                };
+                let end = read_u32(self.data, int_key_end_offset(n, i)) as usize;
+                self.data[base + start..base + end].to_vec()
+            })
+            .collect();
+
+        self.rewrite(&children, &keys);
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
-    /// Copy all children and keys into owned `Vec`s so they can be modified
-    /// before being written back. Required because any change to `num_keys`
-    /// shifts every section offset.
     fn snapshot(&self) -> (Vec<PageId>, Vec<Vec<u8>>) {
         let n = read_u16(self.data, OFF_INT_NUM_KEYS) as usize;
 
@@ -311,8 +400,6 @@ impl<'a, K: Key> InternalPageMutator<'a, K> {
         (children, keys)
     }
 
-    /// Write children and keys back to the page using the correct section
-    /// layout. `num_keys` is derived from `keys.len()`.
     fn rewrite(&mut self, children: &[PageId], keys: &[Vec<u8>]) {
         let new_n = keys.len();
         write_u16(self.data, OFF_INT_NUM_KEYS, new_n as u16);
@@ -337,9 +424,6 @@ impl<'a, K: Key> InternalPageMutator<'a, K> {
 }
 
 // ── InternalPageBuilder ───────────────────────────────────────────────────────
-//
-// Keys are buffered in `keys` and written all at once in `finish()` because
-// every section offset depends on the final `num_keys`.
 
 /// Write-once constructor for a fresh internal page.
 pub struct InternalPageBuilder<'a, K: Key> {
@@ -351,18 +435,17 @@ pub struct InternalPageBuilder<'a, K: Key> {
 
 impl<'a, K: Key> InternalPageBuilder<'a, K> {
     /// Zero the buffer, stamp the page type and page ID.
+    /// Rightlink and high_key default to 0 (rightmost, +infinity).
     pub fn new(page_id: PageId, data: &'a mut [u8]) -> Self {
         data.fill(0);
         write_u8 (data, OFF_PAGE_TYPE, INTERNAL);
         write_u64(data, OFF_PAGE_ID,   page_id);
+        // rightlink = 0 (rightmost), high_key_len = 0 (+infinity) — already zero
         Self { data, keys: Vec::new(), children: Vec::new(), _key: PhantomData }
     }
 
     /// Register the leftmost child. Must be called exactly once, before any
     /// `push_key_and_right_child` calls.
-    ///
-    /// # Panics
-    /// Panics if called more than once (programming error).
     pub fn push_first_child(&mut self, child: PageId) {
         assert!(
             self.children.is_empty(),
@@ -373,9 +456,6 @@ impl<'a, K: Key> InternalPageBuilder<'a, K> {
 
     /// Append a separator key and the right child that follows it.
     /// Keys must be pushed in strictly ascending order.
-    ///
-    /// # Panics
-    /// Panics if `push_first_child` has not been called yet.
     pub fn push_key_and_right_child(&mut self, key: &K::SelfType<'_>, right_child: PageId) {
         assert!(
             !self.children.is_empty(),
@@ -386,8 +466,24 @@ impl<'a, K: Key> InternalPageBuilder<'a, K> {
         self.children.push(right_child);
     }
 
+    /// Set the right sibling page ID. Call before `finish()`.
+    pub fn set_rightlink(&mut self, right: Option<PageId>) {
+        write_u64(self.data, OFF_INT_RIGHTLINK, right.unwrap_or(0));
+    }
+
+    /// Set the high key (exclusive upper bound). Call before `finish()`.
+    /// Pass `&[]` for the rightmost page (+infinity).
+    pub fn set_high_key(&mut self, key_bytes: &[u8]) {
+        let len = key_bytes.len();
+        write_u16(self.data, OFF_INT_HIGH_KEY_LEN, len as u16);
+        if len > 0 {
+            let start = super::PAGE_SIZE - len;
+            self.data[start..super::PAGE_SIZE].copy_from_slice(key_bytes);
+        }
+    }
+
     /// Seal the page: flush all buffered data with the correct layout, then
-    /// return a mutator for remaining header writes (lsn, parent).
+    /// return a mutator for remaining header writes (lsn, etc.).
     pub fn finish(self) -> InternalPageMutator<'a, K> {
         let Self { data, keys, children, .. } = self;
         let num_keys = keys.len();
@@ -460,28 +556,60 @@ mod tests {
     }
 
     #[test]
-    fn lsn_and_parent_round_trip() {
-        let buf = build_page(7, 1, &[(&[42], 2)]);
-        let mut buf = buf;
-        let mut mutator = InternalPageMutator::<&[u8]>::new(buf.memory_mut());
-        mutator.set_lsn(99);
-        mutator.set_parent_page_id(Some(55));
-
+    fn rightlink_round_trip() {
+        let mut buf = build_page(7, 1, &[(&[42], 2)]);
+        {
+            let mut m = InternalPageMutator::<&[u8]>::new(buf.memory_mut());
+            m.set_rightlink(Some(99));
+        }
         let acc = InternalPageAccessor::<&[u8]>::new(buf.memory());
-        assert_eq!(acc.lsn(), 99);
-        assert_eq!(acc.parent_page_id(), Some(55));
+        assert_eq!(acc.rightlink(), Some(99));
     }
 
     #[test]
-    fn parent_page_id_none_when_zero() {
+    fn rightlink_none_when_zero() {
         let buf = build_page(1, 10, &[]);
         let acc = InternalPageAccessor::<&[u8]>::new(buf.memory());
-        assert_eq!(acc.parent_page_id(), None);
+        assert_eq!(acc.rightlink(), None);
+    }
+
+    #[test]
+    fn high_key_round_trip() {
+        let mut buf = PageBuffer::new();
+        {
+            let mut builder = InternalPageBuilder::<&[u8]>::new(1, buf.memory_mut());
+            builder.push_first_child(10);
+            builder.push_key_and_right_child(&(&[5][..]), 20);
+            builder.set_high_key(&[42, 43]);
+            builder.set_rightlink(Some(99));
+            builder.finish();
+        }
+        let acc = InternalPageAccessor::<&[u8]>::new(buf.memory());
+        assert_eq!(acc.high_key_len(), 2);
+        assert_eq!(acc.high_key_bytes(), Some(&[42u8, 43][..]));
+        assert_eq!(acc.high_key(), Some(&[42u8, 43][..]));
+        assert_eq!(acc.rightlink(), Some(99));
+    }
+
+    #[test]
+    fn high_key_none_when_rightmost() {
+        let buf = build_page(1, 10, &[]);
+        let acc = InternalPageAccessor::<&[u8]>::new(buf.memory());
+        assert_eq!(acc.high_key_len(), 0);
+        assert_eq!(acc.high_key_bytes(), None);
+        assert_eq!(acc.high_key(), None);
+    }
+
+    #[test]
+    fn lsn_round_trip() {
+        let mut buf = build_page(7, 1, &[(&[42], 2)]);
+        InternalPageMutator::<&[u8]>::new(buf.memory_mut()).set_lsn(99);
+        let acc = InternalPageAccessor::<&[u8]>::new(buf.memory());
+        assert_eq!(acc.lsn(), 99);
     }
 
     #[test]
     fn find_child_binary_search() {
-        // keys: [10, 20, 30]  children: [1, 2, 3, 4]
         let buf = build_page(
             1,
             1,
@@ -489,30 +617,20 @@ mod tests {
         );
         let acc = InternalPageAccessor::<&[u8]>::new(buf.memory());
 
-        // Anything < 10 → child 0
         let (idx, pid) = acc.find_child(&(&[5][..]));
-        assert_eq!(idx, 0);
-        assert_eq!(pid, 1);
+        assert_eq!(idx, 0); assert_eq!(pid, 1);
 
-        // Exactly 10 → child 1 (key[mid] == search: low = mid+1)
         let (idx, pid) = acc.find_child(&(&[10][..]));
-        assert_eq!(idx, 1);
-        assert_eq!(pid, 2);
+        assert_eq!(idx, 1); assert_eq!(pid, 2);
 
-        // Between 10 and 20 → child 1
         let (idx, pid) = acc.find_child(&(&[15][..]));
-        assert_eq!(idx, 1);
-        assert_eq!(pid, 2);
+        assert_eq!(idx, 1); assert_eq!(pid, 2);
 
-        // Exactly 30 → child 3
         let (idx, pid) = acc.find_child(&(&[30][..]));
-        assert_eq!(idx, 3);
-        assert_eq!(pid, 4);
+        assert_eq!(idx, 3); assert_eq!(pid, 4);
 
-        // Greater than all keys → child 3
         let (idx, pid) = acc.find_child(&(&[99][..]));
-        assert_eq!(idx, 3);
-        assert_eq!(pid, 4);
+        assert_eq!(idx, 3); assert_eq!(pid, 4);
     }
 
     #[test]
@@ -533,8 +651,6 @@ mod tests {
 
     #[test]
     fn insert_returns_err_when_full() {
-        // Build a page, then fill it via repeated mutator inserts until a
-        // further insert fails with InsufficientSpace.
         let mut buf = PageBuffer::new();
         {
             let mut b = InternalPageBuilder::<&[u8]>::new(1, buf.memory_mut());
@@ -559,8 +675,6 @@ mod tests {
 
     #[test]
     fn remove_key_keep_left_child() {
-        // keys: [10, 20]  children: [1, 2, 3]
-        // Remove key[0]=10, keep child[0]=1 (drop child[1]=2)
         let mut buf = build_page(1, 1, &[(&[10], 2), (&[20], 3)]);
         InternalPageMutator::<&[u8]>::new(buf.memory_mut())
             .remove_key_at(0, ChildSide::Left);
@@ -574,8 +688,6 @@ mod tests {
 
     #[test]
     fn remove_key_keep_right_child() {
-        // keys: [10, 20]  children: [1, 2, 3]
-        // Remove key[0]=10, keep child[1]=2 (drop child[0]=1)
         let mut buf = build_page(1, 1, &[(&[10], 2), (&[20], 3)]);
         InternalPageMutator::<&[u8]>::new(buf.memory_mut())
             .remove_key_at(0, ChildSide::Right);
@@ -603,8 +715,29 @@ mod tests {
             .insert_key_and_right_child(0, &(&[42u8][..]), 2)
             .unwrap();
         let free_after = InternalPageAccessor::<&[u8]>::new(buf.memory()).free_bytes();
-        // 8 (child ptr) + 4 (key_end entry) + 1 (key byte)
         assert_eq!(free_before - free_after, 8 + 4 + 1);
+    }
+
+    #[test]
+    fn free_bytes_accounts_for_high_key() {
+        let mut buf = PageBuffer::new();
+        {
+            let mut b = InternalPageBuilder::<&[u8]>::new(1, buf.memory_mut());
+            b.push_first_child(10);
+            b.set_high_key(&[1, 2, 3, 4, 5]); // 5 bytes
+            b.finish();
+        }
+        let free_with_hk = InternalPageAccessor::<&[u8]>::new(buf.memory()).free_bytes();
+
+        let mut buf2 = PageBuffer::new();
+        {
+            let mut b = InternalPageBuilder::<&[u8]>::new(1, buf2.memory_mut());
+            b.push_first_child(10);
+            b.finish();
+        }
+        let free_without_hk = InternalPageAccessor::<&[u8]>::new(buf2.memory()).free_bytes();
+
+        assert_eq!(free_without_hk - free_with_hk, 5);
     }
 
     #[test]
@@ -613,7 +746,7 @@ mod tests {
         let mut buf = PageBuffer::new();
         let mut b = InternalPageBuilder::<&[u8]>::new(1, buf.memory_mut());
         b.push_first_child(1);
-        b.push_first_child(2); // must panic
+        b.push_first_child(2);
     }
 
     #[test]
@@ -621,6 +754,6 @@ mod tests {
     fn push_key_without_first_child_panics() {
         let mut buf = PageBuffer::new();
         let mut b = InternalPageBuilder::<&[u8]>::new(1, buf.memory_mut());
-        b.push_key_and_right_child(&(&[1][..]), 2); // must panic
+        b.push_key_and_right_child(&(&[1][..]), 2);
     }
 }

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -371,6 +371,7 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
         if len > 0 {
             self.data[LEAF_HEADER_SIZE..LEAF_HEADER_SIZE + len].copy_from_slice(key_bytes);
         }
+        write_u16(self.data, OFF_LEAF_FREE_START, slot_base(len) as u16);
     }
 
     /// Borrow as a read-only accessor without releasing the mutable borrow.

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -1,15 +1,15 @@
 //! Leaf (data) page types for the B+Tree storage engine.
 //!
-//! ## Layout
+//! ## Layout (Lehman-Yao)
 //!
 //! ```text
 //! Page size: 4096 bytes
 //!
 //! ┌─────────────────────────────────────────────────────────┐
-//! │ FIXED HEADER — 40 bytes (fully 8-byte aligned)          │
+//! │ FIXED HEADER — 48 bytes (fully 8-byte aligned)          │
 //! ├────────┬───────────┬─────────────────────────────────── ┤
 //! │ Off  0 │ u8        │ page_type                          │
-//! │ Off  1 │ u8        │ flags                              │
+//! │ Off  1 │ u8        │ _reserved (0)                      │
 //! │ Off  2 │ u16       │ slot_count                         │
 //! │ Off  4 │ u16       │ free_start  (end of slot directory)│
 //! │ Off  6 │ u16       │ free_end    (start of record area) │
@@ -17,25 +17,36 @@
 //! │ Off  8 │ u64       │ page_id          [8-byte aligned]  │
 //! │ Off 16 │ u64       │ lsn              [8-byte aligned]  │
 //! │ Off 24 │ u64       │ prev_page        [8-byte aligned]  │
-//! │ Off 32 │ u64       │ next_page        [8-byte aligned]  │
+//! │ Off 32 │ u64       │ rightlink        [8-byte aligned]  │
+//! │ Off 40 │ u16       │ high_key_len (0 = +∞ / rightmost)  │
+//! │ Off 42 │ u16       │ _padding                           │
+//! │ Off 44 │ u32       │ _padding2                          │
 //! └────────┴───────────┴─────────────────────────────────── ┘
+//!
+//! ┌──────────────────────────────────────────────────────────┐
+//! │ HIGH KEY DATA  [high_key_len bytes, right after header]  │
+//! │  page[48 .. 48 + high_key_len]                           │
+//! └──────────────────────────────────────────────────────────┘
 //!
 //! ┌──────────────────────────────────────────────────────────┐
 //! │ SLOT DIRECTORY  [slot_count × 4 bytes, grows →]          │
 //! │  slot[i] = (offset: u16, rec_size: u16)                  │
-//! │  slot[i] byte offset = 40 + i*4                          │
+//! │  slot[i] byte offset = slot_base + i*4                   │
+//! │  where slot_base = 48 + ((high_key_len + 1) & !1)        │
 //! └──────────────────────────────────────────────────────────┘
 //!
 //!          ↕  free space (free_end − free_start bytes)
 //!
 //! ┌──────────────────────────────────────────────────────────┐
 //! │ RECORD DATA AREA  [grows ←]                              │
-//! │  ┌──────┬──────┬───────┬──────┬───────────┬──────────┐  │
-//! │  │ u16  │ u16  │  u8   │ u8   │ key bytes │ val bytes│  │
-//! │  │k_len │v_len │ flags │ pad  │           │          │  │
-//! │  └──────┴──────┴───────┴──────┴───────────┴──────────┘  │
-//! │    2B     2B     1B     1B      k_len B     v_len B      │
-//! │  Fixed record header = 6 bytes, padded to 8 bytes total  │
+//! │  ┌──────┬──────┬──────┬──────────┬──────────┬──────────┐ │
+//! │  │ u16  │ u16  │  u32 │  u64     │  u64     │ key bytes│ │
+//! │  │k_len │v_len │ rsv  │  xmin    │  xmax    │ val bytes│ │
+//! │  └──────┴──────┴──────┴──────────┴──────────┴──────────┘ │
+//! │    2B     2B     4B      8B         8B    k_len  v_len    │
+//! │  Fixed record header = 24 bytes                           │
+//! │  xmin = creating transaction ID                           │
+//! │  xmax = deleting/replacing transaction ID (0 = live)      │
 //! └──────────────────────────────────────────────────────────┘
 //! ```
 
@@ -44,37 +55,47 @@ use std::marker::PhantomData;
 use common::{Key, Value};
 
 use super::{
-    read_u16, read_u8,
-    write_u8, write_u16, write_u64,
+    read_u16, read_u64, read_u8,
+    write_u8, write_u16, write_u32, write_u64,
     Lsn, PageError, PageId, PAGE_SIZE,
     OFF_LSN, OFF_PAGE_ID, OFF_PAGE_TYPE, LEAF,
 };
 
 // ── Leaf-page-specific header offsets ────────────────────────────────────────
 
-const OFF_LEAF_SLOT_COUNT: usize = 2;  // u16
-const OFF_LEAF_FREE_START: usize = 4;  // u16
-const OFF_LEAF_FREE_END:   usize = 6;  // u16
+const OFF_LEAF_SLOT_COUNT:  usize = 2;   // u16
+const OFF_LEAF_FREE_START:  usize = 4;   // u16
+const OFF_LEAF_FREE_END:    usize = 6;   // u16
 // OFF_PAGE_ID at 8, OFF_LSN at 16 (shared)
-const OFF_LEAF_PREV:       usize = 24; // u64
-const OFF_LEAF_NEXT:       usize = 32; // u64
-const LEAF_HEADER_SIZE:    usize = 40;
+const OFF_LEAF_PREV:        usize = 24;  // u64
+const OFF_LEAF_RIGHTLINK:   usize = 32;  // u64 (was next_page)
+const OFF_LEAF_HIGH_KEY_LEN: usize = 40; // u16
+// bytes 42..48: padding
+const LEAF_HEADER_SIZE:     usize = 48;
 
 const SLOT_SIZE: usize = 4; // u16 offset + u16 rec_size
 
 // ── Record layout offsets (relative to record base) ──────────────────────────
 
-const REC_OFF_KEY_LEN: usize = 0; // u16
-const REC_OFF_VAL_LEN: usize = 2; // u16
-const REC_OFF_FLAGS:   usize = 4; // u8
-// byte 5: padding
-const REC_HEADER_SIZE: usize = 8; // padded to 8 bytes for cache alignment
+const REC_OFF_KEY_LEN:  usize = 0;  // u16
+const REC_OFF_VAL_LEN:  usize = 2;  // u16
+// bytes 4..8: reserved (u32, always 0)
+const REC_OFF_XMIN:     usize = 8;  // u64 — creating transaction ID
+const REC_OFF_XMAX:     usize = 16; // u64 — deleting/replacing transaction ID (0 = live)
+const REC_HEADER_SIZE:  usize = 24; // 2+2+4+8+8 = 24 bytes
 
-// ── Record layout helpers ─────────────────────────────────────────────────────
+// ── Layout helpers ───────────────────────────────────────────────────────────
+
+/// Byte offset where the slot directory starts, accounting for the high key
+/// region that sits between the header and the slot directory.
+#[inline]
+fn slot_base(high_key_len: usize) -> usize {
+    LEAF_HEADER_SIZE + ((high_key_len + 1) & !1) // 2-byte aligned
+}
 
 #[inline]
-fn slot_offset(i: usize) -> usize {
-    LEAF_HEADER_SIZE + i * SLOT_SIZE
+fn slot_offset_at(high_key_len: usize, i: usize) -> usize {
+    slot_base(high_key_len) + i * SLOT_SIZE
 }
 
 #[inline]
@@ -125,11 +146,11 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
     // ── Page-level metadata ───────────────────────────────────────────────────
 
     pub fn page_id(&self) -> PageId {
-        super::read_u64(self.data, OFF_PAGE_ID)
+        read_u64(self.data, OFF_PAGE_ID)
     }
 
     pub fn lsn(&self) -> Lsn {
-        super::read_u64(self.data, OFF_LSN)
+        read_u64(self.data, OFF_LSN)
     }
 
     pub fn num_pairs(&self) -> u16 {
@@ -139,28 +160,47 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
     /// Previous leaf in the doubly-linked leaf chain, or `None` if this is the
     /// leftmost leaf.
     pub fn prev_page(&self) -> Option<PageId> {
-        match super::read_u64(self.data, OFF_LEAF_PREV) {
+        match read_u64(self.data, OFF_LEAF_PREV) {
             0 => None,
             v => Some(v),
         }
     }
 
-    /// Next leaf in the chain, or `None` if this is the rightmost leaf.
-    pub fn next_page(&self) -> Option<PageId> {
-        match super::read_u64(self.data, OFF_LEAF_NEXT) {
+    /// Right sibling (Lehman-Yao rightlink), or `None` if this is the
+    /// rightmost leaf.
+    pub fn rightlink(&self) -> Option<PageId> {
+        match read_u64(self.data, OFF_LEAF_RIGHTLINK) {
             0 => None,
             v => Some(v),
         }
+    }
+
+    // ── High key ──────────────────────────────────────────────────────────────
+
+    /// Length of the high key in bytes. 0 means this is the rightmost leaf
+    /// (high key is +infinity).
+    pub fn high_key_len(&self) -> u16 {
+        read_u16(self.data, OFF_LEAF_HIGH_KEY_LEN)
+    }
+
+    /// Raw high key bytes, or `None` if this is the rightmost leaf (+infinity).
+    pub fn high_key_bytes(&self) -> Option<&'a [u8]> {
+        let len = self.high_key_len() as usize;
+        if len == 0 { return None; }
+        Some(&self.data[LEAF_HEADER_SIZE..LEAF_HEADER_SIZE + len])
+    }
+
+    /// Deserialized high key, or `None` if rightmost (+infinity).
+    pub fn high_key(&self) -> Option<K::SelfType<'a>> {
+        self.high_key_bytes().map(K::from_bytes)
     }
 
     // ── Free-space accounting ─────────────────────────────────────────────────
 
-    /// Byte offset of the first byte past the slot directory.
     pub fn free_start(&self) -> usize {
         read_u16(self.data, OFF_LEAF_FREE_START) as usize
     }
 
-    /// Byte offset of the lowest live record (top of the record area).
     pub fn free_end(&self) -> usize {
         read_u16(self.data, OFF_LEAF_FREE_END) as usize
     }
@@ -176,21 +216,19 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
         self.free_space() >= SLOT_SIZE + rec_total_size(key_len, val_len)
     }
 
-    /// `true` if the pair fits after compacting all dead record fragments.
-    ///
-    /// This is O(n) because it sums live record sizes. Only call it when
-    /// `can_fit_direct` returns `false`.
-    pub fn can_fit_after_compact(&self, key_len: usize, val_len: usize) -> bool {
+    /// Returns `true` if this leaf has so few live (non-deleted) bytes that it
+    /// should donate to or merge with a sibling.
+    pub fn is_underfull(&self) -> bool {
         let n = self.num_pairs() as usize;
-        let live_bytes: usize = (0..n).map(|i| self.slot_rec_size(i)).sum();
-
-        let needed    = SLOT_SIZE + rec_total_size(key_len, val_len);
-        let available = PAGE_SIZE
-            .saturating_sub(LEAF_HEADER_SIZE)
-            .saturating_sub(n * SLOT_SIZE)
-            .saturating_sub(live_bytes);
-
-        available >= needed
+        if n == 0 { return true; }
+        let hkl = self.high_key_len() as usize;
+        let mut live = 0usize;
+        for i in 0..n {
+            if !self.is_deleted(i) {
+                live += self.slot_rec_size(i) + SLOT_SIZE;
+            }
+        }
+        live * 2 < (PAGE_SIZE - slot_base(hkl))
     }
 
     // ── Binary search ─────────────────────────────────────────────────────────
@@ -240,14 +278,36 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
         (self.get_key(i), self.get_value(i))
     }
 
+    /// Creating transaction ID of the record at slot `i`.
+    pub fn get_xmin(&self, i: usize) -> u64 {
+        let rec_base = self.slot_rec_base(i);
+        read_u64(self.data, rec_base + REC_OFF_XMIN)
+    }
+
+    /// Deleting/replacing transaction ID of the record at slot `i`.
+    /// 0 means the record is live (not deleted or replaced).
+    pub fn get_xmax(&self, i: usize) -> u64 {
+        let rec_base = self.slot_rec_base(i);
+        read_u64(self.data, rec_base + REC_OFF_XMAX)
+    }
+
+    /// Returns `true` if the record at slot `i` has been deleted or replaced
+    /// (xmax != 0). Use `is_visible()` from the transaction module for
+    /// proper MVCC visibility checks.
+    pub fn is_deleted(&self, i: usize) -> bool {
+        self.get_xmax(i) != 0
+    }
+
     // ── Private helpers ───────────────────────────────────────────────────────
 
     fn slot_rec_base(&self, i: usize) -> usize {
-        read_u16(self.data, slot_offset(i)) as usize
+        let hkl = self.high_key_len() as usize;
+        read_u16(self.data, slot_offset_at(hkl, i)) as usize
     }
 
-    fn slot_rec_size(&self, i: usize) -> usize {
-        read_u16(self.data, slot_offset(i) + 2) as usize
+    pub(crate) fn slot_rec_size(&self, i: usize) -> usize {
+        let hkl = self.high_key_len() as usize;
+        read_u16(self.data, slot_offset_at(hkl, i) + 2) as usize
     }
 
     fn key_bytes_at(&self, i: usize) -> &'a [u8] {
@@ -296,8 +356,21 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
         write_u64(self.data, OFF_LEAF_PREV, prev.unwrap_or(0));
     }
 
-    pub fn set_next_page(&mut self, next: Option<PageId>) {
-        write_u64(self.data, OFF_LEAF_NEXT, next.unwrap_or(0));
+    pub fn set_rightlink(&mut self, right: Option<PageId>) {
+        write_u64(self.data, OFF_LEAF_RIGHTLINK, right.unwrap_or(0));
+    }
+
+    /// Write the high key. `key_bytes` is stored right after the header.
+    /// Pass `&[]` for the rightmost leaf (+infinity).
+    ///
+    /// **Must be called before any `insert` or slot directory mutation** because
+    /// the slot directory base depends on `high_key_len`.
+    pub fn set_high_key(&mut self, key_bytes: &[u8]) {
+        let len = key_bytes.len();
+        write_u16(self.data, OFF_LEAF_HIGH_KEY_LEN, len as u16);
+        if len > 0 {
+            self.data[LEAF_HEADER_SIZE..LEAF_HEADER_SIZE + len].copy_from_slice(key_bytes);
+        }
     }
 
     /// Borrow as a read-only accessor without releasing the mutable borrow.
@@ -305,17 +378,27 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
         LeafPageAccessor::new(self.data)
     }
 
+    // ── Record-level mutations ────────────────────────────────────────────────
+
+    /// Set the creating transaction ID on the record at slot `pos`.
+    pub fn set_xmin(&mut self, pos: usize, xmin: u64) {
+        let hkl = read_u16(self.data, OFF_LEAF_HIGH_KEY_LEN) as usize;
+        let rec_base = read_u16(self.data, slot_offset_at(hkl, pos)) as usize;
+        write_u64(self.data, rec_base + REC_OFF_XMIN, xmin);
+    }
+
+    /// Set the deleting/replacing transaction ID on the record at slot `pos`.
+    /// Setting xmax to a non-zero value marks the record as dead to
+    /// transactions whose snapshot sees that xmax as committed.
+    pub fn set_xmax(&mut self, pos: usize, xmax: u64) {
+        let hkl = read_u16(self.data, OFF_LEAF_HIGH_KEY_LEN) as usize;
+        let rec_base = read_u16(self.data, slot_offset_at(hkl, pos)) as usize;
+        write_u64(self.data, rec_base + REC_OFF_XMAX, xmax);
+    }
+
     // ── Insert ────────────────────────────────────────────────────────────────
 
-    /// Insert a new `(key, value)` pair at slot position `pos`, shifting all
-    /// existing slots at `[pos..]` one position to the right.
-    ///
-    /// `pos` must be the insertion point returned by `position()` — the caller
-    /// is responsible for maintaining the sorted invariant.
-    ///
-    /// Returns `Err(InsufficientSpace)` when the contiguous free gap is too
-    /// small; the caller should `compact()` and retry if
-    /// `can_fit_after_compact` returns `true`.
+    /// Insert a new `(key, value)` pair at slot position `pos`.
     pub fn insert(
         &mut self,
         pos:   usize,
@@ -346,7 +429,9 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
 
         write_u16(self.data, rec_base + REC_OFF_KEY_LEN, key_len as u16);
         write_u16(self.data, rec_base + REC_OFF_VAL_LEN, val_len as u16);
-        write_u8 (self.data, rec_base + REC_OFF_FLAGS,   0);
+        write_u32(self.data, rec_base + 4, 0); // reserved
+        write_u64(self.data, rec_base + REC_OFF_XMIN, 0);
+        write_u64(self.data, rec_base + REC_OFF_XMAX, 0);
 
         let key_off = rec_key_offset(rec_base);
         self.data[key_off..key_off + key_len].copy_from_slice(key_bytes);
@@ -355,89 +440,23 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
         self.data[val_off..val_off + val_len].copy_from_slice(val_bytes);
 
         // Shift slot directory: [pos..n] → [pos+1..n+1].
-        // copy_within handles overlap correctly because dst > src.
+        let hkl = read_u16(self.data, OFF_LEAF_HIGH_KEY_LEN) as usize;
         let n   = read_u16(self.data, OFF_LEAF_SLOT_COUNT) as usize;
-        let src = slot_offset(pos);
+        let src = slot_offset_at(hkl, pos);
         let len = (n - pos) * SLOT_SIZE;
         if len > 0 {
             self.data.copy_within(src..src + len, src + SLOT_SIZE);
         }
 
         // Write the new slot entry.
-        write_u16(self.data, slot_offset(pos),     rec_base as u16);
-        write_u16(self.data, slot_offset(pos) + 2, rec_size as u16);
+        let slot_off = slot_offset_at(hkl, pos);
+        write_u16(self.data, slot_off,     rec_base as u16);
+        write_u16(self.data, slot_off + 2, rec_size as u16);
 
         // Update header.
         write_u16(self.data, OFF_LEAF_SLOT_COUNT,  (n + 1) as u16);
         write_u16(self.data, OFF_LEAF_FREE_START,  (free_start + SLOT_SIZE) as u16);
         write_u16(self.data, OFF_LEAF_FREE_END,    rec_base as u16);
-
-        Ok(())
-    }
-
-    // ── Overwrite value ───────────────────────────────────────────────────────
-
-    /// Replace the value stored at slot `pos`.
-    ///
-    /// **Same-size fast path** — bytes are written directly into the existing
-    /// record. No slot entry or free-space pointer is touched.
-    ///
-    /// **Different-size slow path** — a fresh record is allocated in the free
-    /// gap; the slot is updated to point at it; the old record becomes dead
-    /// space reclaimed by `compact()`.
-    ///
-    /// Returns `Err(InsufficientSpace)` when the free gap is too small.
-    pub fn overwrite_value(
-        &mut self,
-        pos:       usize,
-        new_value: &V::SelfType<'_>,
-    ) -> Result<(), PageError> {
-        let val_bytes   = V::as_bytes(new_value);
-        let val_bytes   = val_bytes.as_ref();
-        let new_val_len = val_bytes.len();
-
-        let rec_base    = read_u16(self.data, slot_offset(pos))           as usize;
-        let key_len     = read_u16(self.data, rec_base + REC_OFF_KEY_LEN) as usize;
-        let old_val_len = read_u16(self.data, rec_base + REC_OFF_VAL_LEN) as usize;
-
-        if new_val_len == old_val_len {
-            // Fast path: in-place write, no structural change.
-            let val_off = rec_val_offset(rec_base, key_len);
-            self.data[val_off..val_off + new_val_len].copy_from_slice(val_bytes);
-            return Ok(());
-        }
-
-        // Slow path: allocate a new record.
-        let new_rec_size = rec_total_size(key_len, new_val_len);
-        let free_end     = read_u16(self.data, OFF_LEAF_FREE_END)   as usize;
-        let free_start   = read_u16(self.data, OFF_LEAF_FREE_START) as usize;
-        let free         = free_end - free_start;
-
-        if free < new_rec_size {
-            return Err(PageError::InsufficientSpace {
-                needed:    new_rec_size,
-                available: free,
-            });
-        }
-
-        // Copy the key bytes out before writing, in case regions overlap.
-        let old_key_off  = rec_key_offset(rec_base);
-        let new_rec_base = free_end - new_rec_size;
-
-        write_u16(self.data, new_rec_base + REC_OFF_KEY_LEN, key_len as u16);
-        write_u16(self.data, new_rec_base + REC_OFF_VAL_LEN, new_val_len as u16);
-        write_u8 (self.data, new_rec_base + REC_OFF_FLAGS,   0);
-
-        let new_key_off = rec_key_offset(new_rec_base);
-        self.data.copy_within(old_key_off..old_key_off + key_len, new_key_off);
-
-        let new_val_off = rec_val_offset(new_rec_base, key_len);
-        self.data[new_val_off..new_val_off + new_val_len].copy_from_slice(val_bytes);
-
-        // Slot now points at the new record; old record bytes are dead space.
-        write_u16(self.data, slot_offset(pos),     new_rec_base as u16);
-        write_u16(self.data, slot_offset(pos) + 2, new_rec_size as u16);
-        write_u16(self.data, OFF_LEAF_FREE_END,    new_rec_base as u16);
 
         Ok(())
     }
@@ -455,105 +474,73 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
     pub fn remove(&mut self, pos: usize) {
         let n          = read_u16(self.data, OFF_LEAF_SLOT_COUNT) as usize;
         let free_start = read_u16(self.data, OFF_LEAF_FREE_START) as usize;
+        let hkl        = read_u16(self.data, OFF_LEAF_HIGH_KEY_LEN) as usize;
         assert!(pos < n, "LeafPageMutator::remove: pos {} out of bounds (n={})", pos, n);
 
-        // Shift [pos+1..n] one slot to the left.
-        let src = slot_offset(pos + 1);
+        let src = slot_offset_at(hkl, pos + 1);
         let len = (n - pos - 1) * SLOT_SIZE;
         if len > 0 {
             self.data.copy_within(src..src + len, src - SLOT_SIZE);
         }
 
-        // Zero the vacated slot at the end of the directory.
-        let vacated = slot_offset(n - 1);
+        let vacated = slot_offset_at(hkl, n - 1);
         self.data[vacated..vacated + SLOT_SIZE].fill(0);
 
         write_u16(self.data, OFF_LEAF_SLOT_COUNT,  (n - 1) as u16);
         write_u16(self.data, OFF_LEAF_FREE_START,  (free_start - SLOT_SIZE) as u16);
-        // free_end is NOT updated — dead record bytes remain until compact().
     }
 
-    // ── Compact ───────────────────────────────────────────────────────────────
-
-    /// Reclaim dead record space left by overwrites and removals.
-    ///
-    /// All live records are repacked from `PAGE_SIZE` downward with no gaps,
-    /// and the corresponding slot offsets are updated. After `compact()`:
-    ///   `free_end = PAGE_SIZE − Σ(live record sizes)`
-    ///
-    /// **Algorithm**: collect live records sorted by current offset descending
-    /// (closest to `PAGE_SIZE` first). Walk through them maintaining a
-    /// `write_end` cursor that starts at `PAGE_SIZE` and decreases. For each
-    /// record, set `write_end -= size` and copy the record there if it isn't
-    /// already at that position.
-    ///
-    /// `copy_within` handles overlapping regions safely by copying from the
-    /// high end first when `write_end > old_base`.
-    pub fn compact(&mut self) {
-        let n = read_u16(self.data, OFF_LEAF_SLOT_COUNT) as usize;
-        if n == 0 {
-            write_u16(self.data, OFF_LEAF_FREE_END, PAGE_SIZE as u16);
-            return;
-        }
-
-        // Collect (slot_index, current_rec_base, rec_size) for all live slots.
-        let mut live: Vec<(usize, usize, usize)> = (0..n)
-            .map(|i| {
-                let base = read_u16(self.data, slot_offset(i))     as usize;
-                let size = read_u16(self.data, slot_offset(i) + 2) as usize;
-                (i, base, size)
-            })
-            .collect();
-
-        // Process the record closest to PAGE_SIZE first so every destination
-        // is clear when we write to it (nothing above has been moved yet).
-        live.sort_unstable_by(|a, b| b.1.cmp(&a.1));
-
-        let mut write_end = PAGE_SIZE;
-        for (slot_idx, old_base, size) in live {
-            write_end -= size;
-            if old_base != write_end {
-                self.data.copy_within(old_base..old_base + size, write_end);
-                write_u16(self.data, slot_offset(slot_idx), write_end as u16);
-            }
-        }
-
-        write_u16(self.data, OFF_LEAF_FREE_END, write_end as u16);
-    }
+    // NOTE: compact() has been removed. In the MVCC model, there is no dead
+    // space from overwrites (overwrite_value is gone — updates create new
+    // records). Dead records (xmax != 0) are reclaimed by vacuum, not inline
+    // during inserts.
+    // TODO! implement vacuum to reclaim dead records where xmax < global_xmin
 }
 
 // ── LeafPageBuilder ───────────────────────────────────────────────────────────
-//
-// Write-once constructor for a fresh leaf page. The caller pushes entries in
-// ascending key order. Because entries arrive sorted, each push is O(1) —
-// append a slot, write the record — no search or shift needed.
 
 /// Write-once constructor for a fresh leaf page.
 pub struct LeafPageBuilder<'a, K: Key, V: Value> {
     data:      &'a mut [u8],
     write_end: usize,
+    hkl:       usize, // high_key_len, cached for slot offset calculation
     _key:      PhantomData<K>,
     _val:      PhantomData<V>,
 }
 
 impl<'a, K: Key, V: Value> LeafPageBuilder<'a, K, V> {
     /// Zero the buffer, stamp the page type and page ID, initialise free
-    /// pointers.
+    /// pointers. High key defaults to 0 (rightmost, +infinity).
     pub fn new(page_id: PageId, data: &'a mut [u8]) -> Self {
         data.fill(0);
         write_u8 (data, OFF_PAGE_TYPE,       LEAF);
         write_u64(data, OFF_PAGE_ID,         page_id);
-        write_u16(data, OFF_LEAF_FREE_START, LEAF_HEADER_SIZE as u16);
+        // high_key_len = 0 by default (rightmost page).
+        // Slot directory starts at slot_base(0) = 48.
+        write_u16(data, OFF_LEAF_FREE_START, slot_base(0) as u16);
         write_u16(data, OFF_LEAF_FREE_END,   PAGE_SIZE as u16);
-        Self { data, write_end: PAGE_SIZE, _key: PhantomData, _val: PhantomData }
+        Self { data, write_end: PAGE_SIZE, hkl: 0, _key: PhantomData, _val: PhantomData }
     }
 
     pub fn set_prev_page(&mut self, prev: Option<PageId>) {
         write_u64(self.data, OFF_LEAF_PREV, prev.unwrap_or(0));
     }
 
-    pub fn set_next_page(&mut self, next: Option<PageId>) {
-        write_u64(self.data, OFF_LEAF_NEXT, next.unwrap_or(0));
+    pub fn set_rightlink(&mut self, right: Option<PageId>) {
+        write_u64(self.data, OFF_LEAF_RIGHTLINK, right.unwrap_or(0));
+    }
+
+    /// Set the high key. **Must be called before any `push()`** because the
+    /// slot directory base depends on `high_key_len`.
+    pub fn set_high_key(&mut self, key_bytes: &[u8]) {
+        let len = key_bytes.len();
+        write_u16(self.data, OFF_LEAF_HIGH_KEY_LEN, len as u16);
+        if len > 0 {
+            self.data[LEAF_HEADER_SIZE..LEAF_HEADER_SIZE + len].copy_from_slice(key_bytes);
+        }
+        self.hkl = len;
+        // Update free_start to account for the high key region.
+        write_u16(self.data, OFF_LEAF_FREE_START, slot_base(len) as u16);
     }
 
     /// Append a key-value pair. Keys must be pushed in strictly ascending
@@ -561,7 +548,18 @@ impl<'a, K: Key, V: Value> LeafPageBuilder<'a, K, V> {
     ///
     /// # Panics
     /// Panics if the page has no remaining space for the record.
-    pub fn push(&mut self, key: &K::SelfType<'_>, value: &V::SelfType<'_>) {
+    /// Append a key-value pair with explicit xmin/xmax values.
+    ///
+    /// Used by split paths to preserve the version chain from the original
+    /// page when rebuilding both halves.
+    pub fn push_with_mvcc(
+        &mut self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+        xmin: u64,
+        xmax: u64,
+    ) {
+        // Identical to push() but writes caller-supplied xmin/xmax.
         let key_bytes = K::as_bytes(key);
         let key_bytes = key_bytes.as_ref();
         let val_bytes = V::as_bytes(value);
@@ -571,20 +569,21 @@ impl<'a, K: Key, V: Value> LeafPageBuilder<'a, K, V> {
         let rec_size = rec_total_size(key_len, val_len);
 
         let n          = read_u16(self.data, OFF_LEAF_SLOT_COUNT) as usize;
-        let free_start = LEAF_HEADER_SIZE + n * SLOT_SIZE;
+        let free_start = slot_base(self.hkl) + n * SLOT_SIZE;
 
         assert!(
             self.write_end >= free_start + SLOT_SIZE + rec_size,
-            "LeafPageBuilder::push: page is full"
+            "LeafPageBuilder::push_with_mvcc: page is full"
         );
 
-        // Write record at the top of the free area (growing downward).
         self.write_end -= rec_size;
         let rec_base = self.write_end;
 
         write_u16(self.data, rec_base + REC_OFF_KEY_LEN, key_len as u16);
         write_u16(self.data, rec_base + REC_OFF_VAL_LEN, val_len as u16);
-        write_u8 (self.data, rec_base + REC_OFF_FLAGS,   0);
+        write_u32(self.data, rec_base + 4, 0); // reserved
+        write_u64(self.data, rec_base + REC_OFF_XMIN, xmin);
+        write_u64(self.data, rec_base + REC_OFF_XMAX, xmax);
 
         let key_off = rec_key_offset(rec_base);
         self.data[key_off..key_off + key_len].copy_from_slice(key_bytes);
@@ -592,12 +591,10 @@ impl<'a, K: Key, V: Value> LeafPageBuilder<'a, K, V> {
         let val_off = rec_val_offset(rec_base, key_len);
         self.data[val_off..val_off + val_len].copy_from_slice(val_bytes);
 
-        // Append slot.
-        let slot_off = slot_offset(n);
+        let slot_off = slot_offset_at(self.hkl, n);
         write_u16(self.data, slot_off,     rec_base as u16);
         write_u16(self.data, slot_off + 2, rec_size as u16);
 
-        // Update header.
         write_u16(self.data, OFF_LEAF_SLOT_COUNT,  (n + 1) as u16);
         write_u16(self.data, OFF_LEAF_FREE_START,  (slot_off + SLOT_SIZE) as u16);
         write_u16(self.data, OFF_LEAF_FREE_END,    rec_base as u16);
@@ -621,13 +618,11 @@ mod tests {
     type K = &'static [u8];
     type V = &'static [u8];
 
-    /// Build a leaf page from a slice of `(&[u8], &[u8])` pairs using the
-    /// builder (entries must be in ascending order).
     fn build_page(page_id: u64, pairs: &[(&[u8], &[u8])]) -> PageBuffer {
         let mut buf = PageBuffer::new();
         let mut b = LeafPageBuilder::<K, V>::new(page_id, buf.memory_mut());
         for (k, v) in pairs {
-            b.push(k, v);
+            b.push_with_mvcc(k, v, 0, 0);
         }
         b.finish();
         buf
@@ -660,38 +655,60 @@ mod tests {
         assert_eq!(acc.entry(1), (b"k2".as_ref(), b"v2".as_ref()));
     }
 
-    // ── Linked-list pointers ──────────────────────────────────────────────────
+    // ── Rightlink and high key ───────────────────────────────────────────────
 
     #[test]
-    fn prev_next_page_none_when_zero() {
+    fn rightlink_none_when_zero() {
         let buf = build_page(1, &[]);
         let acc = LeafPageAccessor::<K, V>::new(buf.memory());
-        assert_eq!(acc.prev_page(), None);
-        assert_eq!(acc.next_page(), None);
+        assert_eq!(acc.rightlink(), None);
     }
 
     #[test]
-    fn set_prev_next_round_trip() {
+    fn rightlink_round_trip() {
+        let mut buf = build_page(1, &[]);
+        {
+            let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
+            m.set_rightlink(Some(42));
+        }
+        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
+        assert_eq!(acc.rightlink(), Some(42));
+    }
+
+    #[test]
+    fn prev_page_round_trip() {
         let mut buf = build_page(1, &[]);
         {
             let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
             m.set_prev_page(Some(10));
-            m.set_next_page(Some(20));
         }
         let acc = LeafPageAccessor::<K, V>::new(buf.memory());
         assert_eq!(acc.prev_page(), Some(10));
-        assert_eq!(acc.next_page(), Some(20));
     }
 
     #[test]
-    fn set_prev_next_to_none() {
-        let mut buf = build_page(1, &[]);
+    fn high_key_round_trip() {
+        let mut buf = PageBuffer::new();
         {
-            let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
-            m.set_prev_page(Some(5));
-            m.set_prev_page(None);
+            let mut b = LeafPageBuilder::<K, V>::new(1, buf.memory_mut());
+            b.set_high_key(&[42, 43, 44]);
+            b.push_with_mvcc(&b"a".as_ref(), &b"A".as_ref(), 0, 0);
+            b.finish();
         }
-        assert_eq!(LeafPageAccessor::<K, V>::new(buf.memory()).prev_page(), None);
+        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
+        assert_eq!(acc.high_key_len(), 3);
+        assert_eq!(acc.high_key_bytes(), Some(&[42u8, 43, 44][..]));
+        // Entry is still readable with non-zero high_key_len.
+        assert_eq!(acc.get_key(0), b"a".as_ref());
+        assert_eq!(acc.get_value(0), b"A".as_ref());
+    }
+
+    #[test]
+    fn high_key_none_when_rightmost() {
+        let buf = build_page(1, &[]);
+        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
+        assert_eq!(acc.high_key_len(), 0);
+        assert_eq!(acc.high_key_bytes(), None);
     }
 
     // ── LSN ───────────────────────────────────────────────────────────────────
@@ -703,7 +720,64 @@ mod tests {
         assert_eq!(LeafPageAccessor::<K, V>::new(buf.memory()).lsn(), 12345);
     }
 
-    // ── Binary search (position / find_key) ──────────────────────────────────
+    // ── xmin / xmax ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn xmin_xmax_default_to_zero() {
+        let buf = build_page(1, &[(b"k", b"v")]);
+        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
+        assert_eq!(acc.get_xmin(0), 0);
+        assert_eq!(acc.get_xmax(0), 0);
+        assert!(!acc.is_deleted(0));
+    }
+
+    #[test]
+    fn xmin_round_trip() {
+        let mut buf = build_page(1, &[(b"k", b"v")]);
+        LeafPageMutator::<K, V>::new(buf.memory_mut()).set_xmin(0, 42);
+        assert_eq!(LeafPageAccessor::<K, V>::new(buf.memory()).get_xmin(0), 42);
+    }
+
+    #[test]
+    fn xmax_round_trip() {
+        let mut buf = build_page(1, &[(b"k", b"v")]);
+        LeafPageMutator::<K, V>::new(buf.memory_mut()).set_xmax(0, 99);
+        assert_eq!(LeafPageAccessor::<K, V>::new(buf.memory()).get_xmax(0), 99);
+    }
+
+    #[test]
+    fn is_deleted_when_xmax_nonzero() {
+        let mut buf = build_page(1, &[(b"k", b"v")]);
+        LeafPageMutator::<K, V>::new(buf.memory_mut()).set_xmax(0, 5);
+        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
+        assert!(acc.is_deleted(0));
+        // Key and value are still readable (tombstone, not erased).
+        assert_eq!(acc.get_key(0), b"k".as_ref());
+    }
+
+    #[test]
+    fn is_deleted_false_when_xmax_zero() {
+        let buf = build_page(1, &[(b"k", b"v")]);
+        assert!(!LeafPageAccessor::<K, V>::new(buf.memory()).is_deleted(0));
+    }
+
+    #[test]
+    fn push_with_mvcc_preserves_xmin_xmax() {
+        let mut buf = PageBuffer::new();
+        {
+            let mut b = LeafPageBuilder::<K, V>::new(1, buf.memory_mut());
+            b.push_with_mvcc(&b"k".as_ref(), &b"v".as_ref(), 10, 20);
+            b.finish();
+        }
+        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
+        assert_eq!(acc.num_pairs(), 1);
+        assert_eq!(acc.get_xmin(0), 10);
+        assert_eq!(acc.get_xmax(0), 20);
+        assert_eq!(acc.get_key(0), b"k".as_ref());
+        assert_eq!(acc.get_value(0), b"v".as_ref());
+    }
+
+    // ── Binary search ─────────────────────────────────────────────────────────
 
     #[test]
     fn position_finds_exact_match() {
@@ -716,7 +790,6 @@ mod tests {
     fn position_returns_insertion_point_when_absent() {
         let buf = build_page(1, &[(b"a", b"1"), (b"c", b"3")]);
         let acc = LeafPageAccessor::<K, V>::new(buf.memory());
-        // "b" is between index 0 and 1 → insertion point is 1
         assert_eq!(acc.position(&b"b".as_ref()), (1, false));
     }
 
@@ -742,7 +815,6 @@ mod tests {
         assert_eq!(acc.num_pairs(), 3);
         assert_eq!(acc.get_key(1), b"b".as_ref());
         assert_eq!(acc.get_value(1), b"B".as_ref());
-        // surrounding entries must still be correct
         assert_eq!(acc.get_key(0), b"a".as_ref());
         assert_eq!(acc.get_key(2), b"c".as_ref());
     }
@@ -771,7 +843,6 @@ mod tests {
 
     #[test]
     fn insert_returns_err_when_no_space() {
-        // Fill the page until it cannot hold a 200-byte key + 200-byte value.
         let mut buf = PageBuffer::new();
         LeafPageBuilder::<K, V>::new(1, buf.memory_mut()).finish();
         let big_key = vec![0u8; 100];
@@ -826,102 +897,6 @@ mod tests {
         LeafPageMutator::<K, V>::new(buf.memory_mut()).remove(1);
     }
 
-    // ── Overwrite value ───────────────────────────────────────────────────────
-
-    #[test]
-    fn overwrite_same_size_fast_path() {
-        let mut buf = build_page(1, &[(b"key", b"old")]);
-        LeafPageMutator::<K, V>::new(buf.memory_mut())
-            .overwrite_value(0, &b"new".as_ref())
-            .unwrap();
-        assert_eq!(
-            LeafPageAccessor::<K, V>::new(buf.memory()).get_value(0),
-            b"new".as_ref()
-        );
-    }
-
-    #[test]
-    fn overwrite_different_size_allocates_new_record() {
-        let mut buf = build_page(1, &[(b"key", b"v")]);
-        let free_before = LeafPageAccessor::<K, V>::new(buf.memory()).free_space();
-        LeafPageMutator::<K, V>::new(buf.memory_mut())
-            .overwrite_value(0, &b"value_longer".as_ref())
-            .unwrap();
-        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
-        assert_eq!(acc.get_value(0), b"value_longer".as_ref());
-        // free_end moved so free space decreased
-        assert!(acc.free_space() < free_before);
-    }
-
-    #[test]
-    fn overwrite_same_size_does_not_change_free_space() {
-        let mut buf = build_page(1, &[(b"k", b"abc")]);
-        let free_before = LeafPageAccessor::<K, V>::new(buf.memory()).free_space();
-        LeafPageMutator::<K, V>::new(buf.memory_mut())
-            .overwrite_value(0, &b"xyz".as_ref())
-            .unwrap();
-        assert_eq!(
-            LeafPageAccessor::<K, V>::new(buf.memory()).free_space(),
-            free_before
-        );
-    }
-
-    // ── Compact ───────────────────────────────────────────────────────────────
-
-    #[test]
-    fn compact_reclaims_space_after_overwrite() {
-        let mut buf = build_page(1, &[(b"key", b"short")]);
-        // Overwrite with a longer value → old record becomes dead space.
-        LeafPageMutator::<K, V>::new(buf.memory_mut())
-            .overwrite_value(0, &b"much_longer_value".as_ref())
-            .unwrap();
-        let free_before_compact = LeafPageAccessor::<K, V>::new(buf.memory()).free_space();
-        LeafPageMutator::<K, V>::new(buf.memory_mut()).compact();
-        let free_after_compact = LeafPageAccessor::<K, V>::new(buf.memory()).free_space();
-        // Compacting must recover some space.
-        assert!(free_after_compact > free_before_compact);
-        // Data integrity: key and value must still be correct.
-        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
-        assert_eq!(acc.get_key(0), b"key".as_ref());
-        assert_eq!(acc.get_value(0), b"much_longer_value".as_ref());
-    }
-
-    #[test]
-    fn compact_after_remove_reclaims_space() {
-        let mut buf = build_page(1, &[
-            (b"a", b"AAAA"),
-            (b"b", b"BBBB"),
-            (b"c", b"CCCC"),
-        ]);
-        // Remove the middle entry — its record bytes become dead space.
-        LeafPageMutator::<K, V>::new(buf.memory_mut()).remove(1);
-        let free_before = LeafPageAccessor::<K, V>::new(buf.memory()).free_space();
-        LeafPageMutator::<K, V>::new(buf.memory_mut()).compact();
-        let free_after = LeafPageAccessor::<K, V>::new(buf.memory()).free_space();
-        assert!(free_after > free_before);
-        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
-        assert_eq!(acc.num_pairs(), 2);
-        assert_eq!(acc.get_key(0), b"a".as_ref());
-        assert_eq!(acc.get_key(1), b"c".as_ref());
-    }
-
-    #[test]
-    fn compact_empty_page_is_safe() {
-        let mut buf = build_page(1, &[]);
-        LeafPageMutator::<K, V>::new(buf.memory_mut()).compact();
-        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
-        assert_eq!(acc.num_pairs(), 0);
-        assert_eq!(acc.free_end(), PAGE_SIZE);
-    }
-
-    #[test]
-    fn compact_idempotent_when_no_dead_space() {
-        let mut buf = build_page(1, &[(b"k", b"v")]);
-        let free_before = LeafPageAccessor::<K, V>::new(buf.memory()).free_space();
-        LeafPageMutator::<K, V>::new(buf.memory_mut()).compact();
-        assert_eq!(LeafPageAccessor::<K, V>::new(buf.memory()).free_space(), free_before);
-    }
-
     // ── Free-space accounting ─────────────────────────────────────────────────
 
     #[test]
@@ -929,33 +904,5 @@ mod tests {
         let buf = build_page(1, &[]);
         let acc = LeafPageAccessor::<K, V>::new(buf.memory());
         assert!(acc.can_fit_direct(10, 10));
-    }
-
-    #[test]
-    fn can_fit_after_compact_true_after_removes() {
-        let big_key = vec![0u8; 100];
-        let big_val = vec![0u8; 100];
-        let mut buf = PageBuffer::new();
-        LeafPageBuilder::<K, V>::new(1, buf.memory_mut()).finish();
-
-        // Fill the page.
-        loop {
-            let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
-            if m.as_accessor().can_fit_direct(big_key.len(), big_val.len()) {
-                let n = m.as_accessor().num_pairs() as usize;
-                m.insert(n, &big_key.as_slice(), &big_val.as_slice()).unwrap();
-            } else {
-                break;
-            }
-        }
-        // Remove all but one entry to create dead space.
-        let n = LeafPageAccessor::<K, V>::new(buf.memory()).num_pairs();
-        for _ in 1..n {
-            LeafPageMutator::<K, V>::new(buf.memory_mut()).remove(1);
-        }
-        // Direct fit won't work (dead space, no contiguous gap), but after
-        // compact it should.
-        let acc = LeafPageAccessor::<K, V>::new(buf.memory());
-        assert!(acc.can_fit_after_compact(big_key.len(), big_val.len()));
     }
 }

--- a/crates/storage/src/page/mod.rs
+++ b/crates/storage/src/page/mod.rs
@@ -35,7 +35,7 @@ pub const PAGE_SIZE: usize = 4096;
 // ── Shared header offsets (present in both page types) ───────────────────────
 
 pub(super) const OFF_PAGE_TYPE: usize = 0;  // u8
-pub(super) const OFF_FLAGS:     usize = 1;  // u8
+// Byte 1 is reserved (was `flags`, never used).
 pub(super) const OFF_PAGE_ID:   usize = 8;  // u64
 pub(super) const OFF_LSN:       usize = 16; // u64
 


### PR DESCRIPTION
## Summary
This PR integrates buffer pool, leaf page and internal page to expose the final api's to interact with storage layer 

## Changes
- add index.rs which includes the logic for tree traversal and get/update/insert/delete and also handles various split cases with MVCC transactions
- header of leaf.rs and internal.rs is changed to include highkey + rightlink which is used during tree traversal under concurrent splits 
- row header is also modified to store xmin and xmax, xmin is the transaction id when the record is created and xmax is set when update/deletes happen 
- transaction.rs is added to provide basic skeleton for MVCC handling
- updates no longer overwrite the old record, instead a new record is created and old record is marked deleted by setting xmax. this means we no longer need to compact dead space caused by difference in record sizes so compact function is entirely removed. 


## Related Issue
Closes #3 

## Any design changes?
- follows postgres convention for tree traversal logic, earlier page layouts were not compatible with MVCC so they are updated. 
- parent id is no longer stored in internal nodes since a split in 1 page while require updating multiple child pages. 
- there are a lot of edge cases possible with MVCC especially under two concurrent transactions modifying same thing, fallbacks and checks are added for this but this has to be tested thoroughly once entire MVCC Layer is implemented. 
- the design focuses on optimistic locking and latch crabbing for entire tree-traversal to provide maximum concurrency. 

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes