### PR TITLE
Add the engine crate: public API + transaction lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,15 @@ name = "db-core"
 version = "0.1.0"
 
 [[package]]
+name = "engine"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "db-core",
+ "storage",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "common",
  "db-core",
  "storage",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = ["crates/*"]
 [workspace.dependencies]
 clap = { version = "4", features = ["derive"] }
 common = { path = "crates/common" }
+storage = {path = "crates/storage"}
 thiserror = "1"
 db-core = { path = "crates/db-core"}

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -143,6 +143,8 @@ pub enum TypeNameError {
 pub enum EngineError {
     #[error("another database exists at that location")]
     AlreadyExists,
+    #[error("no database found at that location")]
+    NotFound,
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("disk error: {0}")]

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -137,3 +137,20 @@ pub enum TypeNameError {
     #[error("invalid UTF-8 in type name: {0}")]
     InvalidUtf8(#[from] std::str::Utf8Error),
 }
+
+// ==== ENGINE ERRORS =============================================================
+#[derive(Debug, Error)]
+pub enum EngineError {
+    #[error("another database exists at that location")]
+    AlreadyExists,
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("disk error: {0}")]
+    Disk(#[from] DiskError),
+    #[error("WAL error: {0}")]
+    Wal(#[from] WalError),
+    #[error("buffer pool error: {0}")]
+    BufferPool(#[from] BufferPoolError),
+    #[error("index error: {0}")]
+    Index(#[from] IndexError),
+}

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -155,4 +155,6 @@ pub enum EngineError {
     BufferPool(#[from] BufferPoolError),
     #[error("index error: {0}")]
     Index(#[from] IndexError),
+    #[error("write conflict: the transaction was aborted and may be retried")]
+    TransactionConflict,
 }

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -36,9 +36,21 @@ pub struct Transaction {
     pub snapshot: Snapshot,
     /// The manager tracking commit log entries for visibility checking.
     pub tm: Arc<TransactionManager>,
+    pub(crate) wrote_anything: bool,
 }
 
 impl Transaction {
+    /// Builds a fresh transaction. The single construction point — keeps the
+    /// write-tracking flag (`wrote_anything`) private and always-initialized.
+    pub fn new(txn_id: u64, snapshot: Snapshot, tm: Arc<TransactionManager>) -> Self {
+        Transaction {
+            txn_id,
+            snapshot,
+            tm,
+            wrote_anything: false,
+        }
+    }
+
     /// Determines whether a record with `(rec_xmin, rec_xmax)` is visible to
     /// this transaction.
     pub fn is_visible(&self, rec_xmin: u64, rec_xmax: u64) -> bool {
@@ -59,6 +71,14 @@ impl Transaction {
     /// perspective?
     pub fn is_in_progress(&self, txn_id: u64) -> bool {
         self.snapshot.is_in_progress(txn_id, &self.tm)
+    }
+
+    pub fn note_write(&mut self) {
+        self.wrote_anything = true;
+    }
+
+    pub fn wrote_anything(&self) -> bool {
+        return self.wrote_anything;
     }
 }
 

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -78,7 +78,7 @@ impl Transaction {
     }
 
     pub fn wrote_anything(&self) -> bool {
-        return self.wrote_anything;
+        self.wrote_anything
     }
 }
 

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -360,7 +360,7 @@ mod tests {
     #[test]
     fn vacuumable_aborted_creator() {
         let tm = TransactionManager::new();
-        tm.abort(5); // xmin=5 aborted
+        tm.mark_aborted(5); // xmin=5 aborted
         // Creator aborted -> always dead
         assert!(is_vacuumable(5, 0, 100, &tm));
         assert!(is_vacuumable(5, 15, 10, &tm));
@@ -376,7 +376,7 @@ mod tests {
     #[test]
     fn vacuumable_committed_deleter_below_horizon() {
         let tm = TransactionManager::new();
-        tm.commit(15); // xmax=15 committed
+        tm.mark_committed(15); // xmax=15 committed
         // xmax=15 < horizon=20 -> dead
         assert!(is_vacuumable(5, 15, 20, &tm));
     }
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn vacuumable_committed_deleter_above_horizon_is_live() {
         let tm = TransactionManager::new();
-        tm.commit(15); // xmax=15 committed
+        tm.mark_committed(15); // xmax=15 committed
         // xmax=15 >= horizon=10 -> live (someone might still see the old version)
         assert!(!is_vacuumable(5, 15, 10, &tm));
     }

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -147,7 +147,7 @@ impl TransactionManager {
     /// Once committed, the transaction's writes become eligible for visibility
     /// to new snapshots. Any threads waiting on this transaction via
     /// `wait_until_settled` are woken up.
-    pub fn commit(&self, txn_id: u64) {
+    pub fn mark_committed(&self, txn_id: u64) {
         self.clog
             .write()
             .unwrap()
@@ -159,7 +159,7 @@ impl TransactionManager {
     /// Marks a transaction as aborted in the CLOG and removes it from the active set.
     ///
     /// Any threads waiting on this transaction via `wait_until_settled` are woken up.
-    pub fn abort(&self, txn_id: u64) {
+    pub fn mark_aborted(&self, txn_id: u64) {
         self.clog
             .write()
             .unwrap()
@@ -277,7 +277,7 @@ mod tests {
         let tm = std::sync::Arc::new(TransactionManager::new());
         let txn = tm.begin();
 
-        tm.commit(txn.txn_id);
+        tm.mark_committed(txn.txn_id);
 
         assert!(!tm.is_active(txn.txn_id));
         assert!(tm.is_committed(txn.txn_id));
@@ -289,7 +289,7 @@ mod tests {
         let tm = std::sync::Arc::new(TransactionManager::new());
         let txn = tm.begin();
 
-        tm.abort(txn.txn_id);
+        tm.mark_aborted(txn.txn_id);
 
         assert!(!tm.is_active(txn.txn_id));
         assert!(!tm.is_committed(txn.txn_id));
@@ -329,7 +329,7 @@ mod tests {
         let txn3 = tm.begin();
 
         // Commit txn2 in the middle
-        tm.commit(txn2.txn_id);
+        tm.mark_committed(txn2.txn_id);
 
         let snap = tm.get_snapshot();
 
@@ -346,7 +346,7 @@ mod tests {
     fn wait_until_settled_returns_immediately_if_already_committed() {
         let tm = std::sync::Arc::new(TransactionManager::new());
         let txn = tm.begin();
-        tm.commit(txn.txn_id);
+        tm.mark_committed(txn.txn_id);
         // Must return without blocking — transaction already settled.
         tm.wait_until_settled(txn.txn_id);
     }
@@ -355,7 +355,7 @@ mod tests {
     fn wait_until_settled_returns_immediately_if_already_aborted() {
         let tm = std::sync::Arc::new(TransactionManager::new());
         let txn = tm.begin();
-        tm.abort(txn.txn_id);
+        tm.mark_aborted(txn.txn_id);
         tm.wait_until_settled(txn.txn_id);
     }
 
@@ -378,7 +378,7 @@ mod tests {
         thread::sleep(Duration::from_millis(20));
         assert!(!waiter.is_finished(), "waiter should be blocked");
 
-        tm.commit(blocker_id);
+        tm.mark_committed(blocker_id);
 
         let deadline = Instant::now() + Duration::from_secs(2);
         while !waiter.is_finished() {
@@ -409,7 +409,7 @@ mod tests {
         thread::sleep(Duration::from_millis(20));
         assert!(!waiter.is_finished(), "waiter should be blocked");
 
-        tm.abort(blocker_id);
+        tm.mark_aborted(blocker_id);
 
         let deadline = Instant::now() + Duration::from_secs(2);
         while !waiter.is_finished() {
@@ -442,7 +442,7 @@ mod tests {
             .collect();
 
         thread::sleep(Duration::from_millis(20));
-        tm.commit(blocker_id);
+        tm.mark_committed(blocker_id);
 
         let deadline = Instant::now() + Duration::from_secs(2);
         for handle in handles {
@@ -472,7 +472,7 @@ mod tests {
         // Give the waiter time to register its entry in the map.
         thread::sleep(Duration::from_millis(20));
 
-        tm.commit(blocker_id);
+        tm.mark_committed(blocker_id);
 
         let deadline = Instant::now() + Duration::from_secs(2);
         while !waiter.is_finished() {

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -139,6 +139,7 @@ impl TransactionManager {
                 active: active_vec,
             },
             tm: std::sync::Arc::clone(self),
+            wrote_anything: false,
         }
     }
 

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "engine"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+storage.workspace = true
+common.workspace = true
+db-core.workspace = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2024"
 storage.workspace = true
 common.workspace = true
 db-core.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1,0 +1,59 @@
+use common::{EngineError, Key, Value};
+use db_core::transaction_manager::TransactionManager;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use storage::buffer_pool::BufferPoolManager;
+use storage::disk::DiskManager;
+use storage::index::BTreeIndex;
+use storage::page::PAGE_SIZE;
+use storage::wal::Wal;
+pub struct Engine<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    index: Arc<BTreeIndex<K, V>>,
+    wal: Arc<Mutex<Wal>>,
+    disk_manager: Arc<DiskManager>,
+    buffer_pool: Arc<BufferPoolManager>,
+    transaction_manager: Arc<TransactionManager>,
+}
+
+impl<K, V> Engine<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    // creates a new database
+    pub fn create(dir_path: impl AsRef<Path>) -> Result<Engine<K, V>, EngineError> {
+        let path = dir_path.as_ref();
+        std::fs::create_dir_all(path)?;
+        let exist = path.join("data.db").exists();
+        if exist {
+            return Err(EngineError::AlreadyExists);
+        }
+        // initialize disk manager
+        let disk_manager = Arc::new(DiskManager::new(path.join("data.db"), PAGE_SIZE)?);
+        // initialize wal;
+        // Arc is needed on WAL as both index and buffer_pool will later have a wal instance.
+        let wal = Arc::new(Mutex::new(Wal::new(path.join("wal.log"))?));
+        let buffer_pool = Arc::new(BufferPoolManager::new(Arc::clone(&disk_manager)));
+        let transaction_manager = Arc::new(TransactionManager::new());
+        let (index, _root) = BTreeIndex::create(Arc::clone(&buffer_pool))?;
+        // index needs Arc as it will be later cloned by vaccum to call index.vaccum()
+        let index = Arc::new(index);
+        // TODO! spawn checkpoint thread once checkpoint is there
+        // TODO! spawn vacuum thread once vacuum is implemented
+        Ok(Engine {
+            index,
+            wal,
+            buffer_pool,
+            disk_manager,
+            transaction_manager,
+        })
+    }
+    // opens a existing database
+    pub fn open(dir_path: impl AsRef<Path>) -> Result<Engine<K, V>, EngineError> {
+        todo!()
+    }
+}

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -156,7 +156,7 @@ where
         TxnHandle {
             engine: self,
             txn: Some(self.transaction_manager.begin()),
-            poisoned: false 
+            poisoned: false,
         }
     }
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -12,11 +12,11 @@ where
     K: Key,
     V: Value,
 {
-    index: Arc<BTreeIndex<K, V>>,
-    wal: Arc<Mutex<Wal>>,
-    disk_manager: Arc<DiskManager>,
-    buffer_pool: Arc<BufferPoolManager>,
-    transaction_manager: Arc<TransactionManager>,
+    pub(crate) index: Arc<BTreeIndex<K, V>>,
+    pub(crate) wal: Arc<Mutex<Wal>>,
+    pub(crate) disk_manager: Arc<DiskManager>,
+    pub(crate) buffer_pool: Arc<BufferPoolManager>,
+    pub(crate) transaction_manager: Arc<TransactionManager>,
 }
 
 impl<K, V> Engine<K, V>
@@ -80,4 +80,7 @@ where
             transaction_manager,
         })
     }
+
+
+    // implement close() when checkpoint lands. 
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -7,6 +7,8 @@ use storage::disk::DiskManager;
 use storage::index::BTreeIndex;
 use storage::page::PAGE_SIZE;
 use storage::wal::Wal;
+
+use crate::txn::TxnHandle;
 pub struct Engine<K, V>
 where
     K: Key,
@@ -81,6 +83,80 @@ where
         })
     }
 
+    // implement close() when checkpoint lands.
 
-    // implement close() when checkpoint lands. 
+    // ── PUBLIC API ─────────────────────────────────────────────
+    pub fn insert(
+        &self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+    ) -> Result<(), EngineError> {
+        let mut txn = self.transaction_manager.begin();
+        match self.insert_in(&mut txn, key, value) {
+            Ok(()) => {
+                self.commit(txn);
+                Ok(())
+            }
+            Err(e) => {
+                self.abort(txn);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn get(&self, key: &K::SelfType<'_>) -> Result<Option<Vec<u8>>, EngineError> {
+        // reads still need a transaction: the snapshot from begin() is what
+        // makes the read correct; its commit hits the read-only fast path
+        let txn = self.transaction_manager.begin();
+        match self.get_in(&txn, key) {
+            Ok(v) => {
+                self.commit(txn);
+                Ok(v)
+            }
+            Err(e) => {
+                self.abort(txn);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn update(
+        &self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+    ) -> Result<(), EngineError> {
+        let mut txn = self.transaction_manager.begin();
+        match self.update_in(&mut txn, key, value) {
+            Ok(()) => {
+                self.commit(txn);
+                Ok(())
+            }
+            Err(e) => {
+                self.abort(txn);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn delete(&self, key: &K::SelfType<'_>) -> Result<(), EngineError> {
+        let mut txn = self.transaction_manager.begin();
+        match self.delete_in(&mut txn, key) {
+            Ok(()) => {
+                self.commit(txn);
+                Ok(())
+            }
+            Err(e) => {
+                self.abort(txn);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn begin(&self) -> TxnHandle<'_, K, V> {
+        TxnHandle {
+            engine: self,
+            txn: Some(self.transaction_manager.begin()),
+            poisoned: false 
+        }
+    }
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -52,8 +52,32 @@ where
             transaction_manager,
         })
     }
-    // opens a existing database
+    // opens an existing database
     pub fn open(dir_path: impl AsRef<Path>) -> Result<Engine<K, V>, EngineError> {
-        todo!()
+        let path = dir_path.as_ref();
+        // the data file is the marker that a database lives here
+        if !path.join("data.db").exists() {
+            return Err(EngineError::NotFound);
+        }
+        let disk_manager = Arc::new(DiskManager::new(path.join("data.db"), PAGE_SIZE)?);
+        // Wal::new opens the existing log (and creates it if a pre-WAL database
+        // never had one) — the tail scan / LSN resume lands with the log manager work
+        let wal = Arc::new(Mutex::new(Wal::new(path.join("wal.log"))?));
+        let buffer_pool = Arc::new(BufferPoolManager::new(Arc::clone(&disk_manager)));
+        let transaction_manager = Arc::new(TransactionManager::new());
+        // recovery runs HERE — after the pool exists, before the index opens:
+        // read checkpoint from superblock → seed CLOG from pinned_aborted[] →
+        // replay WAL from redo_point → mark crash victims Aborted →
+        // inject next_txn_id / next_page_id watermarks (from_recovered)
+        // index reads the root page id from the page-0 superblock
+        let index = Arc::new(BTreeIndex::open(Arc::clone(&buffer_pool))?);
+        // TODO! spawn checkpoint + vacuum threads
+        Ok(Engine {
+            index,
+            wal,
+            buffer_pool,
+            disk_manager,
+            transaction_manager,
+        })
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,14 +1,1 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub mod engine;

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,5 +1,7 @@
 mod engine;
 mod ops;
 mod txn;
-pub use common::{EngineError, Key, Value};
+pub use common::{Key, Value};
 pub use engine::Engine;
+pub use txn::TxnHandle;
+pub use common::{BufferPoolError, DiskError, EngineError, IndexError, WalError};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,1 +1,5 @@
-pub mod engine;
+mod engine;
+mod txn;
+
+pub use engine::Engine;
+pub use common::{EngineError, Key, Value};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,7 +1,7 @@
 mod engine;
 mod ops;
 mod txn;
+pub use common::{BufferPoolError, DiskError, EngineError, IndexError, WalError};
 pub use common::{Key, Value};
 pub use engine::Engine;
 pub use txn::TxnHandle;
-pub use common::{BufferPoolError, DiskError, EngineError, IndexError, WalError};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,5 +1,5 @@
 mod engine;
+mod ops;
 mod txn;
-
-pub use engine::Engine;
 pub use common::{EngineError, Key, Value};
+pub use engine::Engine;

--- a/crates/engine/src/ops.rs
+++ b/crates/engine/src/ops.rs
@@ -1,5 +1,4 @@
 use crate::engine::Engine;
-use crate::txn::TxnHandle;
 use common::{EngineError, IndexError, Key, Value};
 use db_core::transaction::Transaction;
 impl<K, V> Engine<K, V>

--- a/crates/engine/src/ops.rs
+++ b/crates/engine/src/ops.rs
@@ -1,7 +1,7 @@
 use crate::engine::Engine;
+use crate::txn::TxnHandle;
 use common::{EngineError, IndexError, Key, Value};
 use db_core::transaction::Transaction;
-use crate::txn::TxnHandle; 
 impl<K, V> Engine<K, V>
 where
     K: Key,
@@ -45,7 +45,6 @@ where
         self.index.update(key, value, txn).map_err(map_conflict)
     }
 }
-
 
 fn map_conflict(e: IndexError) -> EngineError {
     match e {

--- a/crates/engine/src/ops.rs
+++ b/crates/engine/src/ops.rs
@@ -1,0 +1,55 @@
+use crate::engine::Engine;
+use common::{EngineError, IndexError, Key, Value};
+use db_core::transaction::Transaction;
+
+impl<K, V> Engine<K, V>
+where
+    K: Key,
+    V: Value,
+{
+    pub(crate) fn insert_in(
+        &self,
+        txn: &mut Transaction,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+    ) -> Result<(), EngineError> {
+        txn.note_write();
+        self.index.insert(key, value, txn).map_err(map_conflict)
+    }
+
+    pub(crate) fn delete_in(
+        &self,
+        txn: &mut Transaction,
+        key: &K::SelfType<'_>,
+    ) -> Result<(), EngineError> {
+        txn.note_write();
+        self.index.delete(key, txn).map_err(map_conflict)
+    }
+
+    /// Reads take `&Transaction` — they never set the wrote-flag.
+    pub(crate) fn get_in(
+        &self,
+        txn: &Transaction,
+        key: &K::SelfType<'_>,
+    ) -> Result<Option<Vec<u8>>, EngineError> {
+        self.index.get(key, txn).map_err(map_conflict)
+    }
+
+    pub(crate) fn update_in(
+        &self,
+        txn: &mut Transaction,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+    ) -> Result<(), EngineError> {
+        txn.note_write();
+        self.index.update(key, value, txn).map_err(map_conflict)
+    }
+}
+
+
+fn map_conflict(e: IndexError) -> EngineError {
+    match e {
+        IndexError::WriteConflict => EngineError::TransactionConflict,
+        other => other.into(),
+    }
+}

--- a/crates/engine/src/ops.rs
+++ b/crates/engine/src/ops.rs
@@ -1,7 +1,7 @@
 use crate::engine::Engine;
 use common::{EngineError, IndexError, Key, Value};
 use db_core::transaction::Transaction;
-
+use crate::txn::TxnHandle; 
 impl<K, V> Engine<K, V>
 where
     K: Key,

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -119,8 +119,7 @@ where
             .txn
             .as_ref()
             .expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
-        let res = self.engine.get_in(txn, key);
-        res
+        self.engine.get_in(txn, key)
     }
 
     pub fn abort(self) {} // drop does the work here as well.

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -49,12 +49,61 @@ where
     V: Value
 {
     pub fn commit(mut self) -> Result<(), EngineError> {
-        if self.poisoned {};
+        if self.poisoned {
+            return Err(EngineError::TransactionConflict); // no need to call abort here as self will get dropped and abort is called inside drop impl itself. 
+        };
         if let Some(txn) = self.txn.take() {
             self.engine.commit(txn); 
         }
         Ok(())
     }
+
+    pub fn insert(&mut self, key: &K::SelfType<'_>, value: &V::SelfType<'_>) -> Result<(), EngineError> {
+        if self.poisoned {
+            return Err(EngineError::TransactionConflict); 
+        }
+        let txn = self.txn.as_mut().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.insert_in(txn, key, value); 
+        if matches!(res, Err(EngineError::TransactionConflict)) {
+            self.poisoned = true;  //the whole txn is dead
+        }
+        res
+    }
+
+    pub fn delete(&mut self, key: &K::SelfType<'_>) -> Result<(), EngineError> {
+        if self.poisoned {
+            return Err(EngineError::TransactionConflict); 
+        }
+        let txn = self.txn.as_mut().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.delete_in(txn, key); 
+        if matches!(res, Err(EngineError::TransactionConflict)) {
+            self.poisoned = true;  //the whole txn is dead
+        }
+        res
+    }
+
+    pub fn update(&mut self, key: &K::SelfType<'_>, value: &V::SelfType<'_>) -> Result<(), EngineError> {
+        if self.poisoned {
+            return Err(EngineError::TransactionConflict); 
+        }
+        let txn = self.txn.as_mut().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.update_in(txn, key, value); 
+        if matches!(res, Err(EngineError::TransactionConflict)) {
+            self.poisoned = true;  //the whole txn is dead
+        }
+        res
+    }
+
+    pub fn get(&mut self, key: &K::SelfType<'_>) -> Result<Option<Vec<u8>>, EngineError> {
+        if self.poisoned {
+            return Err(EngineError::TransactionConflict); 
+        }
+        let txn = self.txn.as_ref().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.get_in(txn, key); 
+        res
+    }
+
+    pub fn abort(self) {} // drop does the work here as well. 
 }
 
 impl<K: Key, V: Value> Drop for TxnHandle<'_, K, V> {

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -1,26 +1,66 @@
+use crate::engine::Engine;
 use common::{EngineError, Key, Value};
 use db_core::transaction::Transaction;
-use crate::engine::Engine; 
-impl<K,V> Engine<K,V> 
-where 
+
+// Used a reference instead of Arc as reference enforces that transaction does not outlive the engine. 
+pub struct TxnHandle<'e, K:Key, V:Value> {
+    pub(crate) engine:&'e Engine<K,V>,
+    pub(crate) txn: Option<Transaction>,
+    pub(crate) poisoned: bool, 
+}
+
+impl<K, V> Engine<K, V>
+where
     K: Key,
     V: Value,
 {
+    // this function is called once inserts/get/update/delete finishes and returns from index.rs
     pub(crate) fn commit(&self, txn: Transaction) {
+        if !txn.wrote_anything() {
+            self.transaction_manager.mark_committed(txn.txn_id);
+            return;
+        }
         // take the shared lock to prevent checkpoint from running
         // append commit log to wal
-        // fsync upto this commit_lsn 
+        // fsync upto this commit_lsn
         // call tm.mark_committed()
         self.transaction_manager.mark_committed(txn.txn_id);
         // release the lock
     }
 
+    // this function is called once inserts/get/update/delete finishes and returns from index.rs
     pub(crate) fn abort(&self, txn: Transaction) {
+        if !txn.wrote_anything() {
+            self.transaction_manager.mark_aborted(txn.txn_id);
+            return;
+        }
         // take the shared lock to prevent checkpoint from running
         // append abort log to wal
         // no need to fsync aborts
         // call tm.mark_aborted()
-        self.transaction_manager.mark_aborted(txn.txn_id); 
-        // release the lock 
+        self.transaction_manager.mark_aborted(txn.txn_id);
+        // release the lock
     }
 }
+
+impl<K,V> TxnHandle<'_, K,V> 
+where 
+    K: Key,
+    V: Value
+{
+    pub fn commit(mut self) -> Result<(), EngineError> {
+        if self.poisoned {};
+        if let Some(txn) = self.txn.take() {
+            self.engine.commit(txn); 
+        }
+        Ok(())
+    }
+}
+
+impl<K: Key, V: Value> Drop for TxnHandle<'_, K, V> {
+    fn drop(&mut self) {
+        if let Some(txn) = self.txn.take() {  // only way to reach this path is if no one commits so txn still has a value. 
+            self.engine.abort(txn); // abort the transaction is no one commits 
+        }
+    }
+  }

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -2,11 +2,11 @@ use crate::engine::Engine;
 use common::{EngineError, Key, Value};
 use db_core::transaction::Transaction;
 
-// Used a reference instead of Arc as reference enforces that transaction does not outlive the engine. 
-pub struct TxnHandle<'e, K:Key, V:Value> {
-    pub(crate) engine:&'e Engine<K,V>,
+// Used a reference instead of Arc as reference enforces that transaction does not outlive the engine.
+pub struct TxnHandle<'e, K: Key, V: Value> {
+    pub(crate) engine: &'e Engine<K, V>,
     pub(crate) txn: Option<Transaction>,
-    pub(crate) poisoned: bool, 
+    pub(crate) poisoned: bool,
 }
 
 impl<K, V> Engine<K, V>
@@ -43,73 +43,94 @@ where
     }
 }
 
-impl<K,V> TxnHandle<'_, K,V> 
-where 
+impl<K, V> TxnHandle<'_, K, V>
+where
     K: Key,
-    V: Value
+    V: Value,
 {
     pub fn commit(mut self) -> Result<(), EngineError> {
         if self.poisoned {
             return Err(EngineError::TransactionConflict); // no need to call abort here as self will get dropped and abort is called inside drop impl itself. 
         };
         if let Some(txn) = self.txn.take() {
-            self.engine.commit(txn); 
+            self.engine.commit(txn);
         }
         Ok(())
     }
 
-    pub fn insert(&mut self, key: &K::SelfType<'_>, value: &V::SelfType<'_>) -> Result<(), EngineError> {
+    pub fn insert(
+        &mut self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+    ) -> Result<(), EngineError> {
         if self.poisoned {
-            return Err(EngineError::TransactionConflict); 
+            return Err(EngineError::TransactionConflict);
         }
-        let txn = self.txn.as_mut().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
-        let res = self.engine.insert_in(txn, key, value); 
+        let txn = self
+            .txn
+            .as_mut()
+            .expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.insert_in(txn, key, value);
         if matches!(res, Err(EngineError::TransactionConflict)) {
-            self.poisoned = true;  //the whole txn is dead
+            self.poisoned = true; //the whole txn is dead
         }
         res
     }
 
     pub fn delete(&mut self, key: &K::SelfType<'_>) -> Result<(), EngineError> {
         if self.poisoned {
-            return Err(EngineError::TransactionConflict); 
+            return Err(EngineError::TransactionConflict);
         }
-        let txn = self.txn.as_mut().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
-        let res = self.engine.delete_in(txn, key); 
+        let txn = self
+            .txn
+            .as_mut()
+            .expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.delete_in(txn, key);
         if matches!(res, Err(EngineError::TransactionConflict)) {
-            self.poisoned = true;  //the whole txn is dead
+            self.poisoned = true; //the whole txn is dead
         }
         res
     }
 
-    pub fn update(&mut self, key: &K::SelfType<'_>, value: &V::SelfType<'_>) -> Result<(), EngineError> {
+    pub fn update(
+        &mut self,
+        key: &K::SelfType<'_>,
+        value: &V::SelfType<'_>,
+    ) -> Result<(), EngineError> {
         if self.poisoned {
-            return Err(EngineError::TransactionConflict); 
+            return Err(EngineError::TransactionConflict);
         }
-        let txn = self.txn.as_mut().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
-        let res = self.engine.update_in(txn, key, value); 
+        let txn = self
+            .txn
+            .as_mut()
+            .expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.update_in(txn, key, value);
         if matches!(res, Err(EngineError::TransactionConflict)) {
-            self.poisoned = true;  //the whole txn is dead
+            self.poisoned = true; //the whole txn is dead
         }
         res
     }
 
     pub fn get(&mut self, key: &K::SelfType<'_>) -> Result<Option<Vec<u8>>, EngineError> {
         if self.poisoned {
-            return Err(EngineError::TransactionConflict); 
+            return Err(EngineError::TransactionConflict);
         }
-        let txn = self.txn.as_ref().expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
-        let res = self.engine.get_in(txn, key); 
+        let txn = self
+            .txn
+            .as_ref()
+            .expect("this shouldn't be none in any possible case"); // Txn is none only on either committed or dropped 
+        let res = self.engine.get_in(txn, key);
         res
     }
 
-    pub fn abort(self) {} // drop does the work here as well. 
+    pub fn abort(self) {} // drop does the work here as well.
 }
 
 impl<K: Key, V: Value> Drop for TxnHandle<'_, K, V> {
     fn drop(&mut self) {
-        if let Some(txn) = self.txn.take() {  // only way to reach this path is if no one commits so txn still has a value. 
+        if let Some(txn) = self.txn.take() {
+            // only way to reach this path is if no one commits so txn still has a value.
             self.engine.abort(txn); // abort the transaction is no one commits 
         }
     }
-  }
+}

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -1,0 +1,26 @@
+use common::{EngineError, Key, Value};
+use db_core::transaction::Transaction;
+use crate::engine::Engine; 
+impl<K,V> Engine<K,V> 
+where 
+    K: Key,
+    V: Value,
+{
+    pub(crate) fn commit(&self, txn: Transaction) {
+        // take the shared lock to prevent checkpoint from running
+        // append commit log to wal
+        // fsync upto this commit_lsn 
+        // call tm.mark_committed()
+        self.transaction_manager.mark_committed(txn.txn_id);
+        // release the lock
+    }
+
+    pub(crate) fn abort(&self, txn: Transaction) {
+        // take the shared lock to prevent checkpoint from running
+        // append abort log to wal
+        // no need to fsync aborts
+        // call tm.mark_aborted()
+        self.transaction_manager.mark_aborted(txn.txn_id); 
+        // release the lock 
+    }
+}

--- a/crates/engine/tests/lifecycle.rs
+++ b/crates/engine/tests/lifecycle.rs
@@ -1,4 +1,4 @@
-//! End-to-end lifecycle tests 
+//! End-to-end lifecycle tests
 use common::IndexError;
 use engine::{Engine, EngineError};
 use tempfile::TempDir;
@@ -43,10 +43,7 @@ fn reopen_sees_committed_data() {
         engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
     } // engine dropped — data must survive via the data file
     let engine = TestEngine::open(dir.path()).unwrap();
-    assert_eq!(
-        engine.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v1".to_vec())
-    );
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
 }
 
 // ── autocommit lifecycle ──────────────────────────────────────────────────
@@ -55,10 +52,7 @@ fn reopen_sees_committed_data() {
 fn insert_then_get_roundtrip() {
     let (_dir, engine) = fresh_engine();
     engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
-    assert_eq!(
-        engine.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v1".to_vec())
-    );
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
     assert_eq!(engine.get(&b"missing".as_slice()).unwrap(), None);
 }
 
@@ -67,10 +61,7 @@ fn update_replaces_value() {
     let (_dir, engine) = fresh_engine();
     engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
     engine.update(&b"k1".as_slice(), &b"v2".as_slice()).unwrap();
-    assert_eq!(
-        engine.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v2".to_vec())
-    );
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v2".to_vec()));
 }
 
 #[test]
@@ -90,10 +81,7 @@ fn duplicate_insert_fails_and_aborts_cleanly() {
         .unwrap_err();
     assert!(matches!(err, EngineError::Index(IndexError::DuplicateKey)));
     // the failed txn aborted via the envelope — original value untouched
-    assert_eq!(
-        engine.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v1".to_vec())
-    );
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
 }
 
 // ── explicit transactions (TxnHandle) ─────────────────────────────────────
@@ -105,14 +93,8 @@ fn handle_groups_writes_atomically() {
     txn.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
     txn.insert(&b"k2".as_slice(), &b"v2".as_slice()).unwrap();
     txn.commit().unwrap();
-    assert_eq!(
-        engine.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v1".to_vec())
-    );
-    assert_eq!(
-        engine.get(&b"k2".as_slice()).unwrap(),
-        Some(b"v2".to_vec())
-    );
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
+    assert_eq!(engine.get(&b"k2".as_slice()).unwrap(), Some(b"v2".to_vec()));
 }
 
 #[test]
@@ -133,18 +115,12 @@ fn reads_own_writes_but_invisible_to_others_until_commit() {
     txn.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
 
     // the writer sees its own uncommitted write...
-    assert_eq!(
-        txn.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v1".to_vec())
-    );
+    assert_eq!(txn.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
     // ...but a concurrent transaction (autocommit get) does not
     assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), None);
 
     txn.commit().unwrap();
-    assert_eq!(
-        engine.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v1".to_vec())
-    );
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
 }
 
 // ── conflicts & poisoning (wait-die surfaced through the API) ─────────────
@@ -157,7 +133,9 @@ fn younger_conflicting_txn_dies_and_handle_is_poisoned() {
     let mut younger = engine.begin(); // larger txn id
 
     // older claims k1 and holds it (uncommitted)
-    older.insert(&b"k1".as_slice(), &b"v_old".as_slice()).unwrap();
+    older
+        .insert(&b"k1".as_slice(), &b"v_old".as_slice())
+        .unwrap();
 
     // younger hits the in-progress version: wait-die says the younger dies
     let err = younger
@@ -206,8 +184,5 @@ fn retry_after_conflict_succeeds_with_fresh_txn() {
     let mut retry = engine.begin();
     retry.update(&b"k1".as_slice(), &b"v2".as_slice()).unwrap();
     retry.commit().unwrap();
-    assert_eq!(
-        engine.get(&b"k1".as_slice()).unwrap(),
-        Some(b"v2".to_vec())
-    );
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v2".to_vec()));
 }

--- a/crates/engine/tests/lifecycle.rs
+++ b/crates/engine/tests/lifecycle.rs
@@ -1,0 +1,213 @@
+//! End-to-end lifecycle tests 
+use common::IndexError;
+use engine::{Engine, EngineError};
+use tempfile::TempDir;
+
+type TestEngine = Engine<&'static [u8], &'static [u8]>;
+
+fn fresh_engine() -> (TempDir, TestEngine) {
+    let dir = TempDir::new().unwrap();
+    let engine = TestEngine::create(dir.path()).unwrap();
+    (dir, engine)
+}
+
+// ── create / open ─────────────────────────────────────────────────────────
+
+#[test]
+fn create_twice_fails_with_already_exists() {
+    let (dir, engine) = fresh_engine();
+    drop(engine);
+    assert!(matches!(
+        TestEngine::create(dir.path()),
+        Err(EngineError::AlreadyExists)
+    ));
+}
+
+#[test]
+fn open_without_database_fails_with_not_found() {
+    let dir = TempDir::new().unwrap();
+    assert!(matches!(
+        TestEngine::open(dir.path()),
+        Err(EngineError::NotFound)
+    ));
+}
+
+#[test]
+#[ignore = "durability across restart is not built yet: committed pages live only \
+in the buffer pool until eviction/checkpoint/close-flush exists (I-9/I-13). \
+Un-ignore when close() flushes dirty pages or recovery lands."]
+fn reopen_sees_committed_data() {
+    let dir = TempDir::new().unwrap();
+    {
+        let engine = TestEngine::create(dir.path()).unwrap();
+        engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    } // engine dropped — data must survive via the data file
+    let engine = TestEngine::open(dir.path()).unwrap();
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v1".to_vec())
+    );
+}
+
+// ── autocommit lifecycle ──────────────────────────────────────────────────
+
+#[test]
+fn insert_then_get_roundtrip() {
+    let (_dir, engine) = fresh_engine();
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v1".to_vec())
+    );
+    assert_eq!(engine.get(&b"missing".as_slice()).unwrap(), None);
+}
+
+#[test]
+fn update_replaces_value() {
+    let (_dir, engine) = fresh_engine();
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    engine.update(&b"k1".as_slice(), &b"v2".as_slice()).unwrap();
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v2".to_vec())
+    );
+}
+
+#[test]
+fn delete_makes_key_invisible() {
+    let (_dir, engine) = fresh_engine();
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    engine.delete(&b"k1".as_slice()).unwrap();
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), None);
+}
+
+#[test]
+fn duplicate_insert_fails_and_aborts_cleanly() {
+    let (_dir, engine) = fresh_engine();
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    let err = engine
+        .insert(&b"k1".as_slice(), &b"v2".as_slice())
+        .unwrap_err();
+    assert!(matches!(err, EngineError::Index(IndexError::DuplicateKey)));
+    // the failed txn aborted via the envelope — original value untouched
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v1".to_vec())
+    );
+}
+
+// ── explicit transactions (TxnHandle) ─────────────────────────────────────
+
+#[test]
+fn handle_groups_writes_atomically() {
+    let (_dir, engine) = fresh_engine();
+    let mut txn = engine.begin();
+    txn.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    txn.insert(&b"k2".as_slice(), &b"v2".as_slice()).unwrap();
+    txn.commit().unwrap();
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v1".to_vec())
+    );
+    assert_eq!(
+        engine.get(&b"k2".as_slice()).unwrap(),
+        Some(b"v2".to_vec())
+    );
+}
+
+#[test]
+fn dropped_handle_aborts_everything() {
+    let (_dir, engine) = fresh_engine();
+    let mut txn = engine.begin();
+    txn.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    txn.insert(&b"k2".as_slice(), &b"v2".as_slice()).unwrap();
+    drop(txn); // no commit — RAII abort must hide BOTH writes
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), None);
+    assert_eq!(engine.get(&b"k2".as_slice()).unwrap(), None);
+}
+
+#[test]
+fn reads_own_writes_but_invisible_to_others_until_commit() {
+    let (_dir, engine) = fresh_engine();
+    let mut txn = engine.begin();
+    txn.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+
+    // the writer sees its own uncommitted write...
+    assert_eq!(
+        txn.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v1".to_vec())
+    );
+    // ...but a concurrent transaction (autocommit get) does not
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), None);
+
+    txn.commit().unwrap();
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v1".to_vec())
+    );
+}
+
+// ── conflicts & poisoning (wait-die surfaced through the API) ─────────────
+
+#[test]
+fn younger_conflicting_txn_dies_and_handle_is_poisoned() {
+    let (_dir, engine) = fresh_engine();
+
+    let mut older = engine.begin(); // smaller txn id
+    let mut younger = engine.begin(); // larger txn id
+
+    // older claims k1 and holds it (uncommitted)
+    older.insert(&b"k1".as_slice(), &b"v_old".as_slice()).unwrap();
+
+    // younger hits the in-progress version: wait-die says the younger dies
+    let err = younger
+        .insert(&b"k1".as_slice(), &b"v_young".as_slice())
+        .unwrap_err();
+    assert!(matches!(err, EngineError::TransactionConflict));
+
+    // the handle is now poisoned: every further op refuses...
+    let err = younger
+        .insert(&b"k2".as_slice(), &b"v2".as_slice())
+        .unwrap_err();
+    assert!(matches!(err, EngineError::TransactionConflict));
+
+    // ...and commit must fail too — a dead txn can never appear to succeed
+    let err = younger.commit().unwrap_err();
+    assert!(matches!(err, EngineError::TransactionConflict));
+
+    // the older transaction is unaffected and commits normally
+    older.commit().unwrap();
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v_old".to_vec())
+    );
+    // nothing from the dead transaction survives
+    assert_eq!(engine.get(&b"k2".as_slice()).unwrap(), None);
+}
+
+#[test]
+fn retry_after_conflict_succeeds_with_fresh_txn() {
+    let (_dir, engine) = fresh_engine();
+
+    let mut older = engine.begin();
+    let mut younger = engine.begin();
+    older.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+
+    let err = younger
+        .insert(&b"k1".as_slice(), &b"v2".as_slice())
+        .unwrap_err();
+    assert!(matches!(err, EngineError::TransactionConflict));
+    drop(younger); // dead txn aborted
+
+    older.commit().unwrap();
+
+    // the wait-die contract: retry with a FRESH transaction, which now
+    // sees the committed k1 and conflicts no more (update, not insert)
+    let mut retry = engine.begin();
+    retry.update(&b"k1".as_slice(), &b"v2".as_slice()).unwrap();
+    retry.commit().unwrap();
+    assert_eq!(
+        engine.get(&b"k1".as_slice()).unwrap(),
+        Some(b"v2".to_vec())
+    );
+}

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -20,7 +20,6 @@ use crate::page::{
     LeafPageAccessor, LeafPageBuilder, LeafPageMutator, PageId,
 };
 use common::IndexError;
-
 use db_core::transaction::Transaction;
 
 pub type Result<T> = std::result::Result<T, IndexError>;

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -1098,11 +1098,11 @@ mod tests {
             .clone();
 
         static TEST_TXN_ID: AtomicU64 = AtomicU64::new(1);
-        Transaction {
-            txn_id: TEST_TXN_ID.fetch_add(1, Relaxed),
-            snapshot: db_core::transaction::Snapshot::latest(),
+        Transaction::new(
+            TEST_TXN_ID.fetch_add(1, Relaxed),
+            db_core::transaction::Snapshot::latest(),
             tm,
-        }
+        )
     }
 
     fn leak_bytes(b: &[u8]) -> &'static [u8] {
@@ -1407,7 +1407,7 @@ mod tests {
         // 1. Insert a key.
         let insert_txn = tm.begin();
         idx.insert(&(&b"k"[..]), &(&b"v"[..]), &insert_txn).unwrap();
-        tm.commit(insert_txn.txn_id);
+        tm.mark_committed(insert_txn.txn_id);
 
         // 2. Start txn10 and delete the key.
         let txn10 = tm.begin();
@@ -1432,7 +1432,7 @@ mod tests {
             let k = i.to_be_bytes();
             let txn = tm.begin();
             idx.insert(&(k.as_ref()), &(k.as_ref()), &txn).unwrap();
-            tm.commit(txn.txn_id);
+            tm.mark_committed(txn.txn_id);
         }
 
         // 2. Delete 50 keys and commit.
@@ -1440,7 +1440,7 @@ mod tests {
             let k = i.to_be_bytes();
             let txn = tm.begin();
             idx.delete(&(k.as_ref()), &txn).unwrap();
-            tm.commit(txn.txn_id);
+            tm.mark_committed(txn.txn_id);
         }
 
         // 3. Run vacuum. Since all transactions committed, it should reclaim 50 records.

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -998,8 +998,8 @@ mod tests {
     #[test]
     fn compact_removes_dead_records() {
         let tm = TransactionManager::new();
-        tm.commit(10); // deleter of record 1
-        tm.abort(20); // creator of record 2 (never valid)
+        tm.mark_committed(10); // deleter of record 1
+        tm.mark_aborted(20); // creator of record 2 (never valid)
 
         let mut buf = crate::page::PageBuffer::new();
         {

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -164,7 +164,8 @@ impl Iterator for WalIterator {
 }
 
 impl WalIterator {
-    pub fn new(path: &Path) -> io::Result<WalIterator> {
+    pub fn new(path: impl AsRef<Path>) -> io::Result<WalIterator> {
+        let path = path.as_ref();
         let file = OpenOptions::new().read(true).open(path)?;
         Ok(WalIterator {
             reader: BufReader::new(file),
@@ -173,7 +174,8 @@ impl WalIterator {
 }
 
 impl Wal {
-    pub fn new(path: &Path) -> Result<Self> {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
         let file = OpenOptions::new().create(true).append(true).open(path)?;
         Ok(Wal {
             path: path.to_path_buf(),


### PR DESCRIPTION
## Summary
New top-level engine crate , the only crate consumers (CLI, future query layer) should depend on. Everything below it is internal.

## Changes
- engine.rs - `Engine::create(dir) / Engine::open(dir)` (one directory in; `data.db + wal.log` derived internally; root read from the page-0 superblock), the public API: insert / get / update / delete, each a complete begin -> op-> commit-or-abort transaction.
- ops.rs - internal txn-parameterized operations (*_in), maps the index's WriteConflict to a top-level TransactionConflict ("abort and retry the transaction").
- txn.rs - Bodies are one line today; comments mark exactly where the WAL append, fsync, and checkpoint guard has to be integrated later. call sites will never change. Also has `TxnHandle (engine.begin())`: multi-statement transactions with `commit-consumes-the-handle` , abort-on-drop (RAII), and poisoning after a conflict so a dead transaction can't keep operating or commit partially.

## Related Issue
Closes #46 #45 

## Any design changes?
not really any design changes. just changed naming of some existing functions and resolved all the breaking changes due to naming. 

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes