### PR TITLE
fix: snapshot isolation violation in Snapshot::is_committed (non-repeatable read)

### DIFF
--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -129,22 +129,20 @@ impl Snapshot {
     /// - Its ID is between `xmin` and `xmax` AND not in the active list.
     pub fn is_committed(&self, txn_id: u64, tm: &TransactionManager) -> bool {
         if txn_id == 0 {
-            return true; // txn_id 0 is the "auto" transaction, always committed
+            return true; // the "auto" transaction is always committed
         }
-        if tm.is_aborted(txn_id) {
-            return false;
-        }
-        if tm.is_committed(txn_id) {
-            return true;
-        }
-        if txn_id < self.xmin {
-            return true; // finished before snapshot
-        }
+        // Snapshot bounds take precedence over the live CLOG: a txn that was
+        // unborn or in-flight when this snapshot was taken must never become
+        // visible to it later, or reads stop being repeatable.
         if txn_id >= self.xmax {
-            return false; // not yet started
+            return false; // started after the snapshot
         }
-        // Between xmin and xmax: committed if NOT in active list
-        !self.active.contains(&txn_id)
+        if self.active.contains(&txn_id) {
+            return false; // in-flight when the snapshot was taken
+        }
+        // Settled before the snapshot (below xmax, not active) → committed
+        // unless it aborted (presumed commit).
+        !tm.is_aborted(txn_id)
     }
 
     /// Is the given transaction still in-progress from this snapshot's
@@ -298,6 +296,25 @@ mod tests {
         let s = snap(10, 20, &[12, 15]);
         // xmin=12 in active list → not committed → invisible
         assert!(!is_vis(12, 0, &s));
+    }
+
+    #[test]
+    fn active_at_snapshot_stays_invisible_after_commit() {
+        // Snapshot taken while txn 12 was in-flight (12 ∈ active set).
+        let s = snap(10, 20, &[12, 15]);
+        let tm = TransactionManager::new();
+
+        // While 12 is active, its writes are invisible.
+        assert!(!is_visible(12, 0, &s, &tm));
+
+        // Snapshot isolation: a txn that was active when the snapshot was taken
+        // must STAY invisible to this snapshot even after it commits — otherwise
+        // the reader gets a non-repeatable read (the row appears mid-txn).
+        tm.mark_committed(12);
+        assert!(
+            !is_visible(12, 0, &s, &tm),
+            "txn active at snapshot time must stay invisible after it commits"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Fix snapshot isolation violation in `Snapshot::is_committed` (non-repeatable read)

### Summary
A transaction could see the writes of another transaction that was **in-flight when its snapshot was taken**, as soon as that other transaction committed — and even of transactions that started entirely **after** its snapshot. This breaks snapshot isolation: reads are not repeatable, and the snapshot is not stable for the transaction's lifetime.

### Impact
- **Non-repeatable read:** a reader gets a different answer for the same key before vs. after a concurrent writer commits.
- **Visibility leak:** a reader can observe transactions that began after its own snapshot.
- Net effect: visibility drifted toward *read-committed* instead of the intended *snapshot isolation* (the doc comments state only "*new* snapshots" should see a txn's writes).

### Root cause
`Snapshot::is_committed` consulted the **global, live CLOG** *before* the snapshot's own bounds:

```rust
if tm.is_aborted(txn_id) { return false; }
if tm.is_committed(txn_id) { return true; }   // <-- live CLOG checked first
if txn_id < self.xmin { return true; }
if txn_id >= self.xmax { return false; }      // snapshot bounds — reached too late
!self.active.contains(&txn_id)                 // snapshot active set — reached too late
```

The CLOG reflects "as of now"; a snapshot must answer "as of `begin()`." Because the `is_committed` short-circuit ran first, any txn the CLOG had marked `Committed` returned `true`, bypassing the snapshot's `xmax` bound and `active` set. With no CLOG truncation today, committed txns stay `Committed` indefinitely, so this fired for any overlapping committed transaction.

### Fix
Make the snapshot bounds authoritative; consult the CLOG only for the abort case of txns already settled before the snapshot (presumed commit):

```rust
if txn_id == 0 { return true; }                     // auto txn
if txn_id >= self.xmax { return false; }            // started after the snapshot
if self.active.contains(&txn_id) { return false; }  // in-flight at the snapshot
!tm.is_aborted(txn_id)                              // settled before snapshot → committed unless aborted
```

The `txn_id < xmin` shortcut is subsumed: a txn below `xmin` is `< xmax` and (since `xmin = min(active)`) not in `active`, so it falls through to the same `!is_aborted` result.

### Reproduction / test
Added `active_at_snapshot_stays_invisible_after_commit`: builds a snapshot with txn `12` in its `active` set, then `mark_committed(12)`, and asserts the tuple stays invisible. **Fails on the old code, passes on the fix.** The existing visibility tests missed this because their helpers use a fresh, empty `TransactionManager`, so the CLOG never contradicted the snapshot.

### Validation
`cargo test` — db-core (38) and storage (94) pass, clippy clean. No behavior change except the buggy case.
