### PR TITLE
Add standard type support

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -3,6 +3,40 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::mem::size_of;
 
+fn encode_usize_varint(mut value: usize, result: &mut Vec<u8>) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            result.push(byte);
+            break;
+        }
+        byte |= 0x80;
+        result.push(byte);
+    }
+}
+
+fn decode_usize_varint(data: &[u8], offset: &mut usize) -> usize {
+    let mut result = 0usize;
+    let mut shift = 0;
+
+    loop {
+        let byte = data[*offset];
+        *offset += 1;
+        result |= ((byte & 0x7f) as usize) << shift;
+
+        if byte & 0x80 == 0 {
+            return result;
+        }
+
+        shift += 7;
+        assert!(
+            shift < usize::BITS as usize,
+            "varint is too large for usize"
+        );
+    }
+}
+
 #[derive(Eq, PartialEq, Debug, Clone)]
 enum TypeClassification {
     Internal,
@@ -195,6 +229,62 @@ impl Key for bool {
     }
 }
 
+impl<T: Value> Value for Option<T> {
+    type SelfType<'a>
+        = Option<T::SelfType<'a>>
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        T::fixed_width().map(|width| width + 1)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Option<T::SelfType<'a>>
+    where
+        Self: 'a,
+    {
+        match data[0] {
+            0 => None,
+            1 => Some(T::from_bytes(&data[1..])),
+            _ => unreachable!(),
+        }
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Vec<u8>
+    where
+        Self: 'b,
+    {
+        let mut result = vec![0];
+        if let Some(inner) = value {
+            result[0] = 1;
+            result.extend_from_slice(T::as_bytes(inner).as_ref());
+        } else if let Some(width) = T::fixed_width() {
+            result.resize(width + 1, 0);
+        }
+        result
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal(&format!("Option<{}>", T::type_name().name()))
+    }
+}
+
+impl<T: Key> Key for Option<T> {
+    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+        match (data1[0], data2[0]) {
+            (0, 0) => Ordering::Equal,
+            (0, 1) => Ordering::Less,
+            (1, 0) => Ordering::Greater,
+            (1, 1) => T::compare(&data1[1..], &data2[1..]),
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl Value for &[u8] {
     type SelfType<'a>
         = &'a [u8]
@@ -229,6 +319,45 @@ impl Value for &[u8] {
 }
 
 impl Key for &[u8] {
+    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+        data1.cmp(data2)
+    }
+}
+
+impl<const N: usize> Value for &[u8; N] {
+    type SelfType<'a>
+        = &'a [u8; N]
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = &'a [u8; N]
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(N)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> &'a [u8; N]
+    where
+        Self: 'a,
+    {
+        data.try_into().unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a [u8; N]
+    where
+        Self: 'b,
+    {
+        value
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal(&format!("[u8;{N}]"))
+    }
+}
+
+impl<const N: usize> Key for &[u8; N] {
     fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
         data1.cmp(data2)
     }
@@ -328,5 +457,424 @@ impl<const N: usize, T: Key> Key for [T; N] {
             }
         }
         Ordering::Equal
+    }
+}
+
+impl Value for &str {
+    type SelfType<'a>
+        = &'a str
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = &'a str
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> &'a str
+    where
+        Self: 'a,
+    {
+        std::str::from_utf8(data).unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a str
+    where
+        Self: 'b,
+    {
+        value
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal("&str")
+    }
+}
+
+impl Key for &str {
+    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+        let value1 = Self::from_bytes(data1);
+        let value2 = Self::from_bytes(data2);
+        value1.cmp(value2)
+    }
+}
+
+impl Value for String {
+    type SelfType<'a>
+        = String
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = &'a str
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> String
+    where
+        Self: 'a,
+    {
+        std::str::from_utf8(data).unwrap().to_string()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> &'a str
+    where
+        Self: 'b,
+    {
+        value.as_str()
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal("String")
+    }
+}
+
+impl Key for String {
+    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+        let value1 = std::str::from_utf8(data1).unwrap();
+        let value2 = std::str::from_utf8(data2).unwrap();
+        value1.cmp(value2)
+    }
+}
+
+impl Value for char {
+    type SelfType<'a>
+        = char
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = [u8; 3]
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        Some(3)
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> char
+    where
+        Self: 'a,
+    {
+        char::from_u32(u32::from_le_bytes([data[0], data[1], data[2], 0])).unwrap()
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> [u8; 3]
+    where
+        Self: 'b,
+    {
+        let bytes = u32::from(*value).to_le_bytes();
+        [bytes[0], bytes[1], bytes[2]]
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal("char")
+    }
+}
+
+impl Key for char {
+    fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+        Self::from_bytes(data1).cmp(&Self::from_bytes(data2))
+    }
+}
+
+macro_rules! le_value {
+    ($t:ty) => {
+        impl Value for $t {
+            type SelfType<'a>
+                = $t
+            where
+                Self: 'a;
+            type AsBytes<'a>
+                = [u8; std::mem::size_of::<$t>()]
+            where
+                Self: 'a;
+
+            fn fixed_width() -> Option<usize> {
+                Some(std::mem::size_of::<$t>())
+            }
+
+            fn from_bytes<'a>(data: &'a [u8]) -> $t
+            where
+                Self: 'a,
+            {
+                <$t>::from_le_bytes(data.try_into().unwrap())
+            }
+
+            fn as_bytes<'a, 'b: 'a>(
+                value: &'a Self::SelfType<'b>,
+            ) -> [u8; std::mem::size_of::<$t>()]
+            where
+                Self: 'a,
+                Self: 'b,
+            {
+                value.to_le_bytes()
+            }
+
+            fn type_name() -> TypeName {
+                TypeName::internal(stringify!($t))
+            }
+        }
+    };
+}
+
+macro_rules! le_key {
+    ($t:ty) => {
+        le_value!($t);
+
+        impl Key for $t {
+            fn compare(data1: &[u8], data2: &[u8]) -> Ordering {
+                Self::from_bytes(data1).cmp(&Self::from_bytes(data2))
+            }
+        }
+    };
+}
+
+le_key!(u8);
+le_key!(u16);
+le_key!(u32);
+le_key!(u64);
+le_key!(u128);
+le_key!(i8);
+le_key!(i16);
+le_key!(i32);
+le_key!(i64);
+le_key!(i128);
+le_value!(f32);
+le_value!(f64);
+
+impl<T: Value> Value for Vec<T> {
+    type SelfType<'a>
+        = Vec<T::SelfType<'a>>
+    where
+        Self: 'a;
+    type AsBytes<'a>
+        = Vec<u8>
+    where
+        Self: 'a;
+
+    fn fixed_width() -> Option<usize> {
+        None
+    }
+
+    fn from_bytes<'a>(data: &'a [u8]) -> Vec<T::SelfType<'a>>
+    where
+        Self: 'a,
+    {
+        let mut offset = 0;
+        let count = decode_usize_varint(data, &mut offset);
+        let mut result = Vec::with_capacity(count);
+
+        if let Some(fixed) = T::fixed_width() {
+            for i in 0..count {
+                let item_start = offset + fixed * i;
+                let item_end = item_start + fixed;
+                result.push(T::from_bytes(&data[item_start..item_end]));
+            }
+        } else {
+            for _ in 0..count {
+                let item_len = decode_usize_varint(data, &mut offset);
+                let item_end = offset + item_len;
+                result.push(T::from_bytes(&data[offset..item_end]));
+                offset = item_end;
+            }
+        }
+
+        result
+    }
+
+    fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Vec<u8>
+    where
+        Self: 'b,
+    {
+        let mut result = Vec::new();
+        encode_usize_varint(value.len(), &mut result);
+
+        if let Some(fixed) = T::fixed_width() {
+            result.reserve(fixed * value.len());
+            for item in value {
+                result.extend_from_slice(T::as_bytes(item).as_ref());
+            }
+        } else {
+            for item in value {
+                let item_bytes = T::as_bytes(item);
+                encode_usize_varint(item_bytes.as_ref().len(), &mut result);
+                result.extend_from_slice(item_bytes.as_ref());
+            }
+        }
+
+        result
+    }
+
+    fn type_name() -> TypeName {
+        TypeName::internal(&format!("Vec<{}>", T::type_name().name()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_value<T: Value>() {}
+
+    fn assert_key<T: Key>() {}
+
+    #[test]
+    fn primitive_values_roundtrip() {
+        let bytes = <u8 as Value>::as_bytes(&42);
+        assert_eq!(<u8 as Value>::from_bytes(bytes.as_ref()), 42);
+        let bytes = <u16 as Value>::as_bytes(&513);
+        assert_eq!(<u16 as Value>::from_bytes(bytes.as_ref()), 513);
+        let bytes = <u32 as Value>::as_bytes(&123_456);
+        assert_eq!(<u32 as Value>::from_bytes(bytes.as_ref()), 123_456);
+        let bytes = <u64 as Value>::as_bytes(&123_456_789);
+        assert_eq!(<u64 as Value>::from_bytes(bytes.as_ref()), 123_456_789);
+        let bytes = <u128 as Value>::as_bytes(&123_456_789_123);
+        assert_eq!(<u128 as Value>::from_bytes(bytes.as_ref()), 123_456_789_123);
+        let bytes = <i8 as Value>::as_bytes(&-42);
+        assert_eq!(<i8 as Value>::from_bytes(bytes.as_ref()), -42);
+        let bytes = <i16 as Value>::as_bytes(&-513);
+        assert_eq!(<i16 as Value>::from_bytes(bytes.as_ref()), -513);
+        let bytes = <i32 as Value>::as_bytes(&-123_456);
+        assert_eq!(<i32 as Value>::from_bytes(bytes.as_ref()), -123_456);
+        let bytes = <i64 as Value>::as_bytes(&-123_456_789);
+        assert_eq!(<i64 as Value>::from_bytes(bytes.as_ref()), -123_456_789);
+        let bytes = <i128 as Value>::as_bytes(&-123_456_789_123);
+        assert_eq!(
+            <i128 as Value>::from_bytes(bytes.as_ref()),
+            -123_456_789_123
+        );
+        let bytes = <f32 as Value>::as_bytes(&3.5);
+        assert_eq!(<f32 as Value>::from_bytes(bytes.as_ref()), 3.5);
+        let bytes = <f64 as Value>::as_bytes(&-9.25);
+        assert_eq!(<f64 as Value>::from_bytes(bytes.as_ref()), -9.25);
+    }
+
+    #[test]
+    fn string_and_char_values_roundtrip() {
+        let bytes = <&str as Value>::as_bytes(&"flux");
+        assert_eq!(<&str as Value>::from_bytes(bytes.as_ref()), "flux");
+        let value = "database".to_string();
+        let bytes = <String as Value>::as_bytes(&value);
+        assert_eq!(<String as Value>::from_bytes(bytes.as_ref()), "database");
+        let bytes = <char as Value>::as_bytes(&'λ');
+        assert_eq!(<char as Value>::from_bytes(bytes.as_ref()), 'λ');
+        let bytes = <char as Value>::as_bytes(&'\u{10ffff}');
+        assert_eq!(<char as Value>::from_bytes(bytes.as_ref()), '\u{10ffff}');
+    }
+
+    #[test]
+    fn option_values_roundtrip() {
+        let some = Some(42u32);
+        let none: Option<u32> = None;
+
+        let bytes = <Option<u32> as Value>::as_bytes(&some);
+        assert_eq!(<Option<u32> as Value>::from_bytes(bytes.as_ref()), Some(42));
+        let bytes = <Option<u32> as Value>::as_bytes(&none);
+        assert_eq!(<Option<u32> as Value>::from_bytes(bytes.as_ref()), None);
+        assert_eq!(<Option<u32> as Value>::fixed_width(), Some(5));
+        assert_eq!(<Option<&str> as Value>::fixed_width(), None);
+    }
+
+    #[test]
+    fn option_variable_width_roundtrip() {
+        let some = Some("hello");
+        let none: Option<&str> = None;
+
+        let bytes = <Option<&str> as Value>::as_bytes(&some);
+        assert_eq!(<Option<&str> as Value>::from_bytes(bytes.as_ref()), some);
+
+        let bytes = <Option<&str> as Value>::as_bytes(&none);
+        assert_eq!(<Option<&str> as Value>::from_bytes(bytes.as_ref()), none);
+    }
+
+    #[test]
+    fn vec_values_roundtrip() {
+        let fixed = vec![1u32, 2, 3, 4];
+        let variable = vec!["alpha", "beta", "gamma"];
+        let empty: Vec<u64> = Vec::new();
+
+        let bytes = <Vec<u32> as Value>::as_bytes(&fixed);
+        assert_eq!(<Vec<u32> as Value>::from_bytes(bytes.as_ref()), fixed);
+        let bytes = <Vec<&str> as Value>::as_bytes(&variable);
+        assert_eq!(bytes.as_slice(), b"\x03\x05alpha\x04beta\x05gamma");
+        assert_eq!(<Vec<&str> as Value>::from_bytes(bytes.as_ref()), variable);
+        let bytes = <Vec<u64> as Value>::as_bytes(&empty);
+        assert_eq!(<Vec<u64> as Value>::from_bytes(bytes.as_ref()), empty);
+    }
+
+    #[test]
+    fn arrays_and_fixed_byte_refs_roundtrip() {
+        let array = [1u32, 2, 3];
+        let byte_array = *b"flux";
+        let byte_array_ref = &byte_array;
+
+        let bytes = <[u32; 3] as Value>::as_bytes(&array);
+        assert_eq!(<[u32; 3] as Value>::from_bytes(bytes.as_ref()), array);
+        let bytes = <&[u8; 4] as Value>::as_bytes(&byte_array_ref);
+        assert_eq!(
+            <&[u8; 4] as Value>::from_bytes(bytes.as_ref()),
+            byte_array_ref
+        );
+        assert_eq!(
+            <&[u8; 4] as Value>::type_name(),
+            <[u8; 4] as Value>::type_name()
+        );
+    }
+
+    #[test]
+    fn key_ordering_uses_logical_order() {
+        assert_eq!(
+            u32::compare(&10u32.to_le_bytes(), &2u32.to_le_bytes()),
+            Ordering::Greater
+        );
+        assert_eq!(
+            i32::compare(&(-10i32).to_le_bytes(), &2i32.to_le_bytes()),
+            Ordering::Less
+        );
+        assert_eq!(<&str>::compare(b"alpha", b"beta"), Ordering::Less);
+
+        let lambda = <char as Value>::as_bytes(&'λ');
+        let omega = <char as Value>::as_bytes(&'ω');
+        assert_eq!(char::compare(&lambda, &omega), Ordering::Less);
+
+        let none = <Option<u32> as Value>::as_bytes(&None);
+        let some_1 = <Option<u32> as Value>::as_bytes(&Some(1));
+        let some_2 = <Option<u32> as Value>::as_bytes(&Some(2));
+        assert_eq!(
+            <Option<u32> as Key>::compare(&none, &some_1),
+            Ordering::Less
+        );
+        assert_eq!(
+            <Option<u32> as Key>::compare(&some_1, &some_2),
+            Ordering::Less
+        );
+
+        assert_eq!(<&[u8; 3] as Key>::compare(b"abc", b"abd"), Ordering::Less);
+    }
+
+    #[test]
+    fn representative_types_satisfy_trait_bounds() {
+        assert_value::<u64>();
+        assert_value::<i64>();
+        assert_value::<f32>();
+        assert_value::<f64>();
+        assert_value::<&str>();
+        assert_value::<String>();
+        assert_value::<Option<&str>>();
+        assert_value::<Vec<u32>>();
+        assert_value::<Vec<&str>>();
+        assert_value::<&[u8; 8]>();
+
+        assert_key::<u64>();
+        assert_key::<i64>();
+        assert_key::<&str>();
+        assert_key::<String>();
+        assert_key::<Option<&str>>();
+        assert_key::<&[u8; 8]>();
     }
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -15,8 +15,11 @@ where
     V: Value,
 {
     pub(crate) index: Arc<BTreeIndex<K, V>>,
+    #[allow(dead_code)]
     pub(crate) wal: Arc<Mutex<Wal>>,
+    #[allow(dead_code)]
     pub(crate) disk_manager: Arc<DiskManager>,
+    #[allow(dead_code)]
     pub(crate) buffer_pool: Arc<BufferPoolManager>,
     pub(crate) transaction_manager: Arc<TransactionManager>,
 }


### PR DESCRIPTION
## Summary
Adds redb inspired `Value`/`Key` support for standard library types in `common::types`.

## Changes
- Added `Value + Key` impls for integer types, `char`, `&str`, `String`, `Option<T>` where `T: Key`, and `&[u8; N]`
- Added `Value` impls for `Option<T>` where `T: Value`, plus `f32`, `f64`, and `Vec<T>`
- Added tests for roundtrip serialisation, key ordering, variable width `Option`, `Vec<T>` encoding, and representative trait bounds

## Related Issue
Closes #53

## Any design changes?
No storage or engine API changes. `Vec<T>` uses redb style encoding with a varint item count and per item lengths for variable width values. `Key` is intentionally not implemented for floats or `Vec<T>`.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated
- [x] No breaking changes