### PR TITLE
feat: centralize error handling 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,6 @@ dependencies = [
  "crc32fast",
  "db-core",
  "tempfile",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,0 +1,123 @@
+/// Centralized error types for the entire codebase.
+
+// Every submodule's error enum is now written here.
+// Using the `thiserror` crate we easily write clean reusable code without the boilerplate
+
+
+use std::io;
+use thiserror::Error;
+
+// ==== DISK ERRORS ==========================================================
+
+/// Errors that can occur during disk operations.
+#[derive(Debug, Error)]
+pub enum DiskError {
+    /// An underlying I/O error.
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    /// The provided buffer or data size does not match the configured page size.
+    #[error("Invalid page size")]
+    InvalidPageSize,
+}
+
+// ===== WAL ERRORS ===========================================================
+
+/// Errors that can occur during Write-Ahead Log operations.
+#[derive(Debug, Error)]
+pub enum WalError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("Checksum mismatch for LSN {lsn}: expected {expected}, got {actual}")]
+    ChecksumMismatch { lsn: u64, expected: u32, actual: u32 },
+
+    #[error("Corrupted log: {0}")]
+    CorruptedLog(String),
+
+    #[error("Invalid entry type: {0}")]
+    InvalidEntryType(u8),
+
+    #[error("Invalid LSN")]
+    InvalidLsn,
+}
+
+// ==== PAGE ERRORS =============================================================
+/// Errors that can occur during page-level operations.
+#[derive(Debug, Error)]
+pub enum PageError {
+    #[error("insufficient space: needed {needed} bytes but only {available} available")]
+    InsufficientSpace { needed: usize, available: usize },
+}
+
+// === BUFFER POOL ERRORS =======================================================
+
+/// Errors that can occur in the buffer pool subsystem.
+#[derive(Debug, Error)]
+pub enum BufferPoolError {
+    #[error("Page with ID {0} not found")]
+    PageNotFound(u64),
+
+    #[error("Pin count error")]
+    PinCountError,
+
+    #[error("No evictable frames available")]
+    NoEvictableFrames,
+
+    /// A disk I/O error propagated from the [`DiskError`] layer.
+    #[error("Disk error: {0}")]
+    Disk(#[from] DiskError),
+
+    #[error("Internal error: {0}")]
+    InternalError(String),
+}
+
+// ==== INDEX ERRORS ==========================================================
+
+/// Errors that can occur during B+Tree index operations.
+#[derive(Debug, Error)]
+pub enum IndexError {
+    #[error("Key not found")]
+    KeyNotFound,
+
+    #[error("Key too large: {size} bytes (max {max})")]
+    KeyTooLarge { size: usize, max: usize },
+
+    /// Insert attempted on a key that already has a visible version.
+    #[error("Duplicate key")]
+    DuplicateKey,
+
+    /// Another in-progress transaction has already modified this record.
+    /// First-writer-wins: the current transaction should abort.
+    #[error("Write conflict: another transaction modified this record")]
+    WriteConflict,
+
+    #[error("Unexpected page type: expected {expected}, found {found}")]
+    UnexpectedPageType { expected: u8, found: u8 },
+
+    #[error("Buffer pool error: {0}")]
+    BufferPool(#[from] BufferPoolError),
+
+    #[error("Page error: {0}")]
+    Page(#[from] PageError),
+
+    /// An in-progress transaction is blocking this insert. The caller should
+    /// drop its page latch, wait for `txn_id` to settle, then retry.
+    #[error("Wait for transaction {0}")]
+    WaitFor(u64),
+}
+
+// ==== TYPE NAME ERRORS =============================================================
+
+/// Errors that can occur when deserializing a [`TypeName`] from raw bytes.
+#[derive(Debug, Error)]
+pub enum TypeNameError {
+    #[error("empty input: need at least 1 byte for the classification tag")]
+    Empty,
+
+    #[error("unknown classification byte: {0}")]
+    UnknownClassification(u8),
+
+    #[error("invalid UTF-8 in type name: {0}")]
+    InvalidUtf8(#[from] std::str::Utf8Error),
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod constants;
+pub mod error;
 pub mod types;
 
 pub use constants::*;
+pub use error::*;
 pub use types::*;

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,18 +1,7 @@
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::mem::size_of;
-use thiserror::Error;
-
-/// Errors that can occur when deserializing a [`TypeName`] from raw bytes.
-#[derive(Debug, Error)]
-pub enum TypeNameError {
-    #[error("empty input: need at least 1 byte for the classification tag")]
-    Empty,
-    #[error("unknown classification byte: {0}")]
-    UnknownClassification(u8),
-    #[error("invalid UTF-8 in type name: {0}")]
-    InvalidUtf8(#[from] std::str::Utf8Error),
-}
+use crate::TypeNameError;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 enum TypeClassification {

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 common.workspace = true
 crc32fast = "1.5.0"
-thiserror.workspace = true
 db-core.workspace = true
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -1,31 +1,7 @@
 use crate::buffer_pool::shard::{BufferPoolShard, PageReadGuard, PageWriteGuard};
 use crate::disk::DiskManager;
-use common::{MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
-use std::fmt::{Display, Formatter};
+use common::{BufferPoolError, MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
 use std::sync::{Arc, Mutex};
-
-#[derive(Debug)]
-pub enum BufferPoolError {
-    PageNotFound(u64),
-    PinCountError,
-    NoEvictableFrames,
-    InternalError(String),
-}
-
-impl Display for BufferPoolError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BufferPoolError::PageNotFound(page_id) => {
-                write!(f, "Page with ID {} not found", page_id)
-            }
-            BufferPoolError::PinCountError => write!(f, "Pin count error"),
-            BufferPoolError::NoEvictableFrames => write!(f, "No evictable frames available"),
-            BufferPoolError::InternalError(msg) => write!(f, "Internal error: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for BufferPoolError {}
 
 pub type Result<T> = std::result::Result<T, BufferPoolError>;
 
@@ -127,8 +103,7 @@ impl BufferPoolManager {
             let mut data = shard.pages[frame_id].write().unwrap();
             shard
                 .disk_manager
-                .read_page(page_id, data.0.as_mut())
-                .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+                .read_page(page_id, data.0.as_mut())?;
         }
 
         let data = shard.pages[frame_id].read().unwrap();
@@ -169,8 +144,7 @@ impl BufferPoolManager {
         if needs_load {
             shard
                 .disk_manager
-                .read_page(page_id, data.0.as_mut())
-                .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+                .read_page(page_id, data.0.as_mut())?;
         }
 
         Ok(PageWriteGuard {

--- a/crates/storage/src/buffer_pool/mod.rs
+++ b/crates/storage/src/buffer_pool/mod.rs
@@ -5,5 +5,6 @@ pub mod shard;
 #[cfg(test)]
 mod tests;
 
-pub use manager::{BufferPoolError, BufferPoolManager, Result};
+pub use common::BufferPoolError;
+pub use manager::{BufferPoolManager, Result};
 pub use shard::{BufferPoolShard, PageReadGuard, PageWriteGuard};

--- a/crates/storage/src/buffer_pool/replacer.rs
+++ b/crates/storage/src/buffer_pool/replacer.rs
@@ -3,8 +3,9 @@
 //! This module implements the Clock replacement policy, a common approximation
 //! of the Least Recently Used (LRU) algorithm.
 
-use crate::buffer_pool::BufferPoolError;
-use crate::buffer_pool::Result;
+use common::BufferPoolError;
+
+type Result<T> = std::result::Result<T, BufferPoolError>;
 
 /// An implementation of the Clock replacement algorithm.
 ///

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -4,13 +4,15 @@
 //! reduces lock contention by allowing multiple threads to access different
 //! partitions of the buffer pool simultaneously.
 
-use crate::buffer_pool::manager::{BufferPoolError, Result};
+use common::BufferPoolError;
 use crate::buffer_pool::replacer::ClockReplacer;
 use crate::disk::DiskManager;
 use common::{INVALID_FRAME_ID, MAX_PAGE_SIZE};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+type Result<T> = std::result::Result<T, BufferPoolError>;
 
 /// A fixed-size buffer for a single database page.
 pub struct PageData(pub Box<[u8; MAX_PAGE_SIZE]>);
@@ -292,11 +294,9 @@ impl BufferPoolShard {
         }
 
         self.disk_manager
-            .write_page(page_id, &buf)
-            .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+            .write_page(page_id, &buf)?;
         self.disk_manager
-            .sync_data()
-            .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+            .sync_data()?;
         Ok(())
     }
 

--- a/crates/storage/src/buffer_pool/tests.rs
+++ b/crates/storage/src/buffer_pool/tests.rs
@@ -125,7 +125,7 @@ fn test_buffer_pool_manager_concurrency() {
 
 #[test]
 fn test_buffer_pool_manager_pin_count() {
-    use crate::buffer_pool::manager::BufferPoolError;
+    use common::BufferPoolError;
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.db");
     let disk_manager = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());

--- a/crates/storage/src/disk.rs
+++ b/crates/storage/src/disk.rs
@@ -3,41 +3,17 @@
 
 use std::{
     fs::{self, File, OpenOptions},
-    io::{self, Write},
+    io::Write,
     path::{Path, PathBuf},
 };
 
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
 
+use common::DiskError;
+
 /// Represents a unique identifier for a page in the database.
 pub type PageId = u64;
-
-/// Errors that can occur during disk operations.
-#[derive(Debug)]
-pub enum DiskError {
-    /// An underlying I/O error.
-    Io(io::Error),
-    /// The provided buffer or data size does not match the configured page size.
-    InvalidPageSize,
-}
-
-impl std::fmt::Display for DiskError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DiskError::Io(err) => write!(f, "IO error: {}", err),
-            DiskError::InvalidPageSize => write!(f, "Invalid page size"),
-        }
-    }
-}
-
-impl std::error::Error for DiskError {}
-
-impl From<io::Error> for DiskError {
-    fn from(err: io::Error) -> Self {
-        DiskError::Io(err)
-    }
-}
 
 pub type Result<T> = std::result::Result<T, DiskError>;
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -14,42 +14,14 @@ use std::sync::{Arc, Mutex};
 use common::{Key, MAX_KEY_SIZE, Value};
 use db_core::transaction_manager::TransactionManager;
 
-use crate::buffer_pool::{BufferPoolError, BufferPoolManager, PageReadGuard, PageWriteGuard};
+use common::IndexError;
+use crate::buffer_pool::{BufferPoolManager, PageReadGuard, PageWriteGuard};
 use crate::page::{
     INTERNAL, InternalPageAccessor, InternalPageBuilder, InternalPageMutator, LEAF,
     LeafPageAccessor, LeafPageBuilder, LeafPageMutator, PageId,
 };
 
 use db_core::transaction::Transaction;
-// ── Error type ────────────────────────────────────────────────────────────────
-
-#[derive(Debug)]
-pub enum IndexError {
-    KeyNotFound,
-    KeyTooLarge {
-        size: usize,
-        max: usize,
-    },
-    /// Insert attempted on a key that already has a visible version.
-    DuplicateKey,
-    /// Another in-progress transaction has already modified this record.
-    /// First-writer-wins: the current transaction should abort.
-    WriteConflict,
-    /// An in-progress transaction is blocking this insert. The caller should
-    /// drop its page latch, wait for `txn_id` to settle, then retry.
-    WaitFor(u64),
-    UnexpectedPageType {
-        expected: u8,
-        found: u8,
-    },
-    BufferPool(BufferPoolError),
-}
-
-impl From<BufferPoolError> for IndexError {
-    fn from(e: BufferPoolError) -> Self {
-        IndexError::BufferPool(e)
-    }
-}
 
 pub type Result<T> = std::result::Result<T, IndexError>;
 
@@ -723,16 +695,14 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         if target_pid == leaf_pid_actual {
             let (s, _) = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).position(key);
             LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
-                .insert(s, key, value)
-                .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+                .insert(s, key, value)?;
             LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmin(s, txn_id);
         } else {
             drop(leaf_guard);
             let mut right = self.pool.fetch_page_mut(target_pid)?;
             let (s, _) = LeafPageAccessor::<K, V>::new(&right[..]).position(key);
             LeafPageMutator::<K, V>::new(&mut right[..])
-                .insert(s, key, value)
-                .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+                .insert(s, key, value)?;
             LeafPageMutator::<K, V>::new(&mut right[..]).set_xmin(s, txn_id);
         }
 
@@ -890,8 +860,7 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             if acc.can_fit(sep_key.len()) {
                 let (idx, _) = acc.find_child(&K::from_bytes(&sep_key));
                 InternalPageMutator::<K>::new(&mut parent_guard[..])
-                    .insert_key_and_right_child(idx, &K::from_bytes(&sep_key), right_pid)
-                    .map_err(|e| BufferPoolError::InternalError(e.to_string()))?;
+                    .insert_key_and_right_child(idx, &K::from_bytes(&sep_key), right_pid)?;
                 return Ok(());
             }
 

--- a/crates/storage/src/page/mod.rs
+++ b/crates/storage/src/page/mod.rs
@@ -12,7 +12,7 @@ pub mod leaf;
 pub use internal::{InternalPageAccessor, InternalPageBuilder, InternalPageMutator};
 pub use leaf::{LeafPageAccessor, LeafPageBuilder, LeafPageMutator};
 
-use thiserror::Error;
+pub use common::PageError;
 
 // ── Type aliases ──────────────────────────────────────────────────────────────
 
@@ -38,14 +38,6 @@ pub(super) const OFF_PAGE_TYPE: usize = 0; // u8
 // Byte 1 is reserved (was `flags`, never used).
 pub(super) const OFF_PAGE_ID: usize = 8; // u64
 pub(super) const OFF_LSN: usize = 16; // u64
-
-// ── Shared error type ─────────────────────────────────────────────────────────
-
-#[derive(Debug, Error)]
-pub enum PageError {
-    #[error("insufficient space: needed {needed} bytes but only {available} available")]
-    InsufficientSpace { needed: usize, available: usize },
-}
 
 // ── ChildSide — used when removing a separator key during a merge ─────────────
 

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -21,56 +21,15 @@
 //! | Checksum   | 4            | CRC32 of all preceding fields        |
 
 use crc32fast::Hasher;
-use std::fmt::{Display, Formatter};
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec;
 
+use common::WalError;
 use crate::disk::DiskManager;
 use crate::page::Lsn;
-
-#[derive(Debug)]
-pub enum WalError {
-    Io(io::Error),
-    ChecksumMismatch {
-        lsn: Lsn,
-        expected: u32,
-        actual: u32,
-    },
-    CorruptedLog(String),
-    InvalidEntryType(u8),
-    InvalidLsn,
-}
-
-impl From<io::Error> for WalError {
-    fn from(err: io::Error) -> Self {
-        WalError::Io(err)
-    }
-}
-
-impl Display for WalError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WalError::Io(err) => write!(f, "IO error: {}", err),
-            WalError::ChecksumMismatch {
-                lsn,
-                expected,
-                actual,
-            } => write!(
-                f,
-                "Checksum mismatch for LSN {}: expected {}, got {}",
-                lsn, expected, actual
-            ),
-            WalError::CorruptedLog(msg) => write!(f, "Corrupted log: {}", msg),
-            WalError::InvalidEntryType(t) => write!(f, "Invalid entry type: {}", t),
-            WalError::InvalidLsn => write!(f, "Invalid LSN"),
-        }
-    }
-}
-
-impl std::error::Error for WalError {}
 
 pub type Result<T> = std::result::Result<T, WalError>;
 


### PR DESCRIPTION
## Summary
This PR centralizes and standardizes the fragmented error-handling across the entire codebase into a single module under the `common` crate using the `thiserror` crate.

## Changes
- Centralizes and Standardizes the error-handling
- Uses `thiserror` to standardize error-handling

## Related Issue
Closes #22 

## Any design changes?

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes