### PR TITLE
Feature: Add Recovery manager and redo-only pass

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -13,6 +13,7 @@ use storage::buffer_pool::BufferPoolManager;
 use storage::disk::DiskManager;
 use storage::index::BTreeIndex;
 use storage::page::PAGE_SIZE;
+use storage::recovery::RecoveryManager;
 use storage::wal::Wal;
 
 use crate::txn::TxnHandle;
@@ -87,11 +88,13 @@ where
             Arc::clone(&wal),
         ));
         let transaction_manager = Arc::new(TransactionManager::new());
-        // recovery runs HERE — after the pool exists, before the index opens:
-        // read checkpoint from superblock → seed CLOG from pinned_aborted[] →
-        // replay WAL from redo_point → mark crash victims Aborted →
-        // inject next_txn_id / next_page_id watermarks (from_recovered)
-        // index reads the root page id from the page-0 superblock
+        let recovery = RecoveryManager::new(
+            Arc::clone(&buffer_pool),
+            path.join("wal.log"),
+            Arc::clone(&transaction_manager),
+        );
+        recovery.recover::<K,V>()?;
+
         let index = Arc::new(BTreeIndex::open(
             Arc::clone(&buffer_pool),
             Arc::clone(&wal),

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -93,7 +93,7 @@ where
             path.join("wal.log"),
             Arc::clone(&transaction_manager),
         );
-        recovery.recover::<K,V>()?;
+        recovery.recover::<K, V>()?;
 
         let index = Arc::new(BTreeIndex::open(
             Arc::clone(&buffer_pool),

--- a/crates/engine/tests/lifecycle.rs
+++ b/crates/engine/tests/lifecycle.rs
@@ -33,9 +33,6 @@ fn open_without_database_fails_with_not_found() {
 }
 
 #[test]
-#[ignore = "durability across restart is not built yet: committed pages live only \
-in the buffer pool until eviction/checkpoint/close-flush exists (I-9/I-13). \
-Un-ignore when close() flushes dirty pages or recovery lands."]
 fn reopen_sees_committed_data() {
     let dir = TempDir::new().unwrap();
     {

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -2,6 +2,7 @@ use crate::buffer_pool::shard::{BufferPoolShard, PageReadGuard, PageWriteGuard};
 use crate::disk::DiskManager;
 use crate::wal::Wal;
 use common::{BufferPoolError, MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
+use std::cmp::max;
 use std::sync::{Arc, Mutex};
 
 pub type Result<T> = std::result::Result<T, BufferPoolError>;
@@ -217,5 +218,52 @@ impl BufferPoolManager {
     /// * Returns [`BufferPoolError::InternalError`] if a disk I/O error occurs.
     pub fn delete_page(&self, page_id: u64) -> Result<()> {
         self.get_shard(page_id).delete_page(page_id)
+    }
+
+    pub fn ensure_page(&self, page_id: u64) -> Result<PageWriteGuard<'_>> {
+        let shard = self.get_shard(page_id);
+        let (frame_id, needs_load) = shard.acquire_frame(page_id)?;
+        let mut data = shard.pages[frame_id].write().unwrap();
+        if needs_load {
+            let num_pages = shard.disk_manager.num_pages()?;
+            if num_pages > page_id {
+                let load = shard
+                    .disk_manager
+                    .read_page(page_id, data.0.as_mut())
+                    .map_err(BufferPoolError::from)
+                    .and_then(|()| {
+                        crate::page::verify_checksum(&data[..]).map_err(|(expected, actual)| {
+                            BufferPoolError::PageCorruption {
+                                page_id,
+                                expected,
+                                actual,
+                            }
+                        })
+                    });
+                match load {
+                    // Still holding `data` (page write lock) while finish_load takes
+                    // the inner lock — page→inner order is deadlock-free.
+                    Ok(()) => shard.finish_load(page_id, frame_id, true),
+                    Err(e) => {
+                        drop(data);
+                        shard.finish_load(page_id, frame_id, false);
+                        return Err(e);
+                    }
+                }
+            } else {
+                data.fill(0);
+                shard.finish_load(page_id, frame_id, true);
+            }
+        }
+        {
+            let mut id = self.next_page_id.lock().unwrap();
+            *id = max(*id, page_id + 1);
+        }
+        Ok(PageWriteGuard {
+            shard,
+            page_id,
+            guard: Some(data),
+            dirty: false,
+        })
     }
 }

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -596,21 +596,21 @@ fn insert_logs_record_stamps_page_lsn_and_gate_flushes() {
     let (index, root) =
         BTreeIndex::<&'static [u8], &'static [u8]>::create(pool.clone(), wal.clone()).unwrap();
 
-    // `create` logs nothing, so the LSN counter starts at 0.
-    assert_eq!(wal.lock().unwrap().next_lsn, 0);
+    // `create` logs nothing, so the LSN counter starts at 1 (LSN 0 reserved).
+    assert_eq!(wal.lock().unwrap().next_lsn, 1);
 
-    // Two in-place inserts on the same leaf → two Insert records (LSN 0, 1).
+    // Two in-place inserts on the same leaf → two Insert records (LSN 1, 2).
     index.insert(&(&b"a"[..]), &(&b"1"[..]), &auto()).unwrap();
     index.insert(&(&b"b"[..]), &(&b"2"[..]), &auto()).unwrap();
     assert_eq!(
         wal.lock().unwrap().next_lsn,
-        2,
+        3,
         "each insert appends a record"
     );
 
     // The leaf page must carry the latest insert's LSN (set_lsn under the latch).
     let leaf = pool.fetch_page(root).unwrap();
-    assert_eq!(crate::page::page_lsn(&leaf[..]), 1, "page LSN stamped");
+    assert_eq!(crate::page::page_lsn(&leaf[..]), 2, "page LSN stamped");
     drop(leaf);
 
     // Flushing the dirty leaf must drive the WAL durable through that page LSN
@@ -618,7 +618,7 @@ fn insert_logs_record_stamps_page_lsn_and_gate_flushes() {
     pool.flush_all_pages().unwrap();
     assert_eq!(
         wal.lock().unwrap().flushed_lsn,
-        Some(1),
+        Some(2),
         "gate flushed WAL to page LSN"
     );
 }
@@ -639,7 +639,7 @@ fn delete_emits_one_setxmax() {
     index.insert(&key, &val, &auto()).unwrap();
 
     let n = wal.lock().unwrap().next_lsn;
-    assert_eq!(n, 1);
+    assert_eq!(n, 2);
     index.delete(&key, &txn).unwrap();
     assert!(
         wal.lock().unwrap().next_lsn == n + 1,
@@ -648,7 +648,7 @@ fn delete_emits_one_setxmax() {
 
     // The leaf page must carry the latest delete's LSN (set_lsn under the latch).
     let leaf = pool.fetch_page(root).unwrap();
-    assert_eq!(crate::page::page_lsn(&leaf[..]), 1, "page LSN stamped");
+    assert_eq!(crate::page::page_lsn(&leaf[..]), 2, "page LSN stamped");
     drop(leaf);
 
     // Flushing the dirty leaf must drive the WAL durable through that page LSN
@@ -683,7 +683,7 @@ fn update_emits_setxmax_then_insert_in_lsn_order() {
     index.insert(&key, &val, &auto()).unwrap();
 
     let n = wal.lock().unwrap().next_lsn;
-    assert_eq!(n, 1);
+    assert_eq!(n, 2);
 
     index.update(&key, &new_val, &txn).unwrap();
     assert!(
@@ -700,12 +700,12 @@ fn update_emits_setxmax_then_insert_in_lsn_order() {
     let mut it = WalIterator::new(dir.path().join("wal.log")).unwrap();
     it.next_record();
 
-    let rec = it.next_record().unwrap().unwrap(); // SetXmax (LSN 1)
+    let rec = it.next_record().unwrap().unwrap(); // SetXmax (LSN 2)
     assert_eq!(rec.entry_type, WalRecordType::SetXMax);
     assert_eq!(rec.txn_id, txn.txn_id);
     let xmax_lsn = rec.lsn;
 
-    let rec = it.next_record().unwrap().unwrap(); // Insert (LSN 2)
+    let rec = it.next_record().unwrap().unwrap(); // Insert (LSN 3)
     assert_eq!(rec.entry_type, WalRecordType::Insert);
     let ins_lsn = rec.lsn;
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -2,4 +2,5 @@ pub mod buffer_pool;
 pub mod disk;
 pub mod index;
 pub mod page;
+pub mod recovery;
 pub mod wal;

--- a/crates/storage/src/recovery/mod.rs
+++ b/crates/storage/src/recovery/mod.rs
@@ -32,9 +32,6 @@ impl RecoveryManager {
 
     /// Replay the WAL in LSN order: rebuild the CLOG, mark crash victims, restore
     /// the txn-id allocator, and redo page changes. Idempotent (LSN-gated).
-    ///
-    /// Generic over the index's `(K, V)` — physiological redo drives the typed
-    /// page mutators. Assumes a single index per WAL.
     pub fn recover<K: Key, V: Value>(&self) -> Result<()> {
         let mut iter = WalIterator::new(&self.wal_path).map_err(WalError::Io)?;
 
@@ -58,7 +55,7 @@ impl RecoveryManager {
         }
 
         // Crash victims: a txn that did work but never settled was in-flight at
-        // the crash → abort (redo-only, no undo).
+        // the crash
         for &txn_id in &seen {
             if !self.tm.is_committed(txn_id) && !self.tm.is_aborted(txn_id) {
                 self.tm.mark_aborted(txn_id);
@@ -145,8 +142,7 @@ impl RecoveryManager {
                 crate::page::meta::set_root(page, root_page_id);
             }
             _ => {
-                // No physiological apply for this (type, block). FPI blocks never
-                // reach here; v2 records aren't emitted yet.
+                // No physiological apply for this (type, block). FPI blocks never reach here.
             }
         }
         Ok(())

--- a/crates/storage/src/recovery/mod.rs
+++ b/crates/storage/src/recovery/mod.rs
@@ -1,0 +1,154 @@
+//! Crash recovery: replays the WAL at startup to rebuild the CLOG and redo
+//! page changes, run before the engine serves queries. Redo-only (no undo).
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+
+use common::{IndexError, Key, Value, WalError};
+use db_core::transaction_manager::TransactionManager;
+
+use crate::buffer_pool::BufferPoolManager;
+use crate::page::{InternalPageMutator, LeafPageMutator};
+use crate::wal::{WalIterator, WalRecord, WalRecordType};
+
+pub type Result<T> = std::result::Result<T, IndexError>;
+
+pub struct RecoveryManager {
+    pool: Arc<BufferPoolManager>,
+    wal_path: PathBuf,
+    tm: Arc<TransactionManager>,
+}
+
+impl RecoveryManager {
+    pub fn new(
+        pool: Arc<BufferPoolManager>,
+        wal_path: PathBuf,
+        tm: Arc<TransactionManager>,
+    ) -> Self {
+        Self { pool, wal_path, tm }
+    }
+
+    /// Replay the WAL in LSN order: rebuild the CLOG, mark crash victims, restore
+    /// the txn-id allocator, and redo page changes. Idempotent (LSN-gated).
+    ///
+    /// Generic over the index's `(K, V)` — physiological redo drives the typed
+    /// page mutators. Assumes a single index per WAL.
+    pub fn recover<K: Key, V: Value>(&self) -> Result<()> {
+        let mut iter = WalIterator::new(&self.wal_path).map_err(WalError::Io)?;
+
+        // Every txn that did work, and the highest id seen.
+        let mut seen: HashSet<u64> = HashSet::new();
+        let mut max_txn = 0u64;
+
+        while let Some(r) = iter.next_record() {
+            let record = r?;
+
+            if record.txn_id != 0 {
+                seen.insert(record.txn_id);
+                max_txn = max_txn.max(record.txn_id);
+            }
+
+            match record.entry_type {
+                WalRecordType::Commit => self.tm.mark_committed(record.txn_id),
+                WalRecordType::Abort => self.tm.mark_aborted(record.txn_id),
+                _ => self.redo_record::<K, V>(&record)?,
+            }
+        }
+
+        // Crash victims: a txn that did work but never settled was in-flight at
+        // the crash → abort (redo-only, no undo).
+        for &txn_id in &seen {
+            if !self.tm.is_committed(txn_id) && !self.tm.is_aborted(txn_id) {
+                self.tm.mark_aborted(txn_id);
+            }
+        }
+
+        // Restore the id allocator so new txns can't reuse a recovered id.
+        self.tm.next_txn_id.fetch_max(max_txn + 1, Ordering::AcqRel);
+
+        self.pool.flush_all_pages()?;
+        Ok(())
+    }
+
+    /// Replay one page-touching record: per block, LSN-gate then apply (FPI
+    /// stamp or physiological), and re-stamp the page LSN.
+    fn redo_record<K: Key, V: Value>(&self, record: &WalRecord) -> Result<()> {
+        for (i, block) in record.blocks.iter().enumerate() {
+            let mut guard = self.pool.ensure_page(block.page_id)?;
+            if record.lsn <= crate::page::page_lsn(&guard[..]) {
+                continue; // already durable — idempotent skip
+            }
+            match block.fpi {
+                Some(fpi) => {
+                    let dst: &mut [u8] = &mut guard[..];
+                    dst.copy_from_slice(fpi);
+                }
+                None => Self::apply_data::<K, V>(record.entry_type, i, block.data, &mut guard[..])?,
+            }
+            crate::page::set_lsn(&mut guard[..], record.lsn);
+        }
+        Ok(())
+    }
+
+    /// Physiological apply for a DATA / flag-only block, dispatched on
+    /// `(record type, block index)`. Payload layouts mirror `wal.rs::log_*`.
+    fn apply_data<K: Key, V: Value>(
+        entry_type: WalRecordType,
+        block_idx: usize,
+        data: Option<&[u8]>,
+        page: &mut [u8],
+    ) -> Result<()> {
+        match (entry_type, block_idx) {
+            (WalRecordType::Insert, 0) => {
+                // slot u16, key_len u16, val_len u16, xmin u64, key, val
+                let d = data.expect("Insert record missing data block");
+                let slot = u16::from_le_bytes(d[0..2].try_into().unwrap()) as usize;
+                let key_len = u16::from_le_bytes(d[2..4].try_into().unwrap()) as usize;
+                let val_len = u16::from_le_bytes(d[4..6].try_into().unwrap()) as usize;
+                let xmin = u64::from_le_bytes(d[6..14].try_into().unwrap());
+                let key = &d[14..14 + key_len];
+                let val = &d[14 + key_len..14 + key_len + val_len];
+                let mut m = LeafPageMutator::<K, V>::new(page);
+                m.insert(slot, &K::from_bytes(key), &V::from_bytes(val))?;
+                m.set_xmin(slot, xmin);
+            }
+            (WalRecordType::SetXMax, 0) => {
+                // slot u16, xmax u64
+                let d = data.expect("SetXmax record missing data block");
+                let slot = u16::from_le_bytes(d[0..2].try_into().unwrap()) as usize;
+                let xmax = u64::from_le_bytes(d[2..10].try_into().unwrap());
+                LeafPageMutator::<K, V>::new(page).set_xmax(slot, xmax);
+            }
+            (WalRecordType::InsertDownLink, 0) => {
+                // at_index u16, sep_len u16, right_child u64, sep_key
+                let d = data.expect("InsertDownlink parent missing data block");
+                let at_index = u16::from_le_bytes(d[0..2].try_into().unwrap()) as usize;
+                let sep_len = u16::from_le_bytes(d[2..4].try_into().unwrap()) as usize;
+                let right_child = u64::from_le_bytes(d[4..12].try_into().unwrap());
+                let sep_key = &d[12..12 + sep_len];
+                InternalPageMutator::<K>::new(page).insert_key_and_right_child(
+                    at_index,
+                    &K::from_bytes(sep_key),
+                    right_child,
+                )?;
+            }
+            (WalRecordType::InsertDownLink, 1) => {
+                // child block: clear INCOMPLETE_SPLIT (option A).
+                crate::page::clear_incomplete_split(page);
+            }
+            (WalRecordType::NewRoot, 1) => {
+                // page-0 block: root_page_id u64
+                let d = data.expect("NewRoot page-0 missing data block");
+                let root_page_id = u64::from_le_bytes(d[0..8].try_into().unwrap());
+                crate::page::meta::set_root(page, root_page_id);
+            }
+            _ => {
+                // No physiological apply for this (type, block). FPI blocks never
+                // reach here; v2 records aren't emitted yet.
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -313,7 +313,10 @@ impl Wal {
     pub fn new(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
 
-        let mut next_lsn = 0;
+        // LSN 0 is reserved as the "null" LSN (an untouched page reads page_lsn
+        // == 0), so real records start at 1 — otherwise redo can't distinguish
+        // "no record applied" from "the first record applied".
+        let mut next_lsn = 1;
         let mut flushed_lsn = None;
 
         match OpenOptions::new().read(true).open(path) {
@@ -706,7 +709,7 @@ mod tests {
 
         {
             let entry1 = iter.next_record().unwrap()?;
-            assert_eq!(entry1.lsn, 0);
+            assert_eq!(entry1.lsn, 1);
             assert_eq!(entry1.entry_type, WalRecordType::Insert);
             assert_eq!(entry1.txn_id, 42);
             assert_eq!(entry1.blocks.len(), 1);
@@ -716,7 +719,7 @@ mod tests {
 
         {
             let entry2 = iter.next_record().unwrap()?;
-            assert_eq!(entry2.lsn, 1);
+            assert_eq!(entry2.lsn, 2);
             assert_eq!(entry2.entry_type, WalRecordType::Commit);
             assert_eq!(entry2.txn_id, 43);
             assert_eq!(entry2.blocks.len(), 1);
@@ -755,7 +758,7 @@ mod tests {
         }
 
         let wal = Wal::new(&wal_path)?;
-        assert_eq!(wal.next_lsn, 2);
+        assert_eq!(wal.next_lsn, 3);
         Ok(())
     }
 
@@ -768,8 +771,8 @@ mod tests {
         let first = wal.append(WalRecordType::Insert, 42, &[], None)?;
         let second = wal.append(WalRecordType::Commit, 42, &[], None)?;
 
-        assert_eq!(first, 0);
-        assert_eq!(second, 1);
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
         assert_eq!(wal.flushed_lsn, None);
 
         wal.flush_up_to(first)?;
@@ -816,7 +819,7 @@ mod tests {
         file.sync_all()?;
 
         let wal = Wal::new(&wal_path)?;
-        assert_eq!(wal.next_lsn, 1);
+        assert_eq!(wal.next_lsn, 2);
 
         let new_file_len = file.metadata()?.len();
         assert!(new_file_len < file_len);
@@ -856,7 +859,7 @@ mod tests {
 
         let result = Wal::new(&wal_path);
         match result {
-            Err(WalError::ChecksumMismatch { lsn, .. }) => assert_eq!(lsn, 0),
+            Err(WalError::ChecksumMismatch { lsn, .. }) => assert_eq!(lsn, 1),
             Err(e) => panic!("Expected ChecksumMismatch error, got error: {:?}", e),
             Ok(_) => panic!("Expected ChecksumMismatch error, got Ok(_)"),
         }
@@ -878,7 +881,7 @@ mod tests {
                 data: Some(&[1, 2, 3, 4]),
             };
             wal.append(WalRecordType::Insert, 42, &[block1], None)?;
-            wal.flush_up_to(0)?;
+            wal.flush_up_to(1)?;
         }
 
         let mut file = OpenOptions::new()


### PR DESCRIPTION
## Summary
adds redo-only pass and initial implementation of recovery manager without any checkpoints 

## Changes
- added recovery/mod.rs 
- changed wal.rs initial lsn from 0 to 1 to prevent collisions and using 0 as a sentinel. 

## Related Issue
Closes #11 #38 

## Any design changes?
no changes

## Checklist
- [ ] Tests added/updated
- [x] Docs updated
- [x] No breaking changes

## Did not currently add any test suites 
depends on #47 and a future crash-harness that will inject crash at random points and check if recovery works. 