### PR TITLE
Added settled_status a source of truth for TransactionStatus

### DIFF
--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -473,4 +473,29 @@ mod tests {
         // other.txn_id != txn.txn_id, other is active → invisible
         assert!(!txn.is_visible(other.txn_id, 0));
     }
+    #[test]
+    fn vacuumable_after_committed_deleter_clog_entry_truncated() {
+        let tm = Arc::new(TransactionManager::new());
+
+        // Begin a transaction that will act as the deleter (xmax).
+        let deleter = make_txn(&tm);
+        let deleter_id = deleter.txn_id;
+
+        // Commit the deleter — its entry is now in the CLOG as Committed.
+        tm.mark_committed(deleter_id);
+
+        // --- Simulate CLOG truncation ---
+        // Begin a new transaction so global_xmin advances past the deleter.
+        let _newer_txn = tm.begin();
+
+        // Truncate the CLOG up to global_xmin, dropping the deleter's entry.
+        let horizon = tm.global_xmin();
+        tm.truncate_clog(horizon);
+
+        // The row: created by some committed transaction
+        let xmin = 1;
+        let xmax = deleter_id;
+
+        assert!(is_vacuumable(xmin, xmax, horizon, &tm));
+    }
 }

--- a/crates/db-core/src/transaction.rs
+++ b/crates/db-core/src/transaction.rs
@@ -21,7 +21,7 @@
 //! by an active transaction, the current transaction loses (returns
 //! `WriteConflict`). The first transaction to set `xmax` wins.
 
-use crate::transaction_manager::TransactionManager;
+use crate::transaction_manager::{TransactionManager, TransactionStatus};
 use std::sync::Arc;
 
 /// A transaction's identity and its point-in-time view of the database.
@@ -217,12 +217,12 @@ pub fn is_visible(rec_xmin: u64, rec_xmax: u64, snap: &Snapshot, tm: &Transactio
 ///    - AND older than the global horizon (no active txn can see the old state).
 pub fn is_vacuumable(xmin: u64, xmax: u64, horizon: u64, tm: &TransactionManager) -> bool {
     // 1. Aborted records are always dead.
-    if tm.is_aborted(xmin) {
+    if tm.settled_status(xmin) == TransactionStatus::Aborted {
         return true;
     }
 
     // 2. If not deleted (xmax=0) or the deleter hasn't committed yet, it's live.
-    if xmax == 0 || !tm.is_committed(xmax) {
+    if xmax == 0 || tm.settled_status(xmax) != TransactionStatus::Committed {
         return false;
     }
 

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -253,6 +253,18 @@ impl TransactionManager {
             active: active.iter().cloned().collect(),
         }
     }
+
+    pub fn settled_status(&self, txn_id: u64) -> TransactionStatus {
+        if self.is_committed(txn_id) {
+            TransactionStatus::Committed
+        } else if self.is_aborted(txn_id) {
+            TransactionStatus::Aborted
+        } else if txn_id < self.global_xmin(){
+            TransactionStatus::Committed
+        } else {
+            TransactionStatus::Active
+        }
+    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -259,7 +259,7 @@ impl TransactionManager {
             TransactionStatus::Committed
         } else if self.is_aborted(txn_id) {
             TransactionStatus::Aborted
-        } else if txn_id < self.global_xmin(){
+        } else if txn_id < self.global_xmin() {
             TransactionStatus::Committed
         } else {
             TransactionStatus::Active


### PR DESCRIPTION
## Summary
Added settled_status a source of truth for TransactionStatus

## Changes
- settled_status method for TransactionManager to aggregate the methods is_committed(), is_aborted etc to give the TransactionStatus
- is_vacuumable now routes to settled_status

## Related Issue
Closes #85 

## Any design changes?
None
## Checklist
- [x] Tests added/updated
- [ ] Docs updated
- [x] No breaking changes