### PR TITLE
feat: implement lock manager 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,9 @@ dependencies = [
 [[package]]
 name = "concurrency"
 version = "0.1.0"
+dependencies = [
+ "common",
+]
 
 [[package]]
 name = "crc32fast"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,10 @@ dependencies = [
 [[package]]
 name = "db-core"
 version = "0.1.0"
+dependencies = [
+ "common",
+ "concurrency",
+]
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ clap = { version = "4", features = ["derive"] }
 common = { path = "crates/common" }
 thiserror = "1"
 db-core = { path = "crates/db-core"}
+concurrency = { path = "crates/concurrency" }

--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -3,5 +3,5 @@ pub const MAX_FRAMES: usize = 80;
 pub const INVALID_FRAME_ID: u64 = u64::MAX;
 pub const NUM_SHARDS: usize = 8;
 pub const SHARD_MASK: u64 = (NUM_SHARDS - 1) as u64;
-
+pub const LOCK_MANAGER_SHARDS: usize = 128;
 pub const MAX_KEY_SIZE: usize = 512;

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -126,4 +126,8 @@ pub enum TypeNameError {
 pub enum LockManagerError {
     #[error("record not found")]
     RecordNotFound,
+    #[error("upgrade conflict - another transaction is already upgrading")]
+    UpgradeConflict,
+    #[error("invalid lock state - lock not granted or already exclusive")]
+    InvalidLockState,
 }

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -121,3 +121,9 @@ pub enum TypeNameError {
     #[error("invalid UTF-8 in type name: {0}")]
     InvalidUtf8(#[from] std::str::Utf8Error),
 }
+
+#[derive(Debug, Error)]
+pub enum LockManagerError {
+    #[error("record not found")]
+    RecordNotFound,
+}

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -123,6 +123,7 @@ pub enum TypeNameError {
     InvalidUtf8(#[from] std::str::Utf8Error),
 }
 
+/// Errors that can occur during concurrency control operations.
 #[derive(Debug, Error)]
 pub enum LockManagerError {
     #[error("record not found")]

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,9 +1,6 @@
 /// Centralized error types for the entire codebase.
-
 // Every submodule's error enum is now written here.
 // Using the `thiserror` crate we easily write clean reusable code without the boilerplate
-
-
 use std::io;
 use thiserror::Error;
 
@@ -30,7 +27,11 @@ pub enum WalError {
     Io(#[from] io::Error),
 
     #[error("Checksum mismatch for LSN {lsn}: expected {expected}, got {actual}")]
-    ChecksumMismatch { lsn: u64, expected: u32, actual: u32 },
+    ChecksumMismatch {
+        lsn: u64,
+        expected: u32,
+        actual: u32,
+    },
 
     #[error("Corrupted log: {0}")]
     CorruptedLog(String),
@@ -130,4 +131,6 @@ pub enum LockManagerError {
     UpgradeConflict,
     #[error("invalid lock state - lock not granted or already exclusive")]
     InvalidLockState,
+    #[error("deadlock detected")]
+    DeadLock,
 }

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,7 +1,7 @@
+use crate::TypeNameError;
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::mem::size_of;
-use crate::TypeNameError;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 enum TypeClassification {

--- a/crates/concurrency/Cargo.toml
+++ b/crates/concurrency/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+common.workspace = true

--- a/crates/concurrency/src/lock_manager.rs
+++ b/crates/concurrency/src/lock_manager.rs
@@ -1,1 +1,25 @@
-// TODO
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Condvar,
+};
+
+enum LockType {
+    SharedLock,
+    ExclusiveLock,
+}
+
+struct LockRequest {
+    transaction_id: u64,
+    lock_type: LockType,
+    is_granted: bool,
+}
+
+struct LockQueue {
+    queue: VecDeque<LockRequest>,
+    cond_var: Condvar,
+    upgrading_flag: bool,
+}
+
+pub struct LockTable {
+    map: HashMap<u64, LockQueue>,
+}

--- a/crates/concurrency/src/lock_manager.rs
+++ b/crates/concurrency/src/lock_manager.rs
@@ -1,9 +1,12 @@
 use std::{
     collections::{HashMap, VecDeque},
-    sync::Condvar,
+    sync::{Arc, Condvar, Mutex},
 };
 
-enum LockType {
+use common::LockManagerError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockType {
     SharedLock,
     ExclusiveLock,
 }
@@ -15,11 +18,89 @@ struct LockRequest {
 }
 
 struct LockQueue {
-    queue: VecDeque<LockRequest>,
+    queue: Mutex<VecDeque<LockRequest>>,
     cond_var: Condvar,
-    upgrading_flag: bool,
 }
 
-pub struct LockTable {
-    map: HashMap<u64, LockQueue>,
+pub struct LockManager {
+    map: Mutex<HashMap<u64, Arc<LockQueue>>>,
+}
+
+impl Default for LockManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LockManager {
+    pub fn new() -> Self {
+        Self {
+            map: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn acquire_lock(&self, transaction_id: u64, page_id: u64, lock_type: LockType) {
+        let queue = {
+            let mut map_guard = self.map.lock().unwrap();
+            map_guard
+                .entry(page_id)
+                .or_insert_with(|| {
+                    Arc::new(LockQueue {
+                        queue: Mutex::new(VecDeque::new()),
+                        cond_var: Condvar::new(),
+                    })
+                })
+                .clone()
+        };
+
+        let mut guard = queue.queue.lock().unwrap();
+
+        let can_grant = match lock_type {
+            LockType::SharedLock => {
+                let has_exclusive_lock =
+                    guard.iter().any(|r| r.lock_type == LockType::ExclusiveLock);
+                !has_exclusive_lock
+            }
+            LockType::ExclusiveLock => guard.is_empty(),
+        };
+
+        guard.push_back(LockRequest {
+            transaction_id,
+            lock_type,
+            is_granted: can_grant,
+        });
+
+        if can_grant {
+            return;
+        }
+
+        loop {
+            guard = queue.cond_var.wait(guard).unwrap();
+            let my_request = guard
+                .iter()
+                .find(|r| r.transaction_id == transaction_id)
+                .unwrap();
+
+            if my_request.is_granted {
+                break;
+            }
+        }
+    }
+
+    pub fn release_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
+        let queue_guard = {
+            let map_guard = self.map.lock().unwrap();
+            map_guard.get(&page_id).unwrap().clone()
+        };
+
+        let mut guard = queue_guard.queue.lock().unwrap();
+        let index = guard
+            .iter()
+            .position(|r| r.transaction_id == transaction_id)
+            .ok_or(LockManagerError::RecordNotFound)?;
+
+        guard.remove(index);
+        queue_guard.cond_var.notify_all();
+        Ok(())
+    }
 }

--- a/crates/concurrency/src/lock_manager.rs
+++ b/crates/concurrency/src/lock_manager.rs
@@ -100,6 +100,36 @@ impl LockManager {
             .ok_or(LockManagerError::RecordNotFound)?;
 
         guard.remove(index);
+
+        let mut any_granted = false;
+        let mut exclusive_seen = false;
+
+        for request in guard.iter_mut() {
+            if request.is_granted {
+                any_granted = true;
+                if request.lock_type == LockType::ExclusiveLock {
+                    exclusive_seen = true;
+                }
+            } else {
+                let can_grant = match request.lock_type {
+                    LockType::SharedLock => !exclusive_seen,
+                    LockType::ExclusiveLock => !any_granted,
+                };
+
+                if can_grant {
+                    request.is_granted = true;
+                    any_granted = true;
+                    if request.lock_type == LockType::ExclusiveLock {
+                        exclusive_seen = true;
+                    }
+                } else {
+                    if request.lock_type == LockType::ExclusiveLock {
+                        exclusive_seen = true;
+                    }
+                }
+            }
+        }
+
         queue_guard.cond_var.notify_all();
         Ok(())
     }

--- a/crates/concurrency/src/lock_manager.rs
+++ b/crates/concurrency/src/lock_manager.rs
@@ -16,6 +16,7 @@ use std::{
 };
 
 use common::LockManagerError;
+use common::constants::LOCK_MANAGER_SHARDS;
 
 /// The type of lock requested by a transaction.
 ///
@@ -67,7 +68,7 @@ struct WaitForGraph {
 /// 3. **Deadlock Detection:** Automatically detects cycles in a Waits-For Graph and aborts deadlocking transactions.
 #[derive(Debug)]
 pub struct LockManager {
-    map: Mutex<HashMap<u64, Arc<LockQueue>>>,
+    shards: Vec<Mutex<HashMap<u64, Arc<LockQueue>>>>,
     waits: Mutex<WaitForGraph>,
 }
 
@@ -126,10 +127,20 @@ impl WaitForGraph {
 
 impl LockManager {
     pub fn new() -> Self {
+        let mut shards = Vec::with_capacity(LOCK_MANAGER_SHARDS);
+        for _ in 0..LOCK_MANAGER_SHARDS {
+            shards.push(Mutex::new(HashMap::new()));
+        }
         Self {
-            map: Mutex::new(HashMap::new()),
+            shards,
             waits: Mutex::new(WaitForGraph::new()),
         }
+    }
+
+    #[inline]
+    fn get_shard(&self, page_id: u64) -> &Mutex<HashMap<u64, Arc<LockQueue>>> {
+        let idx = (page_id as usize) % LOCK_MANAGER_SHARDS;
+        &self.shards[idx]
     }
 
     /// Attempts to acquire a lock on a page for a transaction.
@@ -144,7 +155,7 @@ impl LockManager {
         lock_type: LockType,
     ) -> Result<(), LockManagerError> {
         let queue = {
-            let mut map_guard = self.map.lock().unwrap();
+            let mut map_guard = self.get_shard(page_id).lock().unwrap();
             map_guard
                 .entry(page_id)
                 .or_insert_with(|| {
@@ -200,10 +211,14 @@ impl LockManager {
                 for &holder_id in &holders {
                     wait_guard.remove_wait(transaction_id, holder_id);
                 }
-                
-                let idx = guard.requests.iter().position(|r| r.transaction_id == transaction_id).unwrap();
+
+                let idx = guard
+                    .requests
+                    .iter()
+                    .position(|r| r.transaction_id == transaction_id)
+                    .unwrap();
                 guard.requests.remove(idx);
-                
+
                 return Err(LockManagerError::DeadLock);
             }
         }
@@ -229,7 +244,7 @@ impl LockManager {
     /// Automatically promotes queued transactions using Writer-Starvation Prevention logic.
     pub fn release_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
         let queue_guard = {
-            let map_guard = self.map.lock().unwrap();
+            let map_guard = self.get_shard(page_id).lock().unwrap();
             map_guard
                 .get(&page_id)
                 .ok_or(LockManagerError::RecordNotFound)?
@@ -292,7 +307,7 @@ impl LockManager {
             for waiter_id in newly_granted_txs {
                 wait_guard.remove_wait(waiter_id, transaction_id);
             }
-            
+
             for waiter_id in remaining_waiters {
                 wait_guard.remove_wait(waiter_id, transaction_id);
             }
@@ -309,7 +324,7 @@ impl LockManager {
     /// but will return `UpgradeConflict` if another transaction is already upgrading.
     pub fn upgrade_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
         let queue_guard = {
-            let map_guard = self.map.lock().unwrap();
+            let map_guard = self.get_shard(page_id).lock().unwrap();
             map_guard
                 .get(&page_id)
                 .ok_or(LockManagerError::RecordNotFound)?
@@ -353,6 +368,19 @@ impl LockManager {
         }
         guard.requests.insert(insert_index, req);
 
+        let any_other_granted = guard
+            .requests
+            .iter()
+            .any(|r| r.is_granted && r.transaction_id != transaction_id);
+        if !any_other_granted {
+            let my_req = guard
+                .requests
+                .iter_mut()
+                .find(|r| r.transaction_id == transaction_id)
+                .unwrap();
+            my_req.is_granted = true;
+        }
+
         loop {
             let my_req = guard
                 .requests
@@ -368,5 +396,106 @@ impl LockManager {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_single_shared_lock() {
+        let lm = LockManager::new();
+        assert!(lm.acquire_lock(1, 100, LockType::SharedLock).is_ok());
+        assert!(lm.release_lock(1, 100).is_ok());
+    }
+
+    #[test]
+    fn test_single_exclusive_lock() {
+        let lm = LockManager::new();
+        assert!(lm.acquire_lock(1, 100, LockType::ExclusiveLock).is_ok());
+        assert!(lm.release_lock(1, 100).is_ok());
+    }
+
+    #[test]
+    fn test_multiple_shared_locks() {
+        let lm = LockManager::new();
+        assert!(lm.acquire_lock(1, 100, LockType::SharedLock).is_ok());
+        assert!(lm.acquire_lock(2, 100, LockType::SharedLock).is_ok());
+        assert!(lm.acquire_lock(3, 100, LockType::SharedLock).is_ok());
+
+        assert!(lm.release_lock(1, 100).is_ok());
+        assert!(lm.release_lock(2, 100).is_ok());
+        assert!(lm.release_lock(3, 100).is_ok());
+    }
+
+    #[test]
+    fn test_upgrade_lock_success() {
+        let lm = LockManager::new();
+        assert!(lm.acquire_lock(1, 100, LockType::SharedLock).is_ok());
+        assert!(lm.upgrade_lock(1, 100).is_ok());
+        assert!(lm.release_lock(1, 100).is_ok());
+    }
+
+    #[test]
+    fn test_upgrade_conflict() {
+        let lm = Arc::new(LockManager::new());
+        lm.acquire_lock(1, 100, LockType::SharedLock).unwrap();
+        lm.acquire_lock(2, 100, LockType::SharedLock).unwrap();
+
+        let lm_clone = Arc::clone(&lm);
+        let t1 = thread::spawn(move || lm_clone.upgrade_lock(1, 100));
+
+        thread::sleep(Duration::from_millis(50));
+        let res2 = lm.upgrade_lock(2, 100);
+        assert!(matches!(res2, Err(LockManagerError::UpgradeConflict)));
+
+        lm.release_lock(2, 100).unwrap();
+        assert!(t1.join().unwrap().is_ok());
+        lm.release_lock(1, 100).unwrap();
+    }
+
+    #[test]
+    fn test_deadlock_detection() {
+        let lm = Arc::new(LockManager::new());
+        lm.acquire_lock(1, 100, LockType::ExclusiveLock).unwrap();
+        lm.acquire_lock(2, 200, LockType::ExclusiveLock).unwrap();
+
+        let lm_clone1 = Arc::clone(&lm);
+        let t1 = thread::spawn(move || lm_clone1.acquire_lock(1, 200, LockType::ExclusiveLock));
+
+        thread::sleep(Duration::from_millis(50));
+        let res2 = lm.acquire_lock(2, 100, LockType::ExclusiveLock);
+        assert!(matches!(res2, Err(LockManagerError::DeadLock)));
+
+        lm.release_lock(1, 100).unwrap();
+        lm.release_lock(2, 200).unwrap();
+        assert!(t1.join().unwrap().is_ok());
+    }
+
+    #[test]
+    fn test_writer_starvation_prevention() {
+        let lm = Arc::new(LockManager::new());
+        lm.acquire_lock(1, 100, LockType::SharedLock).unwrap();
+
+        let lm_clone1 = Arc::clone(&lm);
+        let t1 = thread::spawn(move || lm_clone1.acquire_lock(2, 100, LockType::ExclusiveLock));
+
+        thread::sleep(Duration::from_millis(50));
+
+        let lm_clone2 = Arc::clone(&lm);
+        let t2 = thread::spawn(move || lm_clone2.acquire_lock(3, 100, LockType::SharedLock));
+
+        thread::sleep(Duration::from_millis(50));
+
+        lm.release_lock(1, 100).unwrap();
+
+        assert!(t1.join().unwrap().is_ok());
+        lm.release_lock(2, 100).unwrap();
+
+        assert!(t2.join().unwrap().is_ok());
+        lm.release_lock(3, 100).unwrap();
     }
 }

--- a/crates/concurrency/src/lock_manager.rs
+++ b/crates/concurrency/src/lock_manager.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::{Arc, Condvar, Mutex},
 };
 
@@ -27,8 +27,13 @@ struct LockQueue {
     cond_var: Condvar,
 }
 
+struct WaitForGraph {
+    waits: HashMap<u64, HashSet<u64>>,
+}
+
 pub struct LockManager {
     map: Mutex<HashMap<u64, Arc<LockQueue>>>,
+    waits: Mutex<WaitForGraph>,
 }
 
 impl Default for LockManager {
@@ -37,14 +42,67 @@ impl Default for LockManager {
     }
 }
 
+impl WaitForGraph {
+    pub fn new() -> Self {
+        Self {
+            waits: HashMap::new(),
+        }
+    }
+
+    pub fn add_wait(&mut self, waiter: u64, holder: u64) {
+        self.waits
+            .entry(waiter)
+            .or_insert_with(HashSet::new)
+            .insert(holder);
+    }
+
+    pub fn remove_wait(&mut self, waiter: u64, holder: u64) {
+        if let Some(set) = self.waits.get_mut(&waiter) {
+            set.remove(&holder);
+            if set.is_empty() {
+                self.waits.remove(&waiter);
+            }
+        }
+    }
+
+    pub fn has_cycle(&self, start_tx: u64) -> bool {
+        let mut visited = HashSet::new();
+        self.dfs(start_tx, &mut visited)
+    }
+
+    fn dfs(&self, curr_tx: u64, visited: &mut HashSet<u64>) -> bool {
+        if visited.contains(&curr_tx) {
+            return true;
+        }
+        visited.insert(curr_tx);
+
+        if let Some(waits_for) = self.waits.get(&curr_tx) {
+            for &next_tx in waits_for {
+                if self.dfs(next_tx, visited) {
+                    return true;
+                }
+            }
+        }
+
+        visited.remove(&curr_tx);
+        false
+    }
+}
+
 impl LockManager {
     pub fn new() -> Self {
         Self {
             map: Mutex::new(HashMap::new()),
+            waits: Mutex::new(WaitForGraph::new()),
         }
     }
 
-    pub fn acquire_lock(&self, transaction_id: u64, page_id: u64, lock_type: LockType) {
+    pub fn acquire_lock(
+        &self,
+        transaction_id: u64,
+        page_id: u64,
+        lock_type: LockType,
+    ) -> Result<(), LockManagerError> {
         let queue = {
             let mut map_guard = self.map.lock().unwrap();
             map_guard
@@ -81,7 +139,33 @@ impl LockManager {
         });
 
         if can_grant {
-            return;
+            return Ok(());
+        }
+
+        let holders: Vec<u64> = guard
+            .requests
+            .iter()
+            .filter(|r| r.is_granted)
+            .map(|r| r.transaction_id)
+            .collect();
+
+        {
+            let mut wait_guard = self.waits.lock().unwrap();
+            // Edge direction is: WAITER -> HOLDER
+            for &holder_id in &holders {
+                wait_guard.add_wait(transaction_id, holder_id);
+            }
+
+            if wait_guard.has_cycle(transaction_id) {
+                for &holder_id in &holders {
+                    wait_guard.remove_wait(transaction_id, holder_id);
+                }
+                
+                let idx = guard.requests.iter().position(|r| r.transaction_id == transaction_id).unwrap();
+                guard.requests.remove(idx);
+                
+                return Err(LockManagerError::DeadLock);
+            }
         }
 
         loop {
@@ -96,12 +180,17 @@ impl LockManager {
                 break;
             }
         }
+
+        Ok(())
     }
 
     pub fn release_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
         let queue_guard = {
             let map_guard = self.map.lock().unwrap();
-            map_guard.get(&page_id).ok_or(LockManagerError::RecordNotFound)?.clone()
+            map_guard
+                .get(&page_id)
+                .ok_or(LockManagerError::RecordNotFound)?
+                .clone()
         };
 
         let mut guard = queue_guard.state.lock().unwrap();
@@ -119,6 +208,7 @@ impl LockManager {
 
         let mut any_granted = false;
         let mut exclusive_seen = false;
+        let mut newly_granted_txs = Vec::new();
 
         for request in guard.requests.iter_mut() {
             if request.is_granted {
@@ -134,6 +224,7 @@ impl LockManager {
 
                 if can_grant {
                     request.is_granted = true;
+                    newly_granted_txs.push(request.transaction_id);
                     any_granted = true;
                     if request.lock_type == LockType::ExclusiveLock {
                         exclusive_seen = true;
@@ -146,6 +237,24 @@ impl LockManager {
             }
         }
 
+        let remaining_waiters: Vec<u64> = guard
+            .requests
+            .iter()
+            .filter(|r| !r.is_granted)
+            .map(|r| r.transaction_id)
+            .collect();
+
+        {
+            let mut wait_guard = self.waits.lock().unwrap();
+            for waiter_id in newly_granted_txs {
+                wait_guard.remove_wait(waiter_id, transaction_id);
+            }
+            
+            for waiter_id in remaining_waiters {
+                wait_guard.remove_wait(waiter_id, transaction_id);
+            }
+        }
+
         queue_guard.cond_var.notify_all();
         Ok(())
     }
@@ -153,7 +262,10 @@ impl LockManager {
     pub fn upgrade_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
         let queue_guard = {
             let map_guard = self.map.lock().unwrap();
-            map_guard.get(&page_id).ok_or(LockManagerError::RecordNotFound)?.clone()
+            map_guard
+                .get(&page_id)
+                .ok_or(LockManagerError::RecordNotFound)?
+                .clone()
         };
 
         let mut guard = queue_guard.state.lock().unwrap();
@@ -174,7 +286,7 @@ impl LockManager {
         }
 
         if guard.is_upgrading {
-            return Err(LockManagerError::UpgradeConflict); 
+            return Err(LockManagerError::UpgradeConflict);
         }
 
         guard.is_upgrading = true;
@@ -194,7 +306,11 @@ impl LockManager {
         guard.requests.insert(insert_index, req);
 
         loop {
-            let my_req = guard.requests.iter().find(|r| r.transaction_id == transaction_id).unwrap();
+            let my_req = guard
+                .requests
+                .iter()
+                .find(|r| r.transaction_id == transaction_id)
+                .unwrap();
             if my_req.is_granted {
                 guard.is_upgrading = false;
                 break;

--- a/crates/concurrency/src/lock_manager.rs
+++ b/crates/concurrency/src/lock_manager.rs
@@ -17,8 +17,13 @@ struct LockRequest {
     is_granted: bool,
 }
 
+struct LockQueueState {
+    requests: VecDeque<LockRequest>,
+    is_upgrading: bool,
+}
+
 struct LockQueue {
-    queue: Mutex<VecDeque<LockRequest>>,
+    state: Mutex<LockQueueState>,
     cond_var: Condvar,
 }
 
@@ -46,25 +51,30 @@ impl LockManager {
                 .entry(page_id)
                 .or_insert_with(|| {
                     Arc::new(LockQueue {
-                        queue: Mutex::new(VecDeque::new()),
+                        state: Mutex::new(LockQueueState {
+                            requests: VecDeque::new(),
+                            is_upgrading: false,
+                        }),
                         cond_var: Condvar::new(),
                     })
                 })
                 .clone()
         };
 
-        let mut guard = queue.queue.lock().unwrap();
+        let mut guard = queue.state.lock().unwrap();
 
         let can_grant = match lock_type {
             LockType::SharedLock => {
-                let has_exclusive_lock =
-                    guard.iter().any(|r| r.lock_type == LockType::ExclusiveLock);
+                let has_exclusive_lock = guard
+                    .requests
+                    .iter()
+                    .any(|r| r.lock_type == LockType::ExclusiveLock);
                 !has_exclusive_lock
             }
-            LockType::ExclusiveLock => guard.is_empty(),
+            LockType::ExclusiveLock => guard.requests.is_empty(),
         };
 
-        guard.push_back(LockRequest {
+        guard.requests.push_back(LockRequest {
             transaction_id,
             lock_type,
             is_granted: can_grant,
@@ -77,6 +87,7 @@ impl LockManager {
         loop {
             guard = queue.cond_var.wait(guard).unwrap();
             let my_request = guard
+                .requests
                 .iter()
                 .find(|r| r.transaction_id == transaction_id)
                 .unwrap();
@@ -90,21 +101,26 @@ impl LockManager {
     pub fn release_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
         let queue_guard = {
             let map_guard = self.map.lock().unwrap();
-            map_guard.get(&page_id).unwrap().clone()
+            map_guard.get(&page_id).ok_or(LockManagerError::RecordNotFound)?.clone()
         };
 
-        let mut guard = queue_guard.queue.lock().unwrap();
+        let mut guard = queue_guard.state.lock().unwrap();
         let index = guard
+            .requests
             .iter()
             .position(|r| r.transaction_id == transaction_id)
             .ok_or(LockManagerError::RecordNotFound)?;
 
-        guard.remove(index);
+        if guard.is_upgrading && guard.requests[index].lock_type == LockType::ExclusiveLock {
+            guard.is_upgrading = false;
+        }
+
+        guard.requests.remove(index);
 
         let mut any_granted = false;
         let mut exclusive_seen = false;
 
-        for request in guard.iter_mut() {
+        for request in guard.requests.iter_mut() {
             if request.is_granted {
                 any_granted = true;
                 if request.lock_type == LockType::ExclusiveLock {
@@ -131,6 +147,62 @@ impl LockManager {
         }
 
         queue_guard.cond_var.notify_all();
+        Ok(())
+    }
+
+    pub fn upgrade_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
+        let queue_guard = {
+            let map_guard = self.map.lock().unwrap();
+            map_guard.get(&page_id).ok_or(LockManagerError::RecordNotFound)?.clone()
+        };
+
+        let mut guard = queue_guard.state.lock().unwrap();
+
+        let index = guard
+            .requests
+            .iter()
+            .position(|r| r.transaction_id == transaction_id)
+            .ok_or(LockManagerError::RecordNotFound)?;
+
+        let request = &guard.requests[index];
+
+        if request.lock_type == LockType::ExclusiveLock {
+            return Ok(());
+        }
+        if !request.is_granted {
+            return Err(LockManagerError::InvalidLockState);
+        }
+
+        if guard.is_upgrading {
+            return Err(LockManagerError::UpgradeConflict); 
+        }
+
+        guard.is_upgrading = true;
+
+        let mut req = guard.requests.remove(index).unwrap();
+        req.lock_type = LockType::ExclusiveLock;
+        req.is_granted = false;
+
+        let mut insert_index = 0;
+        for (i, r) in guard.requests.iter().enumerate() {
+            if !r.is_granted {
+                insert_index = i;
+                break;
+            }
+            insert_index = i + 1;
+        }
+        guard.requests.insert(insert_index, req);
+
+        loop {
+            let my_req = guard.requests.iter().find(|r| r.transaction_id == transaction_id).unwrap();
+            if my_req.is_granted {
+                guard.is_upgrading = false;
+                break;
+            }
+
+            guard = queue_guard.cond_var.wait(guard).unwrap();
+        }
+
         Ok(())
     }
 }

--- a/crates/concurrency/src/lock_manager.rs
+++ b/crates/concurrency/src/lock_manager.rs
@@ -1,3 +1,15 @@
+//! Centralized Concurrency Control and Lock Management.
+//!
+//! The `LockManager` enforces strict Two-Phase Locking (2PL) across all transactions
+//! in FluxDB. It manages granular, resource-level queues and condition variables to
+//! allow highly concurrent, non-spinning lock acquisition.
+//!
+//! ## Core Features
+//!
+//! - **Strict 2PL:** Prevents dirty reads, unrepeatable reads, and phantom reads.
+//! - **Writer-Starvation Prevention:** Ensures that exclusive lock requests don't starve behind a constant stream of shared locks.
+//! - **Deadlock Detection:** Synchronously detects deadlocks using a Waits-For Graph (WFG) cycle detection algorithm upon every lock queueing event.
+
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::{Arc, Condvar, Mutex},
@@ -5,32 +17,55 @@ use std::{
 
 use common::LockManagerError;
 
+/// The type of lock requested by a transaction.
+///
+/// FluxDB uses a standard Multiple-Granularity Locking scheme with
+/// strict two-phase locking (2PL).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LockType {
     SharedLock,
     ExclusiveLock,
 }
 
+/// Represents an active or pending lock request in a queue.
+#[derive(Debug)]
 struct LockRequest {
     transaction_id: u64,
     lock_type: LockType,
     is_granted: bool,
 }
 
+/// The internal state of a lock queue for a specific resource (e.g. a page).
+/// Tracks granted and pending locks, and prevents upgrade deadlocks.
+#[derive(Debug)]
 struct LockQueueState {
     requests: VecDeque<LockRequest>,
     is_upgrading: bool,
 }
 
+/// A synchronization queue for a single resource.
+/// Uses a Condition Variable to efficiently block transactions until they
+/// can acquire the requested lock.
+#[derive(Debug)]
 struct LockQueue {
     state: Mutex<LockQueueState>,
     cond_var: Condvar,
 }
 
+/// A Directed Graph tracking which transactions are waiting on which.
+/// Used for synchronous deadlock detection during lock acquisition.
+#[derive(Debug)]
 struct WaitForGraph {
     waits: HashMap<u64, HashSet<u64>>,
 }
 
+/// The centralized manager for all concurrency control locks in FluxDB.
+///
+/// Features:
+/// 1. **Strict 2PL:** Prevents dirty reads and non-repeatable reads.
+/// 2. **Writer-Starvation Prevention:** Shared lock requests will queue behind pending Exclusive requests.
+/// 3. **Deadlock Detection:** Automatically detects cycles in a Waits-For Graph and aborts deadlocking transactions.
+#[derive(Debug)]
 pub struct LockManager {
     map: Mutex<HashMap<u64, Arc<LockQueue>>>,
     waits: Mutex<WaitForGraph>,
@@ -97,6 +132,11 @@ impl LockManager {
         }
     }
 
+    /// Attempts to acquire a lock on a page for a transaction.
+    ///
+    /// If the lock cannot be granted immediately (e.g. due to conflict),
+    /// the transaction will block until the lock becomes available.
+    /// If blocking would cause a deadlock, returns `Err(LockManagerError::DeadLock)`.
     pub fn acquire_lock(
         &self,
         transaction_id: u64,
@@ -184,6 +224,9 @@ impl LockManager {
         Ok(())
     }
 
+    /// Releases a lock held by a transaction on a specific page.
+    ///
+    /// Automatically promotes queued transactions using Writer-Starvation Prevention logic.
     pub fn release_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
         let queue_guard = {
             let map_guard = self.map.lock().unwrap();
@@ -259,6 +302,11 @@ impl LockManager {
         Ok(())
     }
 
+    /// Upgrades an existing `SharedLock` to an `ExclusiveLock`.
+    ///
+    /// Requires the transaction to already hold a `SharedLock`.
+    /// Puts the upgrade request at the front of the queue to avoid starvation,
+    /// but will return `UpgradeConflict` if another transaction is already upgrading.
     pub fn upgrade_lock(&self, transaction_id: u64, page_id: u64) -> Result<(), LockManagerError> {
         let queue_guard = {
             let map_guard = self.map.lock().unwrap();

--- a/crates/db-core/Cargo.toml
+++ b/crates/db-core/Cargo.toml
@@ -4,3 +4,5 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+concurrency.workspace = true
+common.workspace = true

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -22,7 +22,9 @@
 //! `WriteConflict`). The first transaction to set `xmax` wins.
 
 use crate::transaction_manager::TransactionManager;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::{Arc, Mutex}};
+use concurrency::lock_manager::{LockManager, LockType};
+use common::LockManagerError;
 
 /// A transaction's identity and its point-in-time view of the database.
 ///
@@ -30,12 +32,11 @@ use std::sync::Arc;
 /// take a `&Transaction` to determine visibility and ownership.
 #[derive(Debug, Clone)]
 pub struct Transaction {
-    /// This transaction's unique, monotonically increasing ID.
     pub txn_id: u64,
-    /// The snapshot taken at the start of this transaction.
     pub snapshot: Snapshot,
-    /// The manager tracking commit log entries for visibility checking.
     pub tm: Arc<TransactionManager>,
+    pub lock_manager: Arc<LockManager>,
+    pub locked_pages: Arc<Mutex<HashSet<u64>>>
 }
 
 impl Transaction {
@@ -55,6 +56,55 @@ impl Transaction {
     /// perspective?
     pub fn is_in_progress(&self, txn_id: u64) -> bool {
         self.snapshot.is_in_progress(txn_id, &self.tm)
+    }
+
+    /// Acquires a shared lock on the given page.
+    pub fn acquire_shared_lock(&self, page_id: u64) -> Result<(), LockManagerError> {
+        self.lock_manager.acquire_lock(self.txn_id, page_id, LockType::SharedLock)?;
+        self.locked_pages.lock().unwrap().insert(page_id);
+        Ok(())
+    }
+
+    /// Acquires an exclusive lock on the given page.
+    pub fn acquire_exclusive_lock(&self, page_id: u64) -> Result<(), LockManagerError> {
+        self.lock_manager.acquire_lock(self.txn_id, page_id, LockType::ExclusiveLock)?;
+        self.locked_pages.lock().unwrap().insert(page_id);
+        Ok(())
+    }
+
+    /// Upgrades an existing shared lock to an exclusive lock.
+    pub fn upgrade_lock(&self, page_id: u64) -> Result<(), LockManagerError> {
+        self.lock_manager.upgrade_lock(self.txn_id, page_id)?;
+        self.locked_pages.lock().unwrap().insert(page_id);
+        Ok(())
+    }
+
+    /// Commits the transaction and releases all held locks.
+    pub fn commit(&self) {
+        self.tm.commit(self.txn_id);
+        let pages: Vec<u64> = {
+            let mut guard = self.locked_pages.lock().unwrap();
+            let p = guard.iter().copied().collect();
+            guard.clear();
+            p
+        };
+        for page_id in pages {
+            let _ = self.lock_manager.release_lock(self.txn_id, page_id);
+        }
+    }
+
+    /// Aborts the transaction and releases all held locks.
+    pub fn abort(&self) {
+        self.tm.abort(self.txn_id);
+        let pages: Vec<u64> = {
+            let mut guard = self.locked_pages.lock().unwrap();
+            let p = guard.iter().copied().collect();
+            guard.clear();
+            p
+        };
+        for page_id in pages {
+            let _ = self.lock_manager.release_lock(self.txn_id, page_id);
+        }
     }
 }
 

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -22,9 +22,12 @@
 //! `WriteConflict`). The first transaction to set `xmax` wins.
 
 use crate::transaction_manager::TransactionManager;
-use std::{collections::HashSet, sync::{Arc, Mutex}};
-use concurrency::lock_manager::{LockManager, LockType};
 use common::LockManagerError;
+use concurrency::lock_manager::{LockManager, LockType};
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
 
 /// A transaction's identity and its point-in-time view of the database.
 ///
@@ -36,7 +39,7 @@ pub struct Transaction {
     pub snapshot: Snapshot,
     pub tm: Arc<TransactionManager>,
     pub lock_manager: Arc<LockManager>,
-    pub locked_pages: Arc<Mutex<HashSet<u64>>>
+    pub locked_pages: Arc<Mutex<HashSet<u64>>>,
 }
 
 impl Transaction {
@@ -60,14 +63,16 @@ impl Transaction {
 
     /// Acquires a shared lock on the given page.
     pub fn acquire_shared_lock(&self, page_id: u64) -> Result<(), LockManagerError> {
-        self.lock_manager.acquire_lock(self.txn_id, page_id, LockType::SharedLock)?;
+        self.lock_manager
+            .acquire_lock(self.txn_id, page_id, LockType::SharedLock)?;
         self.locked_pages.lock().unwrap().insert(page_id);
         Ok(())
     }
 
     /// Acquires an exclusive lock on the given page.
     pub fn acquire_exclusive_lock(&self, page_id: u64) -> Result<(), LockManagerError> {
-        self.lock_manager.acquire_lock(self.txn_id, page_id, LockType::ExclusiveLock)?;
+        self.lock_manager
+            .acquire_lock(self.txn_id, page_id, LockType::ExclusiveLock)?;
         self.locked_pages.lock().unwrap().insert(page_id);
         Ok(())
     }

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -34,6 +34,8 @@ use std::{
 };
 
 use crate::transaction::{Snapshot, Transaction};
+use concurrency::lock_manager::LockManager;
+use std::sync::Arc;
 
 /// Represents the deterministic final state of a transaction.
 ///
@@ -60,6 +62,7 @@ pub struct TransactionManager {
     pub next_txn_id: AtomicU64,
     pub clog: RwLock<HashMap<u64, TransactionStatus>>,
     pub active_txns: RwLock<HashSet<u64>>,
+    pub lock_manager: Arc<LockManager>,
 }
 
 impl TransactionManager {
@@ -69,6 +72,7 @@ impl TransactionManager {
             next_txn_id: AtomicU64::new(1),
             clog: RwLock::new(HashMap::new()),
             active_txns: RwLock::new(HashSet::new()),
+            lock_manager: Arc::new(LockManager::new()),
         }
     }
 
@@ -98,7 +102,7 @@ impl TransactionManager {
     /// race conditions. It acquires a write-lock on the active set *before*
     /// generating the new ID, ensuring that concurrent snapshot generators
     /// always see a consistent state.
-    pub fn begin(self: &std::sync::Arc<Self>) -> Transaction {
+    pub fn begin(self: &Arc<Self>) -> Transaction {
         // Write-lock active_txns FIRST to prevent race conditions with get_snapshot.
         // We must lock before fetching TXN_ID to ensure that no snapshot is
         // generated in between ID creation and active set insertion.
@@ -125,7 +129,9 @@ impl TransactionManager {
                 xmax,
                 active: active_vec,
             },
-            tm: std::sync::Arc::clone(self),
+            tm: self.clone(),
+            lock_manager: self.lock_manager.clone(),
+            locked_pages: Arc::new(std::sync::Mutex::new(HashSet::new())),
         }
     }
 

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -101,9 +101,7 @@ impl BufferPoolManager {
 
         if needs_load {
             let mut data = shard.pages[frame_id].write().unwrap();
-            shard
-                .disk_manager
-                .read_page(page_id, data.0.as_mut())?;
+            shard.disk_manager.read_page(page_id, data.0.as_mut())?;
         }
 
         let data = shard.pages[frame_id].read().unwrap();
@@ -142,9 +140,7 @@ impl BufferPoolManager {
 
         let mut data = shard.pages[frame_id].write().unwrap();
         if needs_load {
-            shard
-                .disk_manager
-                .read_page(page_id, data.0.as_mut())?;
+            shard.disk_manager.read_page(page_id, data.0.as_mut())?;
         }
 
         Ok(PageWriteGuard {

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -4,9 +4,9 @@
 //! reduces lock contention by allowing multiple threads to access different
 //! partitions of the buffer pool simultaneously.
 
-use common::BufferPoolError;
 use crate::buffer_pool::replacer::ClockReplacer;
 use crate::disk::DiskManager;
+use common::BufferPoolError;
 use common::{INVALID_FRAME_ID, MAX_PAGE_SIZE};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
@@ -293,10 +293,8 @@ impl BufferPoolShard {
             buf.copy_from_slice(&data[..]);
         }
 
-        self.disk_manager
-            .write_page(page_id, &buf)?;
-        self.disk_manager
-            .sync_data()?;
+        self.disk_manager.write_page(page_id, &buf)?;
+        self.disk_manager.sync_data()?;
         Ok(())
     }
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -14,12 +14,12 @@ use std::sync::{Arc, Mutex};
 use common::{Key, MAX_KEY_SIZE, Value};
 use db_core::transaction_manager::TransactionManager;
 
-use common::IndexError;
 use crate::buffer_pool::{BufferPoolManager, PageReadGuard, PageWriteGuard};
 use crate::page::{
     INTERNAL, InternalPageAccessor, InternalPageBuilder, InternalPageMutator, LEAF,
     LeafPageAccessor, LeafPageBuilder, LeafPageMutator, PageId,
 };
+use common::IndexError;
 
 use db_core::transaction::Transaction;
 
@@ -694,15 +694,13 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
 
         if target_pid == leaf_pid_actual {
             let (s, _) = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).position(key);
-            LeafPageMutator::<K, V>::new(&mut leaf_guard[..])
-                .insert(s, key, value)?;
+            LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).insert(s, key, value)?;
             LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmin(s, txn_id);
         } else {
             drop(leaf_guard);
             let mut right = self.pool.fetch_page_mut(target_pid)?;
             let (s, _) = LeafPageAccessor::<K, V>::new(&right[..]).position(key);
-            LeafPageMutator::<K, V>::new(&mut right[..])
-                .insert(s, key, value)?;
+            LeafPageMutator::<K, V>::new(&mut right[..]).insert(s, key, value)?;
             LeafPageMutator::<K, V>::new(&mut right[..]).set_xmin(s, txn_id);
         }
 
@@ -859,8 +857,11 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             let acc = InternalPageAccessor::<K>::new(&parent_guard[..]);
             if acc.can_fit(sep_key.len()) {
                 let (idx, _) = acc.find_child(&K::from_bytes(&sep_key));
-                InternalPageMutator::<K>::new(&mut parent_guard[..])
-                    .insert_key_and_right_child(idx, &K::from_bytes(&sep_key), right_pid)?;
+                InternalPageMutator::<K>::new(&mut parent_guard[..]).insert_key_and_right_child(
+                    idx,
+                    &K::from_bytes(&sep_key),
+                    right_pid,
+                )?;
                 return Ok(());
             }
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1022,7 +1022,7 @@ mod tests {
     use crate::disk::DiskManager;
     use common::MAX_PAGE_SIZE;
     use std::collections::HashSet;
-use std::mem::forget;
+    use std::mem::forget;
     use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
     use std::sync::{Arc, OnceLock};
     use tempfile::tempdir;

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1021,7 +1021,8 @@ mod tests {
     use crate::buffer_pool::manager::BufferPoolManager;
     use crate::disk::DiskManager;
     use common::MAX_PAGE_SIZE;
-    use std::mem::forget;
+    use std::collections::HashSet;
+use std::mem::forget;
     use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
     use std::sync::{Arc, OnceLock};
     use tempfile::tempdir;
@@ -1047,6 +1048,8 @@ mod tests {
         Transaction {
             txn_id: TEST_TXN_ID.fetch_add(1, Relaxed),
             snapshot: db_core::transaction::Snapshot::latest(),
+            lock_manager: tm.lock_manager.clone(),
+            locked_pages: Arc::new(Mutex::new(HashSet::new())),
             tm,
         }
     }

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -27,9 +27,9 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::vec;
 
-use common::WalError;
 use crate::disk::DiskManager;
 use crate::page::Lsn;
+use common::WalError;
 
 pub type Result<T> = std::result::Result<T, WalError>;
 


### PR DESCRIPTION
**Summary**
This PR implements a Lock Manager that enforces strict Two-Phase Locking (2PL) with deadlock detection and integrates it seamlessly into the transaction lifecycle.

**Changes**
- implements strict two-phase locking with shared and exclusive locks
- uses a Waits-For Graph for synchronous deadlock detection
- manually shards the lock table into 128 mutexes for high throughput
- updates `TransactionManager` to automatically release locks on commit or abort

**Related Issue**
Closes #17 

**Any design changes?**
- `Transaction` now internally tracks a `HashSet` of `locked_pages` and requires a reference to the global `LockManager` upon initialization.

**Checklist**
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes