### PR TITLE
feat(perf): optimize B+Tree accessor performance

### DIFF
--- a/crates/storage/src/page/internal.rs
+++ b/crates/storage/src/page/internal.rs
@@ -95,6 +95,8 @@ fn int_key_data_base(num_keys: usize) -> usize {
 /// the accessor itself.
 pub struct InternalPageAccessor<'a, K: Key> {
     data: &'a [u8],
+    num_keys: u16,
+    key_data_base: usize,
     _key: PhantomData<K>,
 }
 
@@ -109,8 +111,11 @@ impl<'a, K: Key> InternalPageAccessor<'a, K> {
             INTERNAL,
             "InternalPageAccessor: page type byte is not INTERNAL"
         );
+        let num_keys = read_u16(data, OFF_INT_NUM_KEYS);
         Self {
             data,
+            num_keys,
+            key_data_base: int_key_data_base(num_keys as usize),
             _key: PhantomData,
         }
     }
@@ -124,7 +129,7 @@ impl<'a, K: Key> InternalPageAccessor<'a, K> {
     }
 
     pub fn num_keys(&self) -> u16 {
-        read_u16(self.data, OFF_INT_NUM_KEYS)
+        self.num_keys
     }
 
     /// Returns the right sibling page ID, or `None` if this is the rightmost
@@ -171,7 +176,7 @@ impl<'a, K: Key> InternalPageAccessor<'a, K> {
     /// separator key that is strictly greater than `search_key`, which is the
     /// correct subtree to follow.
     pub fn find_child(&self, search_key: &K::SelfType<'_>) -> (usize, PageId) {
-        let n = self.num_keys() as usize;
+        let n = self.num_keys as usize;
         let mut low = 0usize;
         let mut high = n;
         let search_bytes = K::as_bytes(search_key);
@@ -212,19 +217,18 @@ impl<'a, K: Key> InternalPageAccessor<'a, K> {
     /// Raw bytes for `key[i]`. Lifetime `'a` lets `key_at` pass the slice
     /// directly to `K::from_bytes` without a copy.
     fn key_bytes_at(&self, i: usize) -> &'a [u8] {
-        let n = self.num_keys() as usize;
-        let base = int_key_data_base(n);
+        let n = self.num_keys as usize;
         let start = if i == 0 {
             0
         } else {
             read_u32(self.data, int_key_end_offset(n, i - 1)) as usize
         };
         let end = read_u32(self.data, int_key_end_offset(n, i)) as usize;
-        &self.data[base + start..base + end]
+        &self.data[self.key_data_base + start..self.key_data_base + end]
     }
 
     fn used_bytes(&self) -> usize {
-        let n = self.num_keys() as usize;
+        let n = self.num_keys as usize;
         let key_data_size = if n == 0 {
             0
         } else {

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -125,6 +125,8 @@ fn rec_total_size(key_len: usize, val_len: usize) -> usize {
 /// accessor itself.
 pub struct LeafPageAccessor<'a, K: Key, V: Value> {
     data: &'a [u8],
+    slot_base: usize,
+    num_pairs: u16,
     _key: PhantomData<K>,
     _val: PhantomData<V>,
 }
@@ -140,8 +142,12 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
             LEAF,
             "LeafPageAccessor: page type byte is not LEAF"
         );
+        let high_key_len = read_u16(data, OFF_LEAF_HIGH_KEY_LEN) as usize;
+        let num_pairs = read_u16(data, OFF_LEAF_SLOT_COUNT);
         Self {
             data,
+            slot_base: slot_base(high_key_len),
+            num_pairs,
             _key: PhantomData,
             _val: PhantomData,
         }
@@ -158,7 +164,7 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
     }
 
     pub fn num_pairs(&self) -> u16 {
-        read_u16(self.data, OFF_LEAF_SLOT_COUNT)
+        self.num_pairs
     }
 
     /// Previous leaf in the doubly-linked leaf chain, or `None` if this is the
@@ -229,14 +235,13 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
         if n == 0 {
             return true;
         }
-        let hkl = self.high_key_len() as usize;
         let mut live = 0usize;
         for i in 0..n {
             if !self.is_deleted(i) {
                 live += self.slot_rec_size(i) + SLOT_SIZE;
             }
         }
-        live * 2 < (PAGE_SIZE - slot_base(hkl))
+        live * 2 < (PAGE_SIZE - self.slot_base)
     }
 
     // ── Binary search ─────────────────────────────────────────────────────────
@@ -309,13 +314,11 @@ impl<'a, K: Key, V: Value> LeafPageAccessor<'a, K, V> {
     // ── Private helpers ───────────────────────────────────────────────────────
 
     fn slot_rec_base(&self, i: usize) -> usize {
-        let hkl = self.high_key_len() as usize;
-        read_u16(self.data, slot_offset_at(hkl, i)) as usize
+        read_u16(self.data, self.slot_base + i * SLOT_SIZE) as usize
     }
 
     pub(crate) fn slot_rec_size(&self, i: usize) -> usize {
-        let hkl = self.high_key_len() as usize;
-        read_u16(self.data, slot_offset_at(hkl, i) + 2) as usize
+        read_u16(self.data, self.slot_base + i * SLOT_SIZE + 2) as usize
     }
 
     fn key_bytes_at(&self, i: usize) -> &'a [u8] {


### PR DESCRIPTION
## Summary
Optimizes B+tree accessor by caching repeatedly read header values upon initialization, hence reducing redundant memory reads during operations like binary searching.

## Changes
- Added memory caching for key metadata (like `num_keys` and `slot_base`) when reading B-Tree pages.
- Updated the search functions to use these cached values instead of continuously re-reading raw bytes from the page buffer. 
- Avoided doing the same math over and over again while searching for records.

## Related Issue
Closes #68 

## Any design changes?
None

## Checklist
- [x] Tests added/updated
- [ ] Docs updated
- [x] No breaking changes