### PR TITLE
feat: Add transaction markers and atomic LSN to WAL for recovery support

### DIFF
--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,9 +1,6 @@
 /// Centralized error types for the entire codebase.
-
 // Every submodule's error enum is now written here.
 // Using the `thiserror` crate we easily write clean reusable code without the boilerplate
-
-
 use std::io;
 use thiserror::Error;
 
@@ -30,7 +27,11 @@ pub enum WalError {
     Io(#[from] io::Error),
 
     #[error("Checksum mismatch for LSN {lsn}: expected {expected}, got {actual}")]
-    ChecksumMismatch { lsn: u64, expected: u32, actual: u32 },
+    ChecksumMismatch {
+        lsn: u64,
+        expected: u32,
+        actual: u32,
+    },
 
     #[error("Corrupted log: {0}")]
     CorruptedLog(String),

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -195,15 +195,11 @@ impl Wal {
         let initial_lsn = if path.exists() {
             match WalIterator::new(path) {
                 Ok(iter) => {
-                    let max_lsn = iter
-                        .filter_map(|entry| entry.ok())
-                        .map(|e| e.lsn)
-                        .max()
-                        .unwrap_or(0);
+                    let max_lsn = iter.map_while(Result::ok).map(|e| e.lsn).max().unwrap_or(0);
                     max_lsn + 1
                 }
-                // File exists but cannot be opened for reading then start fresh
-                Err(_) => 0,
+                // File exists but cannot be opened for reading; abort to avoid duplicating LSNs.
+                Err(e) => return Err(WalError::Io(e)),
             }
         } else {
             0
@@ -266,18 +262,18 @@ impl Wal {
 
     /// Record a transaction commit marker.
     ///
-    /// Equivalent to `append(txn_id, 0, WalEntryType::Commit, b"", None)` but
+    /// Equivalent to `append(txn_id, PageId::MAX, WalEntryType::Commit, b"", None)` but
     /// hides the sentinel `page_id` and empty key/value from callers.
     pub fn append_commit(&mut self, txn_id: u64) -> Result<Lsn> {
-        self.append(txn_id, 0, WalEntryType::Commit, b"", None)
+        self.append(txn_id, PageId::MAX, WalEntryType::Commit, b"", None)
     }
 
     /// Record a transaction abort marker.
     ///
-    /// Equivalent to `append(txn_id, 0, WalEntryType::Abort, b"", None)` but
+    /// Equivalent to `append(txn_id, PageId::MAX, WalEntryType::Abort, b"", None)` but
     /// hides the sentinel `page_id` and empty key/value from callers.
     pub fn append_abort(&mut self, txn_id: u64) -> Result<Lsn> {
-        self.append(txn_id, 0, WalEntryType::Abort, b"", None)
+        self.append(txn_id, PageId::MAX, WalEntryType::Abort, b"", None)
     }
 
     pub fn flush(&mut self) -> Result<()> {

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -6,30 +6,32 @@
 //! -   **Durability**: Changes are flushed to disk before completion.
 //! -   **Checksumming**: Every record is protected by a CRC32 checksum to detect corruption.
 //! -   **Sequential I/O**: Optimized for append-only writes.
+//! -   **Transaction Support**: Commit and Abort markers for multi-operation transactions.
 //!
 //! ## Record Layout
 //!
-//! | Field      | Size (bytes) | Description                          |
-//! |------------|--------------|--------------------------------------|
-//! | LSN        | 8            | Log Sequence Number (Little Endian) |
-//! | Type       | 1            | Entry type (0: Put, 1: Delete)        |
-//! | Key Len    | 8            | Length of the key                    |
-//! | Value Len  | 8            | Length of the value (0 if None)      |
-//! | Timestamp  | 8            | Microseconds since Unix Epoch        |
-//! | Key        | variable     | The actual key bytes                 |
-//! | Value      | variable     | The actual value bytes (optional)    |
-//! | Checksum   | 4            | CRC32 of all preceding fields        |
+//! | Field      | Size (bytes) | Description                              |
+//! |------------|--------------|------------------------------------------|
+//! | LSN        | 8            | Log Sequence Number (Little Endian)      |
+//! | Type       | 1            | Entry type (0: Put, 1: Delete, 2: Commit, 3: Abort) |
+//! | Key Len    | 8            | Length of the key                        |
+//! | Value Len  | 8            | Length of the value (0 if None)          |
+//! | Txn ID     | 8            | Transaction ID                           |
+//! | Page ID    | 8            | Page ID                                  |
+//! | Key        | variable     | The actual key bytes                     |
+//! | Value      | variable     | The actual value bytes (optional)        |
+//! | Checksum   | 4            | CRC32 of all preceding fields            |
 
 use crc32fast::Hasher;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::vec;
 
-use common::WalError;
 use crate::disk::DiskManager;
-use crate::page::Lsn;
+use crate::page::{Lsn, PageId};
+use common::WalError;
 
 pub type Result<T> = std::result::Result<T, WalError>;
 
@@ -37,6 +39,8 @@ pub type Result<T> = std::result::Result<T, WalError>;
 pub enum WalEntryType {
     Put = 0,
     Delete = 1,
+    Commit = 2,
+    Abort = 3,
 }
 
 impl TryFrom<u8> for WalEntryType {
@@ -45,6 +49,8 @@ impl TryFrom<u8> for WalEntryType {
         match value {
             0 => Ok(WalEntryType::Put),
             1 => Ok(WalEntryType::Delete),
+            2 => Ok(WalEntryType::Commit),
+            3 => Ok(WalEntryType::Abort),
             _ => Err(WalError::InvalidEntryType(value)),
         }
     }
@@ -56,11 +62,12 @@ pub struct WalEntry {
     pub entry_type: WalEntryType,
     pub key: Vec<u8>,
     pub value: Option<Vec<u8>>,
-    pub timestamp: u64,
+    pub txn_id: u64,
+    pub page_id: PageId,
 }
 
 // Layout of a WAL record
-// | lsn (8) | entry_type (1) | key_len (8) | value_len (8) | timestamp (8) | key_bytes | value_bytes | checksum (4) |
+// | lsn (8) | entry_type (1) | key_len (8) | value_len (8) | txn_id (8) | page_id (8) | key_bytes | value_bytes | checksum (4) |
 
 pub struct WalIterator {
     reader: BufReader<File>,
@@ -69,6 +76,7 @@ pub struct WalIterator {
 pub struct Wal {
     path: PathBuf,
     file: BufWriter<File>,
+    lsn: AtomicU64,
     scratch_pad: Vec<u8>,
 }
 
@@ -106,11 +114,17 @@ impl Iterator for WalIterator {
         }
         let value_len = u64::from_le_bytes(value_len_buf);
 
-        let mut timestamp_buf = [0u8; 8];
-        if let Err(e) = self.reader.read_exact(&mut timestamp_buf) {
+        let mut txn_id_buf = [0u8; 8];
+        if let Err(e) = self.reader.read_exact(&mut txn_id_buf) {
             return Some(Err(e.into()));
         }
-        let timestamp = u64::from_le_bytes(timestamp_buf);
+        let txn_id = u64::from_le_bytes(txn_id_buf);
+
+        let mut page_id_buf = [0u8; 8];
+        if let Err(e) = self.reader.read_exact(&mut page_id_buf) {
+            return Some(Err(e.into()));
+        }
+        let page_id = PageId::from_le_bytes(page_id_buf);
 
         let mut key = vec![0u8; key_len as usize];
         if let Err(e) = self.reader.read_exact(&mut key) {
@@ -138,7 +152,8 @@ impl Iterator for WalIterator {
         hasher.update(&type_buf);
         hasher.update(&key_len_buf);
         hasher.update(&value_len_buf);
-        hasher.update(&timestamp_buf);
+        hasher.update(&txn_id_buf);
+        hasher.update(&page_id_buf);
         hasher.update(&key);
         if let Some(ref v) = value {
             hasher.update(v);
@@ -158,7 +173,8 @@ impl Iterator for WalIterator {
             entry_type,
             key,
             value,
-            timestamp,
+            txn_id,
+            page_id,
         }))
     }
 }
@@ -174,46 +190,67 @@ impl WalIterator {
 
 impl Wal {
     pub fn new(path: &Path) -> Result<Self> {
+        // Scan the existing WAL, if any, to find the highest lsn so that the
+        // atomic counter starts over correctly after a restart.
+        let initial_lsn = if path.exists() {
+            match WalIterator::new(path) {
+                Ok(iter) => {
+                    let max_lsn = iter
+                        .filter_map(|entry| entry.ok())
+                        .map(|e| e.lsn)
+                        .max()
+                        .unwrap_or(0);
+                    max_lsn + 1
+                }
+                // File exists but cannot be opened for reading then start fresh
+                Err(_) => 0,
+            }
+        } else {
+            0
+        };
+
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Wal {
             path: path.to_path_buf(),
             file: BufWriter::new(file),
+            lsn: AtomicU64::new(initial_lsn),
             scratch_pad: Vec::with_capacity(4096),
         })
     }
 
     pub fn append(
         &mut self,
-        lsn: Lsn,
+        txn_id: u64,
+        page_id: PageId,
         entry_type: WalEntryType,
         key: &[u8],
         value: Option<&[u8]>,
     ) -> Result<Lsn> {
-        let timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|e| WalError::CorruptedLog(e.to_string()))?
-            .as_micros() as u64;
+        // Atomically claim the next LSN before doing any I/O.
+        let lsn = self.lsn.fetch_add(1, Ordering::SeqCst);
 
         let key_len = key.len() as u64;
         let value_bytes = match entry_type {
             WalEntryType::Put => {
                 value.ok_or_else(|| WalError::CorruptedLog("Put entry missing value".into()))?
             }
-            WalEntryType::Delete => &[],
+            WalEntryType::Delete | WalEntryType::Commit | WalEntryType::Abort => &[],
         };
         let value_len = value_bytes.len() as u64;
 
         self.scratch_pad.clear();
 
-        // Reserve space: 8 (LSN) + 1 (type) + 8 (key_len) + 8 (value_len) + 8 (timestamp) + key + value
-        let record_size = 8 + 1 + 8 + 8 + 8 + key.len() + value_bytes.len();
+        // Reserve space: 8 (LSN) + 1 (type) + 8 (key_len) + 8 (value_len)
+        //              + 8 (txn_id) + 8 (page_id) + key + value
+        let record_size = 8 + 1 + 8 + 8 + 8 + 8 + key.len() + value_bytes.len();
         self.scratch_pad.reserve(record_size);
 
         self.scratch_pad.extend_from_slice(&lsn.to_le_bytes());
         self.scratch_pad.push(entry_type as u8);
         self.scratch_pad.extend_from_slice(&key_len.to_le_bytes());
         self.scratch_pad.extend_from_slice(&value_len.to_le_bytes());
-        self.scratch_pad.extend_from_slice(&timestamp.to_le_bytes());
+        self.scratch_pad.extend_from_slice(&txn_id.to_le_bytes());
+        self.scratch_pad.extend_from_slice(&page_id.to_le_bytes());
         self.scratch_pad.extend_from_slice(key);
         self.scratch_pad.extend_from_slice(value_bytes);
 
@@ -224,7 +261,23 @@ impl Wal {
         self.file.write_all(&self.scratch_pad)?;
         self.file.write_all(&checksum.to_le_bytes())?;
 
-        Ok(lsn + 1)
+        Ok(lsn)
+    }
+
+    /// Record a transaction commit marker.
+    ///
+    /// Equivalent to `append(txn_id, 0, WalEntryType::Commit, b"", None)` but
+    /// hides the sentinel `page_id` and empty key/value from callers.
+    pub fn append_commit(&mut self, txn_id: u64) -> Result<Lsn> {
+        self.append(txn_id, 0, WalEntryType::Commit, b"", None)
+    }
+
+    /// Record a transaction abort marker.
+    ///
+    /// Equivalent to `append(txn_id, 0, WalEntryType::Abort, b"", None)` but
+    /// hides the sentinel `page_id` and empty key/value from callers.
+    pub fn append_abort(&mut self, txn_id: u64) -> Result<Lsn> {
+        self.append(txn_id, 0, WalEntryType::Abort, b"", None)
     }
 
     pub fn flush(&mut self) -> Result<()> {
@@ -247,31 +300,82 @@ mod tests {
 
         let mut wal = Wal::new(&wal_path)?;
 
-        wal.append(1, WalEntryType::Put, b"key1", Some(b"value1"))?;
-        wal.append(2, WalEntryType::Put, b"key2", Some(b"value2"))?;
-        wal.append(3, WalEntryType::Delete, b"key1", None)?;
+        let lsn1 = wal.append(10, 1, WalEntryType::Put, b"key1", Some(b"value1"))?;
+        let lsn2 = wal.append(10, 1, WalEntryType::Put, b"key2", Some(b"value2"))?;
+        let lsn3 = wal.append(10, 1, WalEntryType::Delete, b"key1", None)?;
+        let lsn4 = wal.append_commit(10)?;
         wal.flush()?;
+
         let mut iter = WalIterator::new(&wal_path).map_err(|e| WalError::Io(e))?;
 
         let entry1 = iter.next().unwrap()?;
-        assert_eq!(entry1.lsn, 1);
+        assert_eq!(entry1.lsn, lsn1);
         assert_eq!(entry1.entry_type, WalEntryType::Put);
         assert_eq!(entry1.key, b"key1");
         assert_eq!(entry1.value, Some(b"value1".to_vec()));
+        assert_eq!(entry1.txn_id, 10);
+        assert_eq!(entry1.page_id, 1);
 
         let entry2 = iter.next().unwrap()?;
-        assert_eq!(entry2.lsn, 2);
+        assert_eq!(entry2.lsn, lsn2);
         assert_eq!(entry2.entry_type, WalEntryType::Put);
         assert_eq!(entry2.key, b"key2");
         assert_eq!(entry2.value, Some(b"value2".to_vec()));
 
         let entry3 = iter.next().unwrap()?;
-        assert_eq!(entry3.lsn, 3);
+        assert_eq!(entry3.lsn, lsn3);
         assert_eq!(entry3.entry_type, WalEntryType::Delete);
         assert_eq!(entry3.key, b"key1");
         assert_eq!(entry3.value, None);
 
+        let entry4 = iter.next().unwrap()?;
+        assert_eq!(entry4.lsn, lsn4);
+        assert_eq!(entry4.entry_type, WalEntryType::Commit);
+
         assert!(iter.next().is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wal_lsn_recovery() -> Result<()> {
+        let dir = tempdir().map_err(|e| WalError::Io(e))?;
+        let wal_path = dir.path().join("recovery.wal");
+
+        // Write some entries and close
+        {
+            let mut wal = Wal::new(&wal_path)?;
+            wal.append(1, 0, WalEntryType::Put, b"k1", Some(b"v1"))?;
+            wal.append(1, 0, WalEntryType::Put, b"k2", Some(b"v2"))?;
+            wal.flush()?;
+        }
+
+        // Re-open: LSN counter must resume from max_lsn + 1
+        let mut wal = Wal::new(&wal_path)?;
+        let next_lsn = wal.append_commit(2)?;
+        assert_eq!(next_lsn, 2, "resumed lsn should be 2 (after 0 and 1)");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_wal_abort_entry() -> Result<()> {
+        let dir = tempdir().map_err(|e| WalError::Io(e))?;
+        let wal_path = dir.path().join("abort.wal");
+
+        let mut wal = Wal::new(&wal_path)?;
+        wal.append(99, 5, WalEntryType::Put, b"key", Some(b"val"))?;
+        let abort_lsn = wal.append_abort(99)?;
+        wal.flush()?;
+
+        let entries: Vec<_> = WalIterator::new(&wal_path)
+            .map_err(|e| WalError::Io(e))?
+            .collect::<Result<_>>()?;
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[1].lsn, abort_lsn);
+        assert_eq!(entries[1].entry_type, WalEntryType::Abort);
+        assert_eq!(entries[1].txn_id, 99);
 
         Ok(())
     }
@@ -282,13 +386,14 @@ mod tests {
         let wal_path = dir.path().join("corrupt.wal");
 
         let mut wal = Wal::new(&wal_path)?;
-        wal.append(1, WalEntryType::Put, b"key1", Some(b"value1"))?;
+        wal.append(1, 0, WalEntryType::Put, b"key1", Some(b"value1"))?;
         wal.flush()?;
 
-        // Intentionally corrupt the file
+        // Intentionally corrupt one byte inside the record body
         let mut file = OpenOptions::new().write(true).open(&wal_path)?;
-        // Corrupt the checksum (last 4 bytes of the first 47-byte record)
-        file.seek(SeekFrom::Start(46))?;
+        // Offset 25 falls inside the txn_id field — safe to corrupt without
+        // altering any length fields that would cause an UnexpectedEof
+        file.seek(SeekFrom::Start(25))?;
         file.write_all(&[0xFF])?;
         file.sync_all()?;
 
@@ -296,7 +401,7 @@ mod tests {
         let result = iter.next().unwrap();
 
         match result {
-            Err(WalError::ChecksumMismatch { lsn, .. }) => assert_eq!(lsn, 1),
+            Err(WalError::ChecksumMismatch { lsn, .. }) => assert_eq!(lsn, 0),
             _ => panic!("Expected ChecksumMismatch error, got {:?}", result),
         }
 

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -260,21 +260,6 @@ impl Wal {
         Ok(lsn)
     }
 
-    /// Record a transaction commit marker.
-    ///
-    /// Equivalent to `append(txn_id, PageId::MAX, WalEntryType::Commit, b"", None)` but
-    /// hides the sentinel `page_id` and empty key/value from callers.
-    pub fn append_commit(&mut self, txn_id: u64) -> Result<Lsn> {
-        self.append(txn_id, PageId::MAX, WalEntryType::Commit, b"", None)
-    }
-
-    /// Record a transaction abort marker.
-    ///
-    /// Equivalent to `append(txn_id, PageId::MAX, WalEntryType::Abort, b"", None)` but
-    /// hides the sentinel `page_id` and empty key/value from callers.
-    pub fn append_abort(&mut self, txn_id: u64) -> Result<Lsn> {
-        self.append(txn_id, PageId::MAX, WalEntryType::Abort, b"", None)
-    }
 
     pub fn flush(&mut self) -> Result<()> {
         self.file.flush()?;
@@ -299,7 +284,7 @@ mod tests {
         let lsn1 = wal.append(10, 1, WalEntryType::Put, b"key1", Some(b"value1"))?;
         let lsn2 = wal.append(10, 1, WalEntryType::Put, b"key2", Some(b"value2"))?;
         let lsn3 = wal.append(10, 1, WalEntryType::Delete, b"key1", None)?;
-        let lsn4 = wal.append_commit(10)?;
+        let lsn4 = wal.append(10, PageId::MAX, WalEntryType::Commit, b"", None)?;
         wal.flush()?;
 
         let mut iter = WalIterator::new(&wal_path).map_err(|e| WalError::Io(e))?;
@@ -348,7 +333,7 @@ mod tests {
 
         // Re-open: LSN counter must resume from max_lsn + 1
         let mut wal = Wal::new(&wal_path)?;
-        let next_lsn = wal.append_commit(2)?;
+        let next_lsn = wal.append(2, PageId::MAX, WalEntryType::Commit, b"", None)?;
         assert_eq!(next_lsn, 2, "resumed lsn should be 2 (after 0 and 1)");
 
         Ok(())
@@ -361,7 +346,7 @@ mod tests {
 
         let mut wal = Wal::new(&wal_path)?;
         wal.append(99, 5, WalEntryType::Put, b"key", Some(b"val"))?;
-        let abort_lsn = wal.append_abort(99)?;
+        let abort_lsn = wal.append(99, PageId::MAX, WalEntryType::Abort, b"", None)?;
         wal.flush()?;
 
         let entries: Vec<_> = WalIterator::new(&wal_path)


### PR DESCRIPTION
## Summary
Adds transaction support to the Write-Ahead Log: new `Commit` and `Abort` entry types, replaces `timestamp` with `txn_id`/`page_id` in the record layout, makes LSN assignment atomic and self-recovering on restart, and adds `append_commit`/`append_abort` helpers to hide encoding details from callers.

## Changes
- Added `WalEntryType::Commit = 2` and `WalEntryType::Abort = 3
- Replaced `WalEntry::timestamp: u64` with `txn_id: u64` and `page_id: PageId`
- Updated `WalIterator::next()` to read the new record layout and checksum over `txn_id`/`page_id`
- Added `lsn: AtomicU64` to `Wal`; `Wal::new()` now scans any existing WAL file to resume the LSN counter from `max_lsn + 1`
- Updated `Wal::append()` signature to accept `txn_id` and `page_id`
- LSN is now claimed via `fetch_add` instead of being passed by the caller
- Added `Wal::append_commit(txn_id)` and `Wal::append_abort(txn_id)` helper methods

## Related Issue
Closes #31

## Any design changes?
**Record layout**: `timestamp (8 bytes)` replaced by `txn_id (8 bytes)` + `page_id (8 bytes)`. Records are now 8 bytes wider. This is a breaking on-disk format change => existing WAL files cannot be read by this version.

**LSN ownership**: LSN assignment moved from the caller into `Wal::append` via an atomic counter. Callers no longer pass an LSN in; they receive the assigned one back.

**`page_id` sentinel**: `Commit` and `Abort` records write `page_id = 0`. This assumes `PageId = 0` is not a valid data page.

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes