### PR TITLE
fix write_conflict and transaction visiblity

### DIFF
--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -42,6 +42,11 @@ impl Transaction {
     /// Determines whether a record with `(rec_xmin, rec_xmax)` is visible to
     /// this transaction.
     pub fn is_visible(&self, rec_xmin: u64, rec_xmax: u64) -> bool {
+        if rec_xmin == self.txn_id {
+        // own write: visible unless we deleted it ourselves
+        // a transaction should be able to able to read its own inserts 
+        return rec_xmax == 0 || rec_xmax != self.txn_id;
+        }
         is_visible(rec_xmin, rec_xmax, &self.snapshot, &self.tm)
     }
 

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -43,9 +43,8 @@ impl Transaction {
     /// this transaction.
     pub fn is_visible(&self, rec_xmin: u64, rec_xmax: u64) -> bool {
         if rec_xmin == self.txn_id {
-        // own write: visible unless we deleted it ourselves
-        // a transaction should be able to able to read its own inserts 
-        return rec_xmax == 0 || rec_xmax != self.txn_id;
+            // Own write: visible unless we deleted it ourselves.
+            return rec_xmax != self.txn_id;
         }
         is_visible(rec_xmin, rec_xmax, &self.snapshot, &self.tm)
     }
@@ -395,5 +394,46 @@ mod tests {
         let tm = TransactionManager::new();
         // xmax=15 in-progress -> live
         assert!(!is_vacuumable(5, 15, 100, &tm));
+    }
+
+    // ── Self-visibility (read-your-own-writes) ───────────────────────────
+
+    fn make_txn(tm: &std::sync::Arc<TransactionManager>) -> Transaction {
+        tm.begin()
+    }
+
+    #[test]
+    fn own_insert_is_visible() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        let txn = make_txn(&tm);
+        // xmin = own txn_id, xmax = 0 (not deleted) → must be visible
+        assert!(txn.is_visible(txn.txn_id, 0));
+    }
+
+    #[test]
+    fn own_deleted_record_is_invisible() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        let txn = make_txn(&tm);
+        // xmin = own txn_id, xmax = own txn_id (we deleted it) → invisible
+        assert!(!txn.is_visible(txn.txn_id, txn.txn_id));
+    }
+
+    #[test]
+    fn own_record_deleted_by_other_is_visible() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        let txn = make_txn(&tm);
+        // xmin = own txn_id, xmax = someone else's txn → still visible to us
+        assert!(txn.is_visible(txn.txn_id, txn.txn_id + 1));
+    }
+
+    #[test]
+    fn foreign_active_creator_invisible_to_self() {
+        // Sanity check: the self-visibility branch only fires for own txn_id.
+        // A record created by a different active transaction must remain invisible.
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        let other = make_txn(&tm);
+        let txn = make_txn(&tm);
+        // other.txn_id != txn.txn_id, other is active → invisible
+        assert!(!txn.is_visible(other.txn_id, 0));
     }
 }

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -55,14 +55,17 @@ pub enum TransactionStatus {
 ///    consistent point-in-time views.
 /// 3. **Commit Log (CLOG)**: Recording the final status of every transaction
 ///    to resolve visibility during record scans.
+//  Each entry is (settled: Mutex<bool>, Condvar). The condvar sleeps on its
+//  own mutex so wait_until_settled never holds the waiters map lock while
+//  sleeping — avoiding lock-order inversion with commit/abort.
+type WaiterEntry = Arc<(Mutex<bool>, Condvar)>;
+
 #[derive(Debug)]
 pub struct TransactionManager {
     pub next_txn_id: AtomicU64,
     pub clog: RwLock<HashMap<u64, TransactionStatus>>,
     pub active_txns: RwLock<HashSet<u64>>,
-    // Per-transaction condvars: threads waiting on a specific txn_id sleep here.
-    // Woken by commit() or abort() when that transaction settles.
-    waiters: Mutex<HashMap<u64, Arc<Condvar>>>,
+    waiters: Mutex<HashMap<u64, WaiterEntry>>,
 }
 
 impl TransactionManager {
@@ -161,23 +164,42 @@ impl TransactionManager {
 
     /// Block the calling thread until `blocking_txn` commits or aborts.
     ///
-    /// Uses a per-transaction condvar so the thread sleeps instead of spinning.
-    /// The condvar is created lazily on first wait and removed after the
-    /// transaction settles.
+    /// Returns immediately if the transaction has already settled. Otherwise
+    /// sleeps on a per-transaction condvar that is woken by commit/abort.
+    /// The waiters map lock is never held while sleeping, avoiding lock-order
+    /// inversion with commit/abort.
     pub fn wait_until_settled(&self, blocking_txn: u64) {
-        let cv = {
+        // Fast path: already settled, nothing to do.
+        if !self.is_active(blocking_txn) {
+            return;
+        }
+
+        // Get or create the waiter entry while holding the map lock briefly.
+        let entry: WaiterEntry = {
             let mut waiters = self.waiters.lock().unwrap();
-            Arc::clone(waiters.entry(blocking_txn).or_insert_with(|| Arc::new(Condvar::new())))
-        };
-        // The condvar needs a mutex to wait on. We reuse the waiters mutex as
-        // the guard — lock it, check the condition, sleep if still active.
-        let waiters = self.waiters.lock().unwrap();
-        let _guard = cv.wait_while(waiters, |_| self.is_active(blocking_txn)).unwrap();
+            // Re-check under the map lock — commit/abort may have fired between
+            // the fast-path check above and acquiring the map lock.
+            if !self.is_active(blocking_txn) {
+                return;
+            }
+            Arc::clone(
+                waiters
+                    .entry(blocking_txn)
+                    .or_insert_with(|| Arc::new((Mutex::new(false), Condvar::new()))),
+            )
+        }; // map lock released here
+
+        // Sleep on the entry's own mutex — no map lock held during the wait.
+        let (settled_lock, cv) = &*entry;
+        let settled = settled_lock.lock().unwrap();
+        drop(cv.wait_while(settled, |&mut s| !s).unwrap());
     }
 
     fn notify_waiters(&self, txn_id: u64) {
-        let cv = self.waiters.lock().unwrap().remove(&txn_id);
-        if let Some(cv) = cv {
+        let entry = self.waiters.lock().unwrap().remove(&txn_id);
+        if let Some(entry) = entry {
+            let (settled_lock, cv) = &*entry;
+            *settled_lock.lock().unwrap() = true;
             cv.notify_all();
         }
     }
@@ -300,5 +322,123 @@ mod tests {
         assert!(snap.active.contains(&txn1.txn_id));
         assert!(snap.active.contains(&txn3.txn_id));
         assert_eq!(snap.active.len(), 2);
+    }
+
+    // ── wait_until_settled ────────────────────────────────────────────────
+
+    #[test]
+    fn wait_until_settled_returns_immediately_if_already_committed() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        let txn = tm.begin();
+        tm.commit(txn.txn_id);
+        // Must return without blocking — transaction already settled.
+        tm.wait_until_settled(txn.txn_id);
+    }
+
+    #[test]
+    fn wait_until_settled_returns_immediately_if_already_aborted() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        let txn = tm.begin();
+        tm.abort(txn.txn_id);
+        tm.wait_until_settled(txn.txn_id);
+    }
+
+    #[test]
+    fn wait_until_settled_unblocks_on_commit() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let tm = Arc::new(TransactionManager::new());
+        let blocker = tm.begin();
+        let blocker_id = blocker.txn_id;
+
+        let tm_clone = Arc::clone(&tm);
+        let waiter = thread::spawn(move || {
+            tm_clone.wait_until_settled(blocker_id);
+        });
+
+        // Give the waiter thread time to reach wait_until_settled and sleep.
+        thread::sleep(Duration::from_millis(20));
+        assert!(!waiter.is_finished(), "waiter should be blocked");
+
+        tm.commit(blocker_id);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !waiter.is_finished() {
+            assert!(Instant::now() < deadline, "waiter did not unblock after commit");
+            thread::sleep(Duration::from_millis(5));
+        }
+        waiter.join().expect("waiter panicked");
+    }
+
+    #[test]
+    fn wait_until_settled_unblocks_on_abort() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let tm = Arc::new(TransactionManager::new());
+        let blocker = tm.begin();
+        let blocker_id = blocker.txn_id;
+
+        let tm_clone = Arc::clone(&tm);
+        let waiter = thread::spawn(move || {
+            tm_clone.wait_until_settled(blocker_id);
+        });
+
+        thread::sleep(Duration::from_millis(20));
+        assert!(!waiter.is_finished(), "waiter should be blocked");
+
+        tm.abort(blocker_id);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !waiter.is_finished() {
+            assert!(Instant::now() < deadline, "waiter did not unblock after abort");
+            thread::sleep(Duration::from_millis(5));
+        }
+        waiter.join().expect("waiter panicked");
+    }
+
+    #[test]
+    fn wait_until_settled_multiple_waiters_all_unblock() {
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let tm = Arc::new(TransactionManager::new());
+        let blocker = tm.begin();
+        let blocker_id = blocker.txn_id;
+
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                let tm_clone = Arc::clone(&tm);
+                thread::spawn(move || {
+                    tm_clone.wait_until_settled(blocker_id);
+                })
+            })
+            .collect();
+
+        thread::sleep(Duration::from_millis(20));
+        tm.commit(blocker_id);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        for handle in handles {
+            while !handle.is_finished() {
+                assert!(Instant::now() < deadline, "a waiter did not unblock");
+                thread::sleep(Duration::from_millis(5));
+            }
+            handle.join().expect("waiter panicked");
+        }
+    }
+
+    #[test]
+    fn waiter_map_cleaned_up_after_settle() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        let txn = tm.begin();
+        let txn_id = txn.txn_id;
+        tm.commit(txn_id);
+        // Entry must not be in the map after settle — no memory leak.
+        assert!(!tm.waiters.lock().unwrap().contains_key(&txn_id));
     }
 }

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -30,7 +30,7 @@ use std::sync::atomic::{
 };
 use std::{
     collections::{HashMap, HashSet},
-    sync::RwLock,
+    sync::{Arc, Condvar, Mutex, RwLock},
 };
 
 use crate::transaction::{Snapshot, Transaction};
@@ -60,6 +60,9 @@ pub struct TransactionManager {
     pub next_txn_id: AtomicU64,
     pub clog: RwLock<HashMap<u64, TransactionStatus>>,
     pub active_txns: RwLock<HashSet<u64>>,
+    // Per-transaction condvars: threads waiting on a specific txn_id sleep here.
+    // Woken by commit() or abort() when that transaction settles.
+    waiters: Mutex<HashMap<u64, Arc<Condvar>>>,
 }
 
 impl TransactionManager {
@@ -69,6 +72,7 @@ impl TransactionManager {
             next_txn_id: AtomicU64::new(1),
             clog: RwLock::new(HashMap::new()),
             active_txns: RwLock::new(HashSet::new()),
+            waiters: Mutex::new(HashMap::new()),
         }
     }
 
@@ -132,27 +136,50 @@ impl TransactionManager {
     /// Marks a transaction as committed in the CLOG and removes it from the active set.
     ///
     /// Once committed, the transaction's writes become eligible for visibility
-    /// to new snapshots.
+    /// to new snapshots. Any threads waiting on this transaction via
+    /// `wait_until_settled` are woken up.
     pub fn commit(&self, txn_id: u64) {
         self.clog
             .write()
             .unwrap()
             .insert(txn_id, TransactionStatus::Committed);
         self.active_txns.write().unwrap().remove(&txn_id);
+        self.notify_waiters(txn_id);
     }
 
     /// Marks a transaction as aborted in the CLOG and removes it from the active set.
     ///
-    /// **Note**: The caller (e.g., storage engine) is responsible for rolling back
-    /// any physical writes or undo logs associated with this transaction before
-    /// or after calling this method.
+    /// Any threads waiting on this transaction via `wait_until_settled` are woken up.
     pub fn abort(&self, txn_id: u64) {
-        // TODO: The storage/undo layer must rollback writes before calling this.
         self.clog
             .write()
             .unwrap()
             .insert(txn_id, TransactionStatus::Aborted);
         self.active_txns.write().unwrap().remove(&txn_id);
+        self.notify_waiters(txn_id);
+    }
+
+    /// Block the calling thread until `blocking_txn` commits or aborts.
+    ///
+    /// Uses a per-transaction condvar so the thread sleeps instead of spinning.
+    /// The condvar is created lazily on first wait and removed after the
+    /// transaction settles.
+    pub fn wait_until_settled(&self, blocking_txn: u64) {
+        let cv = {
+            let mut waiters = self.waiters.lock().unwrap();
+            Arc::clone(waiters.entry(blocking_txn).or_insert_with(|| Arc::new(Condvar::new())))
+        };
+        // The condvar needs a mutex to wait on. We reuse the waiters mutex as
+        // the guard — lock it, check the condition, sleep if still active.
+        let waiters = self.waiters.lock().unwrap();
+        let _guard = cv.wait_while(waiters, |_| self.is_active(blocking_txn)).unwrap();
+    }
+
+    fn notify_waiters(&self, txn_id: u64) {
+        let cv = self.waiters.lock().unwrap().remove(&txn_id);
+        if let Some(cv) = cv {
+            cv.notify_all();
+        }
     }
 
     /// Returns `true` if the transaction is recorded as `Committed` in the CLOG.

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -167,10 +167,10 @@ impl TransactionManager {
     /// Returns immediately if the transaction has already settled. Otherwise
     /// sleeps on a per-transaction condvar that is woken by commit/abort.
     ///
-    /// Lock ordering: this function never holds the waiters mutex while calling
-    /// is_active (which takes active_txns). commit/abort hold active_txns then
-    /// lock waiters in notify_waiters — so is_active must only be called
-    /// outside the waiters lock to avoid inversion.
+    /// Lock ordering: never hold the `waiters` mutex while calling `is_active`
+    /// (which locks `active_txns`). `commit`/`abort` lock `active_txns` and may
+    /// subsequently lock `waiters` when notifying, so keeping `is_active` calls
+    /// outside the `waiters` lock avoids potential lock-order inversion.
     pub fn wait_until_settled(&self, blocking_txn: u64) {
         // Fast path: already settled, nothing to do.
         if !self.is_active(blocking_txn) {

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -166,33 +166,43 @@ impl TransactionManager {
     ///
     /// Returns immediately if the transaction has already settled. Otherwise
     /// sleeps on a per-transaction condvar that is woken by commit/abort.
-    /// The waiters map lock is never held while sleeping, avoiding lock-order
-    /// inversion with commit/abort.
+    ///
+    /// Lock ordering: this function never holds the waiters mutex while calling
+    /// is_active (which takes active_txns). commit/abort hold active_txns then
+    /// lock waiters in notify_waiters — so is_active must only be called
+    /// outside the waiters lock to avoid inversion.
     pub fn wait_until_settled(&self, blocking_txn: u64) {
         // Fast path: already settled, nothing to do.
         if !self.is_active(blocking_txn) {
             return;
         }
 
-        // Get or create the waiter entry while holding the map lock briefly.
+        // Install the waiter entry. Do NOT call is_active while holding the
+        // waiters mutex — that acquires active_txns and inverts the lock order
+        // used by commit/abort (active_txns → waiters).
         let entry: WaiterEntry = {
             let mut waiters = self.waiters.lock().unwrap();
-            // Re-check under the map lock — commit/abort may have fired between
-            // the fast-path check above and acquiring the map lock.
-            if !self.is_active(blocking_txn) {
-                return;
-            }
             Arc::clone(
                 waiters
                     .entry(blocking_txn)
                     .or_insert_with(|| Arc::new((Mutex::new(false), Condvar::new()))),
             )
-        }; // map lock released here
+        }; // waiters lock released here — safe to call is_active again
+
+        // Missed-wakeup guard: the transaction may have settled between the
+        // fast-path check above and installing our entry. notify_waiters would
+        // have found no entry at that point and done nothing. Check now:
+        // - if settled is already true, wait_while returns immediately below
+        // - if is_active is false but settled not yet true, clean up and return
+        if !self.is_active(blocking_txn) {
+            self.notify_waiters(blocking_txn);
+            return;
+        }
 
         // Sleep on the entry's own mutex — no map lock held during the wait.
         let (settled_lock, cv) = &*entry;
         let settled = settled_lock.lock().unwrap();
-        drop(cv.wait_while(settled, |&mut s| !s).unwrap());
+        drop(cv.wait_while(settled, |s| !*s).unwrap());
     }
 
     fn notify_waiters(&self, txn_id: u64) {
@@ -434,11 +444,32 @@ mod tests {
 
     #[test]
     fn waiter_map_cleaned_up_after_settle() {
-        let tm = std::sync::Arc::new(TransactionManager::new());
-        let txn = tm.begin();
-        let txn_id = txn.txn_id;
-        tm.commit(txn_id);
-        // Entry must not be in the map after settle — no memory leak.
-        assert!(!tm.waiters.lock().unwrap().contains_key(&txn_id));
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let tm = Arc::new(TransactionManager::new());
+        let blocker = tm.begin();
+        let blocker_id = blocker.txn_id;
+
+        let tm_clone = Arc::clone(&tm);
+        let waiter = thread::spawn(move || {
+            tm_clone.wait_until_settled(blocker_id);
+        });
+
+        // Give the waiter time to register its entry in the map.
+        thread::sleep(Duration::from_millis(20));
+
+        tm.commit(blocker_id);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !waiter.is_finished() {
+            assert!(Instant::now() < deadline, "waiter did not unblock");
+            thread::sleep(Duration::from_millis(5));
+        }
+        waiter.join().expect("waiter panicked");
+
+        // Entry must be removed from the map after settle — no memory leak.
+        assert!(!tm.waiters.lock().unwrap().contains_key(&blocker_id));
     }
 }

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -591,17 +591,18 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
     /// Wait for `blocking_txn` to settle using Wait-Die deadlock prevention.
     ///
     /// If the caller is younger than the blocker (higher txn_id), it dies
-    /// immediately rather than waiting — this prevents circular waits where
-    /// two transactions spin on each other across different keys.
+    /// immediately — this prevents circular waits where two transactions
+    /// wait on each other across different keys.
+    ///
+    /// If the caller is older, it sleeps on a condvar until the blocker
+    /// commits or aborts, then returns so the caller can retry.
     ///
     /// Must be called with no page latches held.
     fn wait_for_txn(tm: &TransactionManager, blocking_txn: u64, my_txn_id: u64) -> Result<()> {
         if my_txn_id > blocking_txn {
             return Err(IndexError::WriteConflict);
         }
-        while tm.is_active(blocking_txn) {
-            std::hint::spin_loop();
-        }
+        tm.wait_until_settled(blocking_txn);
         Ok(())
     }
 

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -279,35 +279,47 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             }
         };
 
-        // Exclusive latch + rightlink correction.
+        // Exclusive latch + rightlink correction + conflict retry loop.
         let mut leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
         loop {
+            // Rightlink correction: follow splits that happened during descent.
+            loop {
+                let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+                if let Some(hk) = acc.high_key_bytes() {
+                    if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                        let right = acc.rightlink().unwrap();
+                        drop(leaf_guard);
+                        leaf_guard = self.pool.fetch_page_mut(right)?;
+                        continue;
+                    }
+                }
+                break;
+            }
+
+            // Find visible version.
             let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
-            if let Some(hk) = acc.high_key_bytes() {
-                if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
-                    let right = acc.rightlink().unwrap();
+            let visible_slot = self
+                .find_visible_slot(&acc, key, txn)
+                .ok_or(IndexError::KeyNotFound)?;
+
+            // Conflict check: if another in-progress txn holds xmax, wait for
+            // it to settle then retry — same Wait-Die protocol as insert.
+            let rec_xmax = acc.get_xmax(visible_slot);
+            match self.check_write_conflict(rec_xmax, txn) {
+                Ok(()) => {}
+                Err(IndexError::WaitFor(blocking_txn)) => {
                     drop(leaf_guard);
-                    leaf_guard = self.pool.fetch_page_mut(right)?;
+                    Self::wait_for_txn(&txn.tm, blocking_txn, txn.txn_id)?;
+                    leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
                     continue;
                 }
+                Err(e) => return Err(e),
             }
-            break;
+
+            // Set xmax to mark this version as deleted by our transaction.
+            LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmax(visible_slot, txn.txn_id);
+            return Ok(());
         }
-
-        // Find visible version.
-        let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
-        let visible_slot = self
-            .find_visible_slot(&acc, key, txn)
-            .ok_or(IndexError::KeyNotFound)?;
-
-        // Conflict check: has another in-progress txn already set xmax?
-        let rec_xmax = acc.get_xmax(visible_slot);
-        self.check_write_conflict(rec_xmax, txn)?;
-
-        // Set xmax to mark this version as deleted by our transaction.
-        LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmax(visible_slot, txn.txn_id);
-
-        Ok(())
     }
 
     /// Update `key` with `new_value`. Atomically sets xmax on the old version
@@ -364,46 +376,57 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             }
         };
 
-        // Exclusive latch + rightlink correction.
+        // Exclusive latch + rightlink correction + conflict retry loop.
         let mut leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
         loop {
+            // Rightlink correction: follow splits that happened during descent.
+            loop {
+                let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
+                if let Some(hk) = acc.high_key_bytes() {
+                    if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
+                        let right = acc.rightlink().unwrap();
+                        drop(leaf_guard);
+                        leaf_guard = self.pool.fetch_page_mut(right)?;
+                        continue;
+                    }
+                }
+                break;
+            }
+
+            // Find visible version under same exclusive latch.
             let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
-            if let Some(hk) = acc.high_key_bytes() {
-                if K::compare(key_bytes.as_ref(), hk) != Ordering::Less {
-                    let right = acc.rightlink().unwrap();
+            let visible_slot = self
+                .find_visible_slot(&acc, key, txn)
+                .ok_or(IndexError::KeyNotFound)?;
+
+            // Conflict check: if another in-progress txn holds xmax, wait for
+            // it to settle then retry — same Wait-Die protocol as insert.
+            let rec_xmax = acc.get_xmax(visible_slot);
+            match self.check_write_conflict(rec_xmax, txn) {
+                Ok(()) => {}
+                Err(IndexError::WaitFor(blocking_txn)) => {
                     drop(leaf_guard);
-                    leaf_guard = self.pool.fetch_page_mut(right)?;
+                    Self::wait_for_txn(&txn.tm, blocking_txn, txn.txn_id)?;
+                    leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
                     continue;
                 }
+                Err(e) => return Err(e),
             }
-            break;
-        }
 
-        // Find visible version under same exclusive latch.
-        let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
-        let visible_slot = self
-            .find_visible_slot(&acc, key, txn)
-            .ok_or(IndexError::KeyNotFound)?;
+            // ── ATOMIC: set xmax on old + insert new (same latch) ────────────
+            LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmax(visible_slot, txn.txn_id);
 
-        // Conflict check.
-        let rec_xmax = acc.get_xmax(visible_slot);
-        self.check_write_conflict(rec_xmax, txn)?;
+            // Find insert position for the new version.
+            let (slot, _) = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).position(key);
+            let result = LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).insert(slot, key, value);
 
-        // ── ATOMIC: set xmax on old + insert new (same latch) ────────────
-        LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmax(visible_slot, txn.txn_id);
-
-        // Find insert position for the new version.
-        let (slot, _) = LeafPageAccessor::<K, V>::new(&leaf_guard[..]).position(key);
-        let result = LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).insert(slot, key, value);
-
-        match result {
-            Ok(()) => {
-                LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmin(slot, txn.txn_id);
-                return Ok(());
-            }
-            Err(_) => {
-                return self.split_and_insert(leaf_guard, key, value, txn.txn_id, &mut stack);
-            }
+            return match result {
+                Ok(()) => {
+                    LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmin(slot, txn.txn_id);
+                    Ok(())
+                }
+                Err(_) => self.split_and_insert(leaf_guard, key, value, txn.txn_id, &mut stack),
+            };
         }
     }
 
@@ -582,7 +605,11 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         Ok(())
     }
 
-    /// First-writer-wins conflict check before setting xmax on a record.
+    /// Conflict check before setting xmax on a record.
+    ///
+    /// Returns `WaitFor(txn_id)` if another in-progress transaction has already
+    /// claimed this version — the caller must drop its latch, wait for the
+    /// blocker to settle, then retry (same pattern as insert).
     fn check_write_conflict(&self, rec_xmax: u64, txn: &Transaction) -> Result<()> {
         if rec_xmax == 0 {
             return Ok(()); // nobody has touched this version
@@ -591,8 +618,7 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             return Ok(()); // we already modified it (re-entrant)
         }
         if txn.is_in_progress(rec_xmax) {
-            // Another active txn claimed this version → first writer wins → we lose.
-            return Err(IndexError::WriteConflict);
+            return Err(IndexError::WaitFor(rec_xmax));
         }
         // The modifier committed → version is already dead.
         // Caller will get KeyNotFound since find_visible_slot won't find it.


### PR DESCRIPTION
## Summary
this PR solves 3 critical bugs introduced in the earlier commits
1. a transaction couldn't see its own inserts 
2. delete and update were following first writer wins while insert was following wait until tx is resolved. now all of them follows wait for tx to resolve sematics
3. spin_loop adds cpu overhead which had to be replaced by a condvar 

## Changes
- check_write_conflicts returns a waitFor instead of WriteConflict
- condvar instead of spin loop 
- a if statement in is_visible to for self-visibliity 

## Related Issue
Closes #

## Any design changes?
no design changes

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes