### PR TITLE
feat: physiological Insert WAL logging + buffer-pool WAL-before-page gate

### DIFF
--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -79,6 +79,10 @@ pub enum BufferPoolError {
     #[error("Disk error: {0}")]
     Disk(#[from] DiskError),
 
+    /// A WAL error propagated while enforcing WAL-before-page during a flush.
+    #[error("WAL error: {0}")]
+    Wal(#[from] WalError),
+
     #[error("Internal error: {0}")]
     InternalError(String),
 }
@@ -111,6 +115,10 @@ pub enum IndexError {
 
     #[error("Page error: {0}")]
     Page(#[from] PageError),
+
+    /// A WAL error propagated while logging a mutation (e.g. `log_insert`).
+    #[error("WAL error: {0}")]
+    Wal(#[from] WalError),
 
     /// An in-progress transaction is blocking this insert. The caller should
     /// drop its page latch, wait for `txn_id` to settle, then retry.

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -49,9 +49,12 @@ where
         // initialize wal;
         // Arc is needed on WAL as both index and buffer_pool will later have a wal instance.
         let wal = Arc::new(Mutex::new(Wal::new(path.join("wal.log"))?));
-        let buffer_pool = Arc::new(BufferPoolManager::new(Arc::clone(&disk_manager)));
+        let buffer_pool = Arc::new(BufferPoolManager::new(
+            Arc::clone(&disk_manager),
+            Arc::clone(&wal),
+        ));
         let transaction_manager = Arc::new(TransactionManager::new());
-        let (index, _root) = BTreeIndex::create(Arc::clone(&buffer_pool))?;
+        let (index, _root) = BTreeIndex::create(Arc::clone(&buffer_pool), Arc::clone(&wal))?;
         // index needs Arc as it will be later cloned by vaccum to call index.vaccum()
         let index = Arc::new(index);
         // TODO! spawn checkpoint thread once checkpoint is there
@@ -79,14 +82,20 @@ where
         // Wal::new opens the existing log (and creates it if a pre-WAL database
         // never had one) — the tail scan / LSN resume lands with the log manager work
         let wal = Arc::new(Mutex::new(Wal::new(path.join("wal.log"))?));
-        let buffer_pool = Arc::new(BufferPoolManager::new(Arc::clone(&disk_manager)));
+        let buffer_pool = Arc::new(BufferPoolManager::new(
+            Arc::clone(&disk_manager),
+            Arc::clone(&wal),
+        ));
         let transaction_manager = Arc::new(TransactionManager::new());
         // recovery runs HERE — after the pool exists, before the index opens:
         // read checkpoint from superblock → seed CLOG from pinned_aborted[] →
         // replay WAL from redo_point → mark crash victims Aborted →
         // inject next_txn_id / next_page_id watermarks (from_recovered)
         // index reads the root page id from the page-0 superblock
-        let index = Arc::new(BTreeIndex::open(Arc::clone(&buffer_pool))?);
+        let index = Arc::new(BTreeIndex::open(
+            Arc::clone(&buffer_pool),
+            Arc::clone(&wal),
+        )?);
         // TODO! spawn checkpoint + vacuum threads
         Ok(Engine {
             index,

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -1,5 +1,6 @@
 use crate::buffer_pool::shard::{BufferPoolShard, PageReadGuard, PageWriteGuard};
 use crate::disk::DiskManager;
+use crate::wal::Wal;
 use common::{BufferPoolError, MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
 use std::sync::{Arc, Mutex};
 
@@ -16,11 +17,11 @@ impl BufferPoolManager {
     ///
     /// It initializes the shards and sets the `next_page_id` based on the
     /// current number of pages in the disk file.
-    pub fn new(disk_manager: Arc<DiskManager>) -> Self {
+    pub fn new(disk_manager: Arc<DiskManager>, wal: Arc<Mutex<Wal>>) -> Self {
         let existing_pages = disk_manager.num_pages().unwrap_or(0);
         let shard_size = MAX_FRAMES / NUM_SHARDS;
         let shards = (0..NUM_SHARDS)
-            .map(|_| BufferPoolShard::new(disk_manager.clone(), shard_size))
+            .map(|_| BufferPoolShard::new(disk_manager.clone(), shard_size, Arc::clone(&wal)))
             .collect();
 
         Self {

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -6,6 +6,7 @@
 
 use crate::buffer_pool::replacer::ClockReplacer;
 use crate::disk::DiskManager;
+use crate::wal::Wal;
 use common::BufferPoolError;
 use common::{INVALID_FRAME_ID, MAX_PAGE_SIZE};
 use std::collections::HashMap;
@@ -133,11 +134,12 @@ pub struct BufferPoolShard {
     pub pages: Vec<RwLock<PageData>>,
     pub inner: Mutex<ShardInner>,
     pub load_done: Condvar, // singalled when any load finishes(success or fail)
+    pub wal: Arc<Mutex<Wal>>,
 }
 
 impl BufferPoolShard {
     /// Creates a new `BufferPoolShard` with the specified number of frames.
-    pub fn new(disk_manager: Arc<DiskManager>, size: usize) -> Self {
+    pub fn new(disk_manager: Arc<DiskManager>, size: usize, wal: Arc<Mutex<Wal>>) -> Self {
         let mut metadata = Vec::with_capacity(size);
         let mut free_list = Vec::with_capacity(size);
         for frame_id in 0..size {
@@ -160,6 +162,7 @@ impl BufferPoolShard {
                 replacer: ClockReplacer::new(size),
             }),
             load_done: Condvar::new(),
+            wal,
         }
     }
 
@@ -313,10 +316,20 @@ impl BufferPoolShard {
 
     pub fn write_frame_to_disk(&self, frame_id: usize, page_id: u64) -> Result<()> {
         let mut buf = vec![0u8; MAX_PAGE_SIZE];
+        let page_lsn;
         {
+            // Snapshot the page LSN and the page bytes under the SAME read guard
+            // so the LSN we flush the WAL to matches exactly the bytes we write.
+            // A concurrent writer cannot interleave between the two reads
             let data = self.pages[frame_id].read().unwrap();
+            page_lsn = crate::page::page_lsn(&data[..]);
             buf.copy_from_slice(&data[..]);
         }
+
+        // WAL-before-page: a page image carrying `page_lsn` must not reach disk
+        // until the WAL is durable through `page_lsn`. No-op when already durable.
+        // (`?` converts WalError → BufferPoolError via `#[from]`.)
+        self.wal.lock().unwrap().flush_up_to(page_lsn)?;
 
         // Stamp the CRC32 on the outgoing copy so corruption is detectable on the next load
         crate::page::stamp_checksum(&mut buf);

--- a/crates/storage/src/buffer_pool/tests.rs
+++ b/crates/storage/src/buffer_pool/tests.rs
@@ -1,9 +1,17 @@
 use crate::buffer_pool::manager::BufferPoolManager;
 use crate::buffer_pool::replacer::ClockReplacer;
 use crate::disk::DiskManager;
+use crate::wal::Wal;
 use common::{MAX_FRAMES, MAX_PAGE_SIZE};
-use std::sync::Arc;
-use tempfile::tempdir;
+use std::sync::{Arc, Mutex};
+use tempfile::{TempDir, tempdir};
+
+/// Build a `BufferPoolManager` backed by a throwaway WAL in `dir`. The WAL is
+/// required since the pool enforces WAL-before-page at its flush seam.
+fn make_bpm(disk_manager: Arc<DiskManager>, dir: &TempDir) -> BufferPoolManager {
+    let wal = Arc::new(Mutex::new(Wal::new(dir.path().join("test.wal")).unwrap()));
+    BufferPoolManager::new(disk_manager, wal)
+}
 
 #[test]
 fn test_clock_replacer_eviction_order() {
@@ -28,7 +36,7 @@ fn test_buffer_pool_manager_basic() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.db");
     let disk_manager = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-    let bpm = BufferPoolManager::new(disk_manager);
+    let bpm = make_bpm(disk_manager, &dir);
     let page_id;
     {
         let mut page = bpm.new_page().unwrap();
@@ -56,7 +64,7 @@ fn test_buffer_pool_manager_eviction_persistence() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.db");
     let disk_manager = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-    let bpm = BufferPoolManager::new(disk_manager);
+    let bpm = make_bpm(disk_manager, &dir);
     let mut page_ids = Vec::new();
     for i in 0..MAX_FRAMES + 1 {
         let mut page = bpm.new_page().unwrap();
@@ -74,7 +82,7 @@ fn test_buffer_pool_manager_full_lifecycle() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.db");
     let disk_manager = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-    let bpm = BufferPoolManager::new(disk_manager);
+    let bpm = make_bpm(disk_manager, &dir);
     let mut page_ids = Vec::new();
     for i in 0..10 {
         let mut page = bpm.new_page().unwrap();
@@ -105,7 +113,7 @@ fn test_buffer_pool_manager_concurrency() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.db");
     let disk_manager = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-    let bpm = Arc::new(BufferPoolManager::new(disk_manager));
+    let bpm = Arc::new(make_bpm(disk_manager, &dir));
     let mut handles = Vec::new();
     for i in 0..10 {
         let bpm_clone = bpm.clone();
@@ -133,7 +141,7 @@ fn test_checksum_survives_reopen() {
 
     let pid;
     {
-        let bpm = BufferPoolManager::new(disk_manager.clone());
+        let bpm = make_bpm(disk_manager.clone(), &dir);
         let mut page = bpm.new_page().unwrap();
         pid = page.page_id;
         page[0] = crate::page::LEAF; // valid page type → checksum applies
@@ -142,7 +150,7 @@ fn test_checksum_survives_reopen() {
         bpm.flush_page(pid).unwrap();
     }
 
-    let bpm = BufferPoolManager::new(disk_manager);
+    let bpm = make_bpm(disk_manager, &dir);
     let page = bpm.fetch_page(pid).unwrap();
     assert_eq!(page[0], crate::page::LEAF);
     assert_eq!(page[100], 42);
@@ -157,7 +165,7 @@ fn test_checksum_detects_corruption() {
 
     let pid;
     {
-        let bpm = BufferPoolManager::new(disk_manager.clone());
+        let bpm = make_bpm(disk_manager.clone(), &dir);
         let mut page = bpm.new_page().unwrap();
         pid = page.page_id;
         page[0] = crate::page::LEAF;
@@ -176,7 +184,7 @@ fn test_checksum_detects_corruption() {
     // A fresh pool must load from disk and reject the corrupted page. A failed
     // verify also discards the frame, so the bad bytes are never cached — both
     // fetch paths on the same pool keep reloading from disk and keep rejecting.
-    let bpm = BufferPoolManager::new(disk_manager);
+    let bpm = make_bpm(disk_manager, &dir);
     assert!(matches!(
         bpm.fetch_page(pid),
         Err(BufferPoolError::PageCorruption { .. })
@@ -201,7 +209,7 @@ fn test_concurrent_fetch_valid_page() {
 
     let pid;
     {
-        let bpm = BufferPoolManager::new(disk_manager.clone());
+        let bpm = make_bpm(disk_manager.clone(), &dir);
         let mut page = bpm.new_page().unwrap();
         pid = page.page_id;
         page[0] = crate::page::LEAF;
@@ -211,7 +219,7 @@ fn test_concurrent_fetch_valid_page() {
     }
 
     // Fresh pool → the page must be loaded from disk; N threads race that load.
-    let bpm = Arc::new(BufferPoolManager::new(disk_manager));
+    let bpm = Arc::new(make_bpm(disk_manager, &dir));
     let mut handles = Vec::new();
     for _ in 0..N {
         let bpm = bpm.clone();
@@ -242,7 +250,7 @@ fn test_concurrent_fetch_corrupt_page() {
 
     let pid;
     {
-        let bpm = BufferPoolManager::new(disk_manager.clone());
+        let bpm = make_bpm(disk_manager.clone(), &dir);
         let mut page = bpm.new_page().unwrap();
         pid = page.page_id;
         page[0] = crate::page::LEAF;
@@ -258,7 +266,7 @@ fn test_concurrent_fetch_corrupt_page() {
     disk_manager.write_page(pid, &raw).unwrap();
     disk_manager.sync_data().unwrap();
 
-    let bpm = Arc::new(BufferPoolManager::new(disk_manager));
+    let bpm = Arc::new(make_bpm(disk_manager, &dir));
     let mut handles = Vec::new();
     for _ in 0..N {
         let bpm = bpm.clone();
@@ -283,7 +291,7 @@ fn test_buffer_pool_manager_pin_count() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("test.db");
     let disk_manager = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-    let bpm = BufferPoolManager::new(disk_manager);
+    let bpm = make_bpm(disk_manager, &dir);
     let mut pages = Vec::new();
     for _ in 0..MAX_FRAMES {
         pages.push(bpm.new_page().unwrap());

--- a/crates/storage/src/index.rs
+++ b/crates/storage/src/index.rs
@@ -44,6 +44,7 @@ type BTStack = Vec<BTStackEntry>;
 
 pub struct BTreeIndex<K: Key, V: Value> {
     pool: Arc<BufferPoolManager>,
+    wal: Arc<Mutex<crate::wal::Wal>>,
     root: Mutex<PageId>,
     _key: PhantomData<K>,
     _val: PhantomData<V>,
@@ -52,7 +53,7 @@ pub struct BTreeIndex<K: Key, V: Value> {
 impl<K: Key, V: Value> BTreeIndex<K, V> {
     // ── Constructors ──────────────────────────────────────────────────────────
 
-    pub fn open(pool: Arc<BufferPoolManager>) -> Result<Self> {
+    pub fn open(pool: Arc<BufferPoolManager>, wal: Arc<Mutex<crate::wal::Wal>>) -> Result<Self> {
         // Page 0 is the superblock. fetch_page verifies its checksum, so a torn
         // write surfaces here as BufferPoolError::PageCorruption.
         let meta = pool.fetch_page(0)?;
@@ -60,7 +61,7 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             IndexError::CorruptMetadata("page 0 is not a FluxDB superblock".into())
         })?;
         drop(meta);
-        Ok(Self::from_root(pool, root))
+        Ok(Self::from_root(pool, wal, root))
     }
 
     /// Reclaims storage space by physically removing dead record versions.
@@ -96,7 +97,10 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         Ok(total_dead)
     }
 
-    pub fn create(pool: Arc<BufferPoolManager>) -> Result<(Self, PageId)> {
+    pub fn create(
+        pool: Arc<BufferPoolManager>,
+        wal: Arc<Mutex<crate::wal::Wal>>,
+    ) -> Result<(Self, PageId)> {
         let mut meta_guard = pool.new_page()?;
         let meta_pid = meta_guard.page_id;
         // create root page first
@@ -111,16 +115,21 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         drop(meta_guard);
         pool.flush_page(meta_pid)?;
 
-        Ok((Self::from_root(pool, root_pid), root_pid))
+        Ok((Self::from_root(pool, wal, root_pid), root_pid))
     }
 
     pub fn root_page_id(&self) -> PageId {
         *self.root.lock().unwrap()
     }
 
-    fn from_root(pool: Arc<BufferPoolManager>, root: PageId) -> Self {
+    fn from_root(
+        pool: Arc<BufferPoolManager>,
+        wal: Arc<Mutex<crate::wal::Wal>>,
+        root: PageId,
+    ) -> Self {
         Self {
             pool,
+            wal,
             root: Mutex::new(root),
             _val: PhantomData,
             _key: PhantomData,
@@ -254,9 +263,26 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             let result = LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).insert(slot, key, value);
             return match result {
                 Ok(()) => {
+                    let page_id = leaf_guard.page_id;
                     LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_xmin(slot, txn.txn_id);
+                    // WAL: physiological Insert (DESIGN §4.2). Append-only here — durability
+                    // is enforced lazily by the buffer pool's WAL-before-page gate or at
+                    // commit, never fsynced at insert time. Stamp the record's LSN as the
+                    // page LSN so the gate flushes the WAL through it before the page lands.
+                    let val_bytes = V::as_bytes(value);
+                    let lsn = self.wal.lock().unwrap().log_insert(
+                        txn.txn_id,
+                        page_id,
+                        slot as u16,
+                        key_bytes.as_ref(),
+                        val_bytes.as_ref(),
+                        txn.txn_id,
+                    )?;
+                    LeafPageMutator::<K, V>::new(&mut leaf_guard[..]).set_lsn(lsn);
                     Ok(())
                 }
+                // TODO(WAL): the split path is not logged yet — it needs LeafSplit (FPI)
+                // records before an insert that triggers a split is recoverable.
                 Err(_) => self.split_and_insert(leaf_guard, key, value, txn, &mut stack),
             };
         }
@@ -1109,19 +1135,33 @@ mod tests {
     use super::*;
     use crate::buffer_pool::manager::BufferPoolManager;
     use crate::disk::DiskManager;
+    use crate::wal::Wal;
     use common::MAX_PAGE_SIZE;
     use std::mem::forget;
+    use std::path::Path;
     use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
-    use std::sync::{Arc, OnceLock};
+    use std::sync::{Arc, Mutex, OnceLock};
     use tempfile::tempdir;
+
+    /// Open a throwaway WAL under `dir`. The index and pool must share one WAL,
+    /// so callers build it once here and clone the `Arc` to both.
+    fn make_wal(dir: &Path) -> Arc<Mutex<Wal>> {
+        Arc::new(Mutex::new(Wal::new(dir.join("wal.log")).unwrap()))
+    }
+
+    /// Wrap `disk` in a pool backed by `wal` (required for WAL-before-page).
+    fn make_pool(disk: Arc<DiskManager>, wal: Arc<Mutex<Wal>>) -> Arc<BufferPoolManager> {
+        Arc::new(BufferPoolManager::new(disk, wal))
+    }
 
     fn make_index() -> BTreeIndex<&'static [u8], &'static [u8]> {
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.db");
+        let wal = make_wal(dir.path());
         forget(dir);
         let disk = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-        let pool = Arc::new(BufferPoolManager::new(disk));
-        let (index, _) = BTreeIndex::create(pool).unwrap();
+        let pool = make_pool(disk, wal.clone());
+        let (index, _) = BTreeIndex::create(pool, wal).unwrap();
         index
     }
 
@@ -1233,9 +1273,10 @@ mod tests {
         // Create, insert enough to force splits (incl. a root split), flush, close.
         {
             let disk = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-            let pool = Arc::new(BufferPoolManager::new(disk));
+            let wal = make_wal(dir.path());
+            let pool = make_pool(disk, wal.clone());
             let (index, _root) =
-                BTreeIndex::<&'static [u8], &'static [u8]>::create(pool.clone()).unwrap();
+                BTreeIndex::<&'static [u8], &'static [u8]>::create(pool.clone(), wal).unwrap();
             for k in 0u32..300 {
                 let key = leak_bytes(&k.to_be_bytes());
                 let val = leak_bytes(&(k * 7).to_be_bytes());
@@ -1246,8 +1287,9 @@ mod tests {
 
         // Reopen with NO root id — it must be recovered from the page-0 superblock.
         let disk = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-        let pool = Arc::new(BufferPoolManager::new(disk));
-        let index = BTreeIndex::<&'static [u8], &'static [u8]>::open(pool).unwrap();
+        let wal = make_wal(dir.path());
+        let pool = make_pool(disk, wal.clone());
+        let index = BTreeIndex::<&'static [u8], &'static [u8]>::open(pool, wal).unwrap();
         for k in 0u32..300 {
             let key = leak_bytes(&k.to_be_bytes());
             let expected = (k * 7).to_be_bytes();
@@ -1268,12 +1310,14 @@ mod tests {
         let path = dir.path().join("fresh.db");
         {
             let disk = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-            let pool = Arc::new(BufferPoolManager::new(disk));
-            let _ = BTreeIndex::<&'static [u8], &'static [u8]>::create(pool).unwrap();
+            let wal = make_wal(dir.path());
+            let pool = make_pool(disk, wal.clone());
+            let _ = BTreeIndex::<&'static [u8], &'static [u8]>::create(pool, wal).unwrap();
         }
         let disk = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
-        let pool = Arc::new(BufferPoolManager::new(disk));
-        let index = BTreeIndex::<&'static [u8], &'static [u8]>::open(pool).unwrap();
+        let wal = make_wal(dir.path());
+        let pool = make_pool(disk, wal.clone());
+        let index = BTreeIndex::<&'static [u8], &'static [u8]>::open(pool, wal).unwrap();
         assert!(index.get(&(&b"anything"[..]), &auto()).unwrap().is_none());
     }
 
@@ -1526,5 +1570,44 @@ mod tests {
 
         let result = idx.get(&(k.as_ref()), &tm.begin()).unwrap();
         assert!(result.is_some(), "Inserted record should be readable");
+    }
+
+    // ── WAL: physiological Insert logging brings the flush gate to life ───────
+
+    #[test]
+    fn insert_logs_record_stamps_page_lsn_and_gate_flushes() {
+        let dir = tempdir().unwrap();
+        let db = dir.path().join("wal_insert.db");
+        let wal = make_wal(dir.path());
+        let disk = Arc::new(DiskManager::new(&db, MAX_PAGE_SIZE).unwrap());
+        let pool = make_pool(disk, wal.clone());
+        let (index, root) =
+            BTreeIndex::<&'static [u8], &'static [u8]>::create(pool.clone(), wal.clone()).unwrap();
+
+        // `create` logs nothing, so the LSN counter starts at 0.
+        assert_eq!(wal.lock().unwrap().next_lsn, 0);
+
+        // Two in-place inserts on the same leaf → two Insert records (LSN 0, 1).
+        index.insert(&(&b"a"[..]), &(&b"1"[..]), &auto()).unwrap();
+        index.insert(&(&b"b"[..]), &(&b"2"[..]), &auto()).unwrap();
+        assert_eq!(
+            wal.lock().unwrap().next_lsn,
+            2,
+            "each insert appends a record"
+        );
+
+        // The leaf page must carry the latest insert's LSN (set_lsn under the latch).
+        let leaf = pool.fetch_page(root).unwrap();
+        assert_eq!(crate::page::page_lsn(&leaf[..]), 1, "page LSN stamped");
+        drop(leaf);
+
+        // Flushing the dirty leaf must drive the WAL durable through that page LSN
+        // (the WAL-before-page gate firing on a real, non-zero LSN).
+        pool.flush_all_pages().unwrap();
+        assert_eq!(
+            wal.lock().unwrap().flushed_lsn,
+            Some(1),
+            "gate flushed WAL to page LSN"
+        );
     }
 }

--- a/crates/storage/src/page/mod.rs
+++ b/crates/storage/src/page/mod.rs
@@ -143,6 +143,15 @@ impl Default for PageBuffer {
 // These are plain functions (not methods) so both sub-modules can use them
 // with a simple `use super::{read_u8, ...}` import.
 
+/// Read a page's LSN (the `pageLSN`) straight from its raw bytes.
+///
+/// Used by the buffer pool's flush seam to enforce WAL-before-page without
+/// having to know the page type. Returns 0 for a never-logged page.
+#[inline]
+pub fn page_lsn(data: &[u8]) -> Lsn {
+    read_u64(data, OFF_LSN)
+}
+
 #[inline]
 pub(super) fn read_u8(data: &[u8], off: usize) -> u8 {
     data[off]

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -390,7 +390,6 @@ impl Wal {
         self.append(WalRecordType::Abort, txn_id, &[], None)
     }
 
-    
     /// Appends only — durability is deferred to the buffer pool's flush seam
     /// (WAL-before-page) or to the transaction's commit, never an fsync here.
     pub fn log_insert(

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -86,6 +86,11 @@ impl TryFrom<u8> for WalRecordType {
     }
 }
 
+/// Block flag bits (`blk_flags`). Bit 0 marks a full-page image; bit 1 marks a
+/// physiological redo payload. Reader keys FPI off bit 0 and data off `data_len`.
+pub const BLK_HAS_FPI: u8 = 0b01;
+pub const BLK_HAS_DATA: u8 = 0b10;
+
 /// Represents a reference to a page modified by the transaction, potentially
 /// including a Full-Page Image (FPI) and specific redo data for that page.
 #[derive(Debug)]
@@ -384,6 +389,36 @@ impl Wal {
     pub fn log_abort(&mut self, txn_id: u64) -> Result<Lsn> {
         self.append(WalRecordType::Abort, txn_id, &[], None)
     }
+
+    
+    /// Appends only — durability is deferred to the buffer pool's flush seam
+    /// (WAL-before-page) or to the transaction's commit, never an fsync here.
+    pub fn log_insert(
+        &mut self,
+        txn_id: u64,
+        page_id: PageId,
+        slot: u16,
+        key: &[u8],
+        value: &[u8],
+        xmin: u64,
+    ) -> Result<Lsn> {
+        let mut payload = Vec::with_capacity(2 + 2 + 2 + 8 + key.len() + value.len());
+        payload.extend_from_slice(&slot.to_le_bytes());
+        payload.extend_from_slice(&(key.len() as u16).to_le_bytes());
+        payload.extend_from_slice(&(value.len() as u16).to_le_bytes());
+        payload.extend_from_slice(&xmin.to_le_bytes());
+        payload.extend_from_slice(key);
+        payload.extend_from_slice(value);
+
+        let block = Block {
+            page_id,
+            blk_flags: BLK_HAS_DATA,
+            fpi: None,
+            data: Some(&payload),
+        };
+        self.append(WalRecordType::Insert, txn_id, &[block], None)
+    }
+
     /// Appends a new physiological record to the WAL buffer.
     ///
     /// This method assigns the next available LSN, serializes the record according to the


### PR DESCRIPTION
## Summary
Wire the storage engine's writes into the WAL, enforce WAL-before-page durability ordering, and make in-place leaf inserts produce real log records that stamp page LSNs.

## Changes
- add log_insert in wal.rs 
- call log_insert in index.rs 
- buffer_pool now calls flush up-to before evicting the page 

## Related Issue
Closes #19 

## Any design changes?


## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes