### PR TITLE
test: Add proptests for Index pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,10 +201,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
 
 [[package]]
 name = "getrandom"
@@ -193,7 +232,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -280,6 +319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +342,15 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 [[package]]
 name = "parser"
 version = "0.1.0"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -315,6 +372,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,9 +407,59 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -340,6 +472,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -401,6 +545,7 @@ dependencies = [
  "common",
  "crc32fast",
  "db-core",
+ "proptest",
  "tempfile",
 ]
 
@@ -428,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -455,6 +600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +622,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasip2"
@@ -625,6 +785,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -9,3 +9,4 @@ crc32fast = "1.5.0"
 db-core.workspace = true
 [dev-dependencies]
 tempfile = "3.10.1"
+proptest = "1"

--- a/crates/storage/src/page/internal.rs
+++ b/crates/storage/src/page/internal.rs
@@ -778,3 +778,338 @@ mod tests {
         b.push_key_and_right_child(&(&[1][..]), 2);
     }
 }
+
+// ── Property-based tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::page::{PAGE_SIZE, PageBuffer};
+    use proptest::prelude::*;
+    use std::cmp::Ordering;
+
+    // Helper functions to check if internal pages are valid
+    // Internal pages are more complex than leaf pages - they have 3 sections!
+
+    /// Check all the structural invariants for an internal page
+    /// Internal pages store keys and child page pointers
+    fn check_internal_structural_invariants(page: &[u8]) -> Result<(), String> {
+        // First make sure this is actually an internal page
+        let page_type = read_u8(page, OFF_PAGE_TYPE);
+        if page_type != INTERNAL {
+            return Err(format!(
+                "page_type: expected {} (INTERNAL), got {}",
+                INTERNAL, page_type
+            ));
+        }
+
+        let num_keys = read_u16(page, OFF_INT_NUM_KEYS) as usize;
+        let high_key_len = read_u16(page, OFF_INT_HIGH_KEY_LEN) as usize;
+
+        // Check that all the child pointers fit in the page
+        // We have num_keys + 1 children (Lehman-Yao B+tree property)
+        let children_end = INT_HEADER_SIZE + (num_keys + 1) * 8;
+        if children_end > PAGE_SIZE {
+            return Err(format!(
+                "children_overflow: {} children need {} bytes, PAGE_SIZE = {}",
+                num_keys + 1,
+                children_end,
+                PAGE_SIZE
+            ));
+        }
+
+        // Make sure all child pointers are valid (non-zero)
+        // Zero is used as "no page" in other places, but here every child must be real
+        for i in 0..=num_keys {
+            let child = read_u64(page, int_child_offset(i));
+            if child == 0 {
+                return Err(format!(
+                    "child_{}_zero: child page ID is 0 (should be a valid page ID)",
+                    i
+                ));
+            }
+        }
+
+        // Check that the key-end offsets are in increasing order
+        // These tell us where each key starts and ends in Section C
+        if num_keys > 0 {
+            let mut prev_end = 0u32;
+            for i in 0..num_keys {
+                let key_end = read_u32(page, int_key_end_offset(num_keys, i));
+                if key_end <= prev_end {
+                    return Err(format!(
+                        "key_end_not_monotonic: key_end[{}] ({}) <= key_end[{}] ({})",
+                        i,
+                        key_end,
+                        if i == 0 { 0 } else { i - 1 },
+                        prev_end
+                    ));
+                }
+                prev_end = key_end;
+            }
+
+            // Make sure the key data doesn't overlap with the high key
+            // High key is stored at the END of the page
+            let total_key_data = prev_end as usize;
+            let key_data_start = int_key_data_base(num_keys);
+            let key_data_end = key_data_start + total_key_data;
+            let high_key_start = PAGE_SIZE - high_key_len;
+
+            if key_data_end > high_key_start {
+                return Err(format!(
+                    "key_data_overlap: key data region [{}, {}) overlaps high key region [{}, {})",
+                    key_data_start, key_data_end, high_key_start, PAGE_SIZE
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check that keys are in sorted order on an internal page
+    fn check_internal_key_ordering(page: &[u8]) -> Result<(), String> {
+        type K = &'static [u8];
+
+        let acc = InternalPageAccessor::<K>::new(page);
+        let n = acc.num_keys() as usize;
+
+        // Make sure keys are sorted
+        for i in 0..n.saturating_sub(1) {
+            let k1 = acc.key_at(i);
+            let k2 = acc.key_at(i + 1);
+            if <K as Key>::compare(
+                <K as common::Value>::as_bytes(&k1).as_ref(),
+                <K as common::Value>::as_bytes(&k2).as_ref(),
+            ) != Ordering::Less
+            {
+                return Err(format!(
+                    "keys_not_sorted: key[{}] ({:?}) >= key[{}] ({:?})",
+                    i,
+                    k1,
+                    i + 1,
+                    k2
+                ));
+            }
+        }
+
+        // If there's a high key, make sure all keys are less than it
+        if let Some(hk) = acc.high_key_bytes() {
+            for i in 0..n {
+                let k = acc.key_at(i);
+                if <K as Key>::compare(<K as common::Value>::as_bytes(&k).as_ref(), hk)
+                    != Ordering::Less
+                {
+                    return Err(format!(
+                        "key_exceeds_high_key: key[{}] ({:?}) >= high_key ({:?})",
+                        i, k, hk
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Main checker - calls both structural and ordering checks
+    fn check_internal_all_invariants(page: &[u8]) -> Result<(), String> {
+        check_internal_structural_invariants(page)?;
+        check_internal_key_ordering(page)?;
+        Ok(())
+    }
+
+    // ── Test data generators for internal pages ────────────────────────────────
+
+    type K = &'static [u8];
+
+    /// Generate random keys (same as leaf page tests)
+    fn key_strategy() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(any::<u8>(), 1..=16usize)
+    }
+
+    /// Operations we can do on internal pages
+    #[derive(Debug, Clone)]
+    enum InternalOp {
+        Insert { key: Vec<u8>, child_id: u64 },
+        RemoveLeft { index: usize },
+        RemoveRight { index: usize },
+    }
+
+    fn internal_op_strategy() -> impl Strategy<Value = InternalOp> {
+        prop_oneof![
+            60 => (key_strategy(), 1u64..10000)
+                .prop_map(|(k, c)| InternalOp::Insert { key: k, child_id: c }),
+            20 => (0usize..100)
+                .prop_map(|idx| InternalOp::RemoveLeft { index: idx }),
+            20 => (0usize..100)
+                .prop_map(|idx| InternalOp::RemoveRight { index: idx }),
+        ]
+    }
+
+    /// Sort and deduplicate keys, returning sorted unique keys.
+    fn sort_dedup_keys(mut keys: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
+        keys.sort();
+        keys.dedup();
+        keys
+    }
+
+    // ── Property tests ───────────────────────────────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// Building an internal page from sorted unique keys always produces a valid page.
+        #[test]
+        fn prop_internal_build_valid(
+            keys in prop::collection::vec(key_strategy(), 1..20),
+            first_child in 1u64..1000,
+        ) {
+            let sorted = sort_dedup_keys(keys);
+            let mut buf = PageBuffer::new();
+            let mut builder = InternalPageBuilder::<K>::new(1, buf.memory_mut());
+            builder.push_first_child(first_child);
+
+            // Pre-calculate available space: PAGE_SIZE - header - first_child(8) - high_key(0)
+            let mut used = INT_HEADER_SIZE + 8; // header + first child pointer
+            let mut child_id = first_child + 1;
+            for k in &sorted {
+                // Each key+child costs: 8 (child) + 4 (key_end offset) + key.len() (key data)
+                let cost = 8 + 4 + k.len();
+                if used + cost > PAGE_SIZE {
+                    break;
+                }
+                builder.push_key_and_right_child(&k.as_slice(), child_id);
+                used += cost;
+                child_id += 1;
+            }
+            builder.finish();
+
+            check_internal_all_invariants(buf.memory())
+                .map_err(|e| TestCaseError::fail(format!("after build: {}", e)))?;
+        }
+
+        /// Building with a high key produces a valid page where all keys < high_key.
+        #[test]
+        fn prop_internal_build_with_high_key(
+            keys in prop::collection::vec(key_strategy(), 1..15),
+            first_child in 1u64..1000,
+        ) {
+            let sorted = sort_dedup_keys(keys);
+            let mut buf = PageBuffer::new();
+
+            let high_key = vec![0xFF; 17]; // larger than any 16-byte key
+
+            let mut builder = InternalPageBuilder::<K>::new(1, buf.memory_mut());
+            builder.push_first_child(first_child);
+            builder.set_high_key(&high_key);
+
+            let mut child_id = first_child + 1;
+            for k in &sorted {
+                // Conservative: stop after a few to avoid overflow
+                if child_id > first_child + 10 {
+                    break;
+                }
+                builder.push_key_and_right_child(&k.as_slice(), child_id);
+                child_id += 1;
+            }
+            builder.finish();
+
+            check_internal_all_invariants(buf.memory())
+                .map_err(|e| TestCaseError::fail(format!("after build with high key: {}", e)))?;
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Arbitrary insert/remove sequences on an internal page preserve invariants.
+        #[test]
+        fn prop_internal_op_sequence_maintains_invariants(
+            ops in prop::collection::vec(internal_op_strategy(), 1..20)
+        ) {
+            // Build a minimal internal page: first_child only
+            let mut buf = PageBuffer::new();
+            {
+                let mut builder = InternalPageBuilder::<K>::new(1, buf.memory_mut());
+                builder.push_first_child(1);
+                builder.finish();
+            }
+
+            let mut next_child: u64 = 2;
+
+            for (i, op) in ops.iter().enumerate() {
+                match op {
+                    InternalOp::Insert { key, child_id } => {
+                        let acc = InternalPageAccessor::<K>::new(buf.memory());
+                        if !acc.can_fit(key.len()) {
+                            continue;
+                        }
+                        // Find insert position using binary search
+                        let n = acc.num_keys() as usize;
+                        let mut lo = 0usize;
+                        let mut hi = n;
+                        while lo < hi {
+                            let mid = lo + (hi - lo) / 2;
+                            if <K as Key>::compare(
+                                <K as common::Value>::as_bytes(&acc.key_at(mid)).as_ref(),
+                                key.as_slice(),
+                            ) == Ordering::Greater
+                            {
+                                hi = mid;
+                            } else {
+                                lo = mid + 1;
+                            }
+                        }
+
+                        // Skip if key already exists at this position
+                        if lo > 0 {
+                            let existing = acc.key_at(lo - 1);
+                            if <K as Key>::compare(
+                                <K as common::Value>::as_bytes(&existing).as_ref(),
+                                key.as_slice(),
+                            ) == Ordering::Equal
+                            {
+                                continue;
+                            }
+                        }
+
+                        let child = if *child_id == 0 { next_child } else { *child_id };
+                        next_child = next_child.max(child + 1);
+
+                        drop(acc);
+                        InternalPageMutator::<K>::new(buf.memory_mut())
+                            .insert_key_and_right_child(lo, &key.as_slice(), child)
+                            .unwrap();
+                    }
+                    InternalOp::RemoveLeft { index } => {
+                        let n = InternalPageAccessor::<K>::new(buf.memory())
+                            .num_keys() as usize;
+                        if n == 0 {
+                            continue;
+                        }
+                        let pos = (*index).min(n - 1);
+                        InternalPageMutator::<K>::new(buf.memory_mut())
+                            .remove_key_at(pos, ChildSide::Left);
+                    }
+                    InternalOp::RemoveRight { index } => {
+                        let n = InternalPageAccessor::<K>::new(buf.memory())
+                            .num_keys() as usize;
+                        if n == 0 {
+                            continue;
+                        }
+                        let pos = (*index).min(n - 1);
+                        InternalPageMutator::<K>::new(buf.memory_mut())
+                            .remove_key_at(pos, ChildSide::Right);
+                    }
+                }
+
+                // Check invariants after EVERY operation
+                check_internal_all_invariants(buf.memory()).map_err(|e| {
+                    TestCaseError::fail(format!(
+                        "Invariant violated after op #{} ({:?}): {}",
+                        i, op, e
+                    ))
+                })?;
+            }
+        }
+    }
+}

--- a/crates/storage/src/page/internal.rs
+++ b/crates/storage/src/page/internal.rs
@@ -873,17 +873,17 @@ mod proptests {
         let acc = InternalPageAccessor::<K>::new(page);
         let n = acc.num_keys() as usize;
 
-        // Make sure keys are sorted
+        // Make sure keys are sorted (allow duplicates for MVCC)
         for i in 0..n.saturating_sub(1) {
             let k1 = acc.key_at(i);
             let k2 = acc.key_at(i + 1);
             if <K as Key>::compare(
                 <K as common::Value>::as_bytes(&k1).as_ref(),
                 <K as common::Value>::as_bytes(&k2).as_ref(),
-            ) != Ordering::Less
+            ) == Ordering::Greater
             {
                 return Err(format!(
-                    "keys_not_sorted: key[{}] ({:?}) >= key[{}] ({:?})",
+                    "keys_not_sorted: key[{}] ({:?}) > key[{}] ({:?})",
                     i,
                     k1,
                     i + 1,
@@ -897,7 +897,7 @@ mod proptests {
             for i in 0..n {
                 let k = acc.key_at(i);
                 if <K as Key>::compare(<K as common::Value>::as_bytes(&k).as_ref(), hk)
-                    != Ordering::Less
+                    == Ordering::Greater
                 {
                     return Err(format!(
                         "key_exceeds_high_key: key[{}] ({:?}) >= high_key ({:?})",
@@ -921,9 +921,14 @@ mod proptests {
 
     type K = &'static [u8];
 
-    /// Generate random keys (same as leaf page tests)
+    /// Generate random keys (same as lea`f page tests)
     fn key_strategy() -> impl Strategy<Value = Vec<u8>> {
-        prop::collection::vec(any::<u8>(), 1..=16usize)
+        prop_oneof![
+            // 80% chance: small pool of keys (length 1-2, values 0-3) to ensure duplicates
+            80 => prop::collection::vec(0u8..4u8, 1..=2usize),
+            // 20% chance: completely random keys up to 16 bytes
+            20 => prop::collection::vec(any::<u8>(), 1..=16usize),
+        ]
     }
 
     /// Operations we can do on internal pages
@@ -945,10 +950,9 @@ mod proptests {
         ]
     }
 
-    /// Sort and deduplicate keys, returning sorted unique keys.
-    fn sort_dedup_keys(mut keys: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
+    /// Sort keys, returning sorted keys (allowing duplicates).
+    fn sort_keys(mut keys: Vec<Vec<u8>>) -> Vec<Vec<u8>> {
         keys.sort();
-        keys.dedup();
         keys
     }
 
@@ -963,7 +967,7 @@ mod proptests {
             keys in prop::collection::vec(key_strategy(), 1..20),
             first_child in 1u64..1000,
         ) {
-            let sorted = sort_dedup_keys(keys);
+            let sorted = sort_keys(keys);
             let mut buf = PageBuffer::new();
             let mut builder = InternalPageBuilder::<K>::new(1, buf.memory_mut());
             builder.push_first_child(first_child);
@@ -993,7 +997,7 @@ mod proptests {
             keys in prop::collection::vec(key_strategy(), 1..15),
             first_child in 1u64..1000,
         ) {
-            let sorted = sort_dedup_keys(keys);
+            let sorted = sort_keys(keys);
             let mut buf = PageBuffer::new();
 
             let high_key = vec![0xFF; 17]; // larger than any 16-byte key
@@ -1057,18 +1061,6 @@ mod proptests {
                                 hi = mid;
                             } else {
                                 lo = mid + 1;
-                            }
-                        }
-
-                        // Skip if key already exists at this position
-                        if lo > 0 {
-                            let existing = acc.key_at(lo - 1);
-                            if <K as Key>::compare(
-                                <K as common::Value>::as_bytes(&existing).as_ref(),
-                                key.as_slice(),
-                            ) == Ordering::Equal
-                            {
-                                continue;
                             }
                         }
 

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -1050,11 +1050,14 @@ mod proptests {
     use proptest::prelude::*;
     use std::cmp::Ordering;
 
-    // ── Invariant checkers (raw-byte based) ───────────────────────────────────
+    // Helper functions to check if the page is valid
+    // These read the raw bytes directly instead of using LeafPageAccessor
+    // because we want to test if the accessor itself is working correctly
 
-    /// Structural invariant checker that reads raw bytes directly, avoiding
-    /// circular trust with the `LeafPageAccessor` under test.
+    /// Check all the structural invariants for a leaf page
+    /// Returns Ok(()) if everything is good, Err with a message if something is wrong
     fn check_leaf_structural_invariants(page: &[u8]) -> Result<(), String> {
+        // First check: make sure this is actually a leaf page
         let page_type = read_u8(page, OFF_PAGE_TYPE);
         if page_type != LEAF {
             return Err(format!(
@@ -1063,17 +1066,24 @@ mod proptests {
             ));
         }
 
+        // Read the important fields from the page header
+        // We need these to check if the page layout is correct
         let slot_count = read_u16(page, OFF_LEAF_SLOT_COUNT) as usize;
         let free_start = read_u16(page, OFF_LEAF_FREE_START) as usize;
         let free_end = read_u16(page, OFF_LEAF_FREE_END) as usize;
         let high_key_len = read_u16(page, OFF_LEAF_HIGH_KEY_LEN) as usize;
 
+        // Check that free space pointers make sense
+        // free_start is where the slot directory ends
+        // free_end is where the record data starts
+        // So free_start should be <= free_end
         if free_start > free_end {
             return Err(format!(
                 "space_accounting: free_start ({}) > free_end ({})",
                 free_start, free_end
             ));
         }
+        // Also make sure free_end doesn't go past the end of the page
         if free_end > PAGE_SIZE {
             return Err(format!(
                 "space_accounting: free_end ({}) > PAGE_SIZE ({})",
@@ -1081,6 +1091,8 @@ mod proptests {
             ));
         }
 
+        // Check if free_start is at the right position
+        // It should be at: header + high_key + (number of slots * 4 bytes per slot)
         let expected_free_start = slot_base(high_key_len) + slot_count * SLOT_SIZE;
         if free_start != expected_free_start {
             return Err(format!(
@@ -1089,13 +1101,17 @@ mod proptests {
             ));
         }
 
+        // Now check each individual slot to make sure it's valid
+        // We'll collect all the slot ranges so we can check for overlaps later
         let mut slot_ranges: Vec<(usize, usize, usize)> = Vec::with_capacity(slot_count);
         for i in 0..slot_count {
+            // Calculate where this slot's data is stored
             let slot_off = slot_offset_at(high_key_len, i);
             let rec_base = read_u16(page, slot_off) as usize;
             let rec_size = read_u16(page, slot_off + 2) as usize;
 
-            // rec_base must be at or past free_end
+            // Make sure the record starts at or after free_end
+            // (records grow downward from the end of the page)
             if rec_base < free_end {
                 return Err(format!(
                     "slot_{}_offset: rec_base ({}) < free_end ({})",
@@ -1103,7 +1119,7 @@ mod proptests {
                 ));
             }
 
-            // rec must fit within page
+            // Make sure the record doesn't go past the end of the page
             if rec_base + rec_size > PAGE_SIZE {
                 return Err(format!(
                     "slot_{}_bounds: rec_base ({}) + rec_size ({}) = {} > PAGE_SIZE ({})",
@@ -1115,7 +1131,7 @@ mod proptests {
                 ));
             }
 
-            // rec_size must be at least REC_HEADER_SIZE
+            // Every record needs at least the header bytes
             if rec_size < REC_HEADER_SIZE {
                 return Err(format!(
                     "slot_{}_size: rec_size ({}) < REC_HEADER_SIZE ({})",
@@ -1123,6 +1139,8 @@ mod proptests {
                 ));
             }
 
+            // Check that the key and value lengths match what the slot says
+            // This catches bugs where the record header has wrong sizes
             let key_len = read_u16(page, rec_base + REC_OFF_KEY_LEN) as usize;
             let val_len = read_u16(page, rec_base + REC_OFF_VAL_LEN) as usize;
             let expected_rec_size = rec_total_size(key_len, val_len);
@@ -1133,17 +1151,20 @@ mod proptests {
                 ));
             }
 
+            // Save this slot's info so we can check for overlaps later
             slot_ranges.push((i, rec_base, rec_size));
         }
 
+        // Check that no two slots point to overlapping memory regions
+        // This would mean two records are overwriting each other's data
         for a in 0..slot_ranges.len() {
             let (ia, base_a, size_a) = slot_ranges[a];
             for b in (a + 1)..slot_ranges.len() {
                 let (ib, base_b, size_b) = slot_ranges[b];
                 let end_a = base_a + size_a;
                 let end_b = base_b + size_b;
-                // Two ranges [base_a, end_a) and [base_b, end_b) overlap iff
-                // base_a < end_b && base_b < end_a
+                // Check if ranges overlap
+                // Two ranges overlap if: base_a < end_b AND base_b < end_a
                 if base_a < end_b && base_b < end_a {
                     return Err(format!(
                         "slot_overlap: slot {} [{}, {}) overlaps slot {} [{}, {})",
@@ -1156,7 +1177,9 @@ mod proptests {
         Ok(())
     }
 
-    /// Key ordering checker. Uses `LeafPageAccessor`
+    /// Check that keys are in the right order
+    /// This uses LeafPageAccessor which is okay because we're just checking
+    /// the logical ordering, not the low-level structure
     fn check_leaf_key_ordering(page: &[u8]) -> Result<(), String> {
         type K = &'static [u8];
         type V = &'static [u8];
@@ -1164,17 +1187,17 @@ mod proptests {
         let acc = LeafPageAccessor::<K, V>::new(page);
         let n = acc.num_pairs() as usize;
 
-        // 1. Keys sorted ascending
+        // 1. Keys sorted ascending (allow duplicates for MVCC)
         for i in 0..n.saturating_sub(1) {
             let k1 = acc.get_key(i);
             let k2 = acc.get_key(i + 1);
             if <K as Key>::compare(
                 <K as Value>::as_bytes(&k1).as_ref(),
                 <K as Value>::as_bytes(&k2).as_ref(),
-            ) != Ordering::Less
+            ) == Ordering::Greater
             {
                 return Err(format!(
-                    "keys_not_sorted: key[{}] ({:?}) >= key[{}] ({:?})",
+                    "keys_not_sorted: key[{}] ({:?}) > key[{}] ({:?})",
                     i,
                     k1,
                     i + 1,
@@ -1183,11 +1206,13 @@ mod proptests {
             }
         }
 
-        // 2. All keys < high_key
+        // Also check that all keys are less than the high_key if one exists
+        // (high_key is the upper bound for keys on this page)
         if let Some(hk) = acc.high_key_bytes() {
             for i in 0..n {
                 let k = acc.get_key(i);
-                if <K as Key>::compare(<K as Value>::as_bytes(&k).as_ref(), hk) != Ordering::Less {
+                if <K as Key>::compare(<K as Value>::as_bytes(&k).as_ref(), hk) == Ordering::Greater
+                {
                     return Err(format!(
                         "key_exceeds_high_key: key[{}] ({:?}) >= high_key ({:?})",
                         i, k, hk
@@ -1199,14 +1224,17 @@ mod proptests {
         Ok(())
     }
 
+    /// Main checker function - calls both structural and ordering checks
+    /// Use this after every operation in tests
     fn check_leaf_all_invariants(page: &[u8]) -> Result<(), String> {
         check_leaf_structural_invariants(page)?;
         check_leaf_key_ordering(page)?;
         Ok(())
     }
 
-    /// Post-sequence read-back: verify all keys are readable, sorted, and unique
-    /// via the accessor. Catches data corruption that structural checks miss.
+    /// After running a bunch of operations, read all the keys back
+    /// and make sure they're still sorted and readable
+    /// This catches corruption bugs that the other checkers might miss
     fn verify_leaf_readable_and_sorted(page: &[u8]) -> Result<(), String> {
         type K = &'static [u8];
         type V = &'static [u8];
@@ -1214,14 +1242,16 @@ mod proptests {
         let acc = LeafPageAccessor::<K, V>::new(page);
         let n = acc.num_pairs() as usize;
 
+        // Keep track of the previous key to compare with the next one
         let mut prev_key: Option<Vec<u8>> = None;
         for i in 0..n {
             let key = acc.get_key(i);
             let _val = acc.get_value(i);
             let key_bytes: Vec<u8> = <K as Value>::as_bytes(&key).as_ref().to_vec();
 
+            // Make sure this key is >= the previous one (allowing duplicates)
             if let Some(ref pk) = prev_key {
-                if <K as Key>::compare(pk.as_slice(), key_bytes.as_slice()) != Ordering::Less {
+                if <K as Key>::compare(pk.as_slice(), key_bytes.as_slice()) == Ordering::Greater {
                     return Err(format!(
                         "readback_not_sorted: key[{}] ({:?}) >= key[{}] ({:?})",
                         i - 1,
@@ -1237,32 +1267,45 @@ mod proptests {
         Ok(())
     }
 
-    // ── Proptest strategies ───────────────────────────────────────────────────
+    // ── Test data generators ───────────────────────────────────────────────────
 
-    /// Random key bytes (1-16 bytes, lexicographic comparison).
+    /// Generate random key bytes
+    /// We use a mix of small key spaces (to encourage duplicates for MVCC testing)
+    /// and larger random keys.
     fn key_strategy() -> impl Strategy<Value = Vec<u8>> {
-        prop::collection::vec(any::<u8>(), 1..=16usize)
+        prop_oneof![
+            // 80% chance: small pool of keys (length 1-2, values 0-3) to ensure duplicates
+            80 => prop::collection::vec(0u8..4u8, 1..=2usize),
+            // 20% chance: completely random keys up to 16 bytes
+            20 => prop::collection::vec(any::<u8>(), 1..=16usize),
+        ]
     }
 
-    /// Random value bytes (1-32 bytes) — small for denser pages.
+    /// Generate small random values (1-32 bytes)
+    /// Used for sequence tests where we want lots of operations
     fn small_value_strategy() -> impl Strategy<Value = Vec<u8>> {
         prop::collection::vec(any::<u8>(), 1..=32usize)
     }
 
-    /// Random value bytes (1-256 bytes) — larger for space-accounting stress.
+    /// Generate larger random values (1-256 bytes)
+    /// Used to test space accounting with bigger records
     fn large_value_strategy() -> impl Strategy<Value = Vec<u8>> {
         prop::collection::vec(any::<u8>(), 1..=256usize)
     }
 
-    /// Operation for sequence testing.
+    /// Different operations we can do on a leaf page
+    /// We'll generate random sequences of these to test
     #[derive(Debug, Clone)]
     enum LeafOp {
         Insert { key: Vec<u8>, value: Vec<u8> },
-        Remove { slot_index: usize },
-        SetXmax { slot_index: usize, xmax: u64 },
-        Compact { horizon: u64 },
+        Remove { slot_index: usize }, // we clamp this to valid range when applying
+        SetXmax { slot_index: usize, xmax: u64 }, // mark record as deleted
+        Compact { horizon: u64 },     // clean up dead records
     }
 
+    /// Generate random operations with different probabilities
+    /// More inserts (50%) because we need to build up state first
+    /// Then removes, setxmax, and compact are less frequent
     fn leaf_op_strategy() -> impl Strategy<Value = LeafOp> {
         prop_oneof![
             50 => (key_strategy(), small_value_strategy())
@@ -1281,7 +1324,7 @@ mod proptests {
     type K = &'static [u8];
     type V = &'static [u8];
 
-    /// Build a valid leaf page from sorted, unique key-value pairs.
+    /// Build a valid leaf page from sorted key-value pairs (allows duplicates for MVCC).
     /// Returns the number of pairs that actually fit.
     fn build_leaf_from_sorted(
         buf: &mut PageBuffer,
@@ -1296,10 +1339,7 @@ mod proptests {
             if !m.as_accessor().can_fit_direct(k.len(), v.len()) {
                 break;
             }
-            let (pos, found) = m.as_accessor().position(&k.as_slice());
-            if found {
-                continue; // skip duplicates
-            }
+            let (pos, _found) = m.as_accessor().position(&k.as_slice());
             m.insert(pos, &k.as_slice(), &v.as_slice()).unwrap();
             m.set_xmin(pos, 1); // dummy txn id
             count += 1;
@@ -1307,19 +1347,19 @@ mod proptests {
         count
     }
 
-    /// Sort and deduplicate a list of (key, value) pairs by key.
-    fn sort_dedup(mut pairs: Vec<(Vec<u8>, Vec<u8>)>) -> Vec<(Vec<u8>, Vec<u8>)> {
+    /// Sort a list of (key, value) pairs by key, allowing duplicates.
+    fn sort_pairs(mut pairs: Vec<(Vec<u8>, Vec<u8>)>) -> Vec<(Vec<u8>, Vec<u8>)> {
         pairs.sort_by(|a, b| a.0.cmp(&b.0));
-        pairs.dedup_by(|a, b| a.0 == b.0);
         pairs
     }
 
-    // ── Step 4: Single-operation property tests ───────────────────────────────
+    // ── Property tests for single operations ──────────────────────────────────
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(512))]
 
-        /// Building a page from sorted unique entries always produces a valid page.
+        /// Test that building a page from random entries always creates a valid page
+        /// We sort the entries (allowing duplicates), then build the page
         #[test]
         fn prop_builder_produces_valid_page(
             entries in prop::collection::vec(
@@ -1327,14 +1367,16 @@ mod proptests {
                 0..30
             )
         ) {
-            let sorted = sort_dedup(entries);
+            let sorted = sort_pairs(entries);
             let mut buf = PageBuffer::new();
             build_leaf_from_sorted(&mut buf, 1, &sorted);
+            // Check that all invariants are satisfied
             check_leaf_all_invariants(buf.memory())
                 .map_err(|e| TestCaseError::fail(format!("after build: {}", e)))?;
         }
 
-        /// A single insert into a valid page preserves all invariants.
+        /// Test that inserting one key into a page keeps it valid
+        /// Start with a page that has some entries, add one more, check invariants
         #[test]
         fn prop_insert_maintains_invariants(
             initial in prop::collection::vec(
@@ -1344,20 +1386,19 @@ mod proptests {
             new_key in key_strategy(),
             new_val in large_value_strategy(),
         ) {
-            let sorted = sort_dedup(initial);
+            // Build the initial page
+            let sorted = sort_pairs(initial);
             let mut buf = PageBuffer::new();
             build_leaf_from_sorted(&mut buf, 1, &sorted);
 
-            // Insert the new key
+            // Try to insert the new key
             let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
             let acc = m.as_accessor();
             if acc.can_fit_direct(new_key.len(), new_val.len()) {
-                let (pos, found) = acc.position(&new_key.as_slice());
-                if !found {
-                    drop(acc);
-                    m.insert(pos, &new_key.as_slice(), &new_val.as_slice()).unwrap();
-                    m.set_xmin(pos, 1);
-                }
+                let (pos, _found) = acc.position(&new_key.as_slice());
+                drop(acc);
+                m.insert(pos, &new_key.as_slice(), &new_val.as_slice()).unwrap();
+                m.set_xmin(pos, 1);
             }
 
             check_leaf_all_invariants(buf.memory())
@@ -1373,7 +1414,7 @@ mod proptests {
             ),
             remove_idx in 0usize..100,
         ) {
-            let sorted = sort_dedup(initial);
+            let sorted = sort_pairs(initial);
             let mut buf = PageBuffer::new();
             let count = build_leaf_from_sorted(&mut buf, 1, &sorted);
 
@@ -1394,7 +1435,7 @@ mod proptests {
                 0..20
             ),
         ) {
-            let sorted = sort_dedup(entries);
+            let sorted = sort_pairs(entries);
             let mut buf = PageBuffer::new();
 
             // Use a high key that's larger than all generated keys
@@ -1409,10 +1450,7 @@ mod proptests {
                 if !m.as_accessor().can_fit_direct(k.len(), v.len()) {
                     break;
                 }
-                let (pos, found) = m.as_accessor().position(&k.as_slice());
-                if found {
-                    continue;
-                }
+                let (pos, _found) = m.as_accessor().position(&k.as_slice());
                 m.insert(pos, &k.as_slice(), &v.as_slice()).unwrap();
             }
 
@@ -1445,10 +1483,7 @@ mod proptests {
                         if !acc.can_fit_direct(key.len(), value.len()) {
                             continue;
                         }
-                        let (pos, found) = acc.position(&key.as_slice());
-                        if found {
-                            continue; // skip duplicates
-                        }
+                        let (pos, _found) = acc.position(&key.as_slice());
                         drop(acc);
                         m.insert(pos, &key.as_slice(), &value.as_slice()).unwrap();
                         m.set_xmin(pos, next_txn);
@@ -1487,7 +1522,7 @@ mod proptests {
                 })?;
             }
 
-            // Final read-back: verify all keys are readable, sorted, and unique
+            // Final read-back: verify all keys are readable and sorted (allows duplicates)
             verify_leaf_readable_and_sorted(buf.memory()).map_err(|e| {
                 TestCaseError::fail(format!("Post-sequence read-back failed: {}", e))
             })?;
@@ -1509,8 +1544,8 @@ mod proptests {
             ),
             split_frac_pct in 20u32..80,
         ) {
-            // 1. Build a source page with sorted, unique entries
-            let sorted = sort_dedup(entries);
+            // 1. Build a source page with sorted entries (allowing duplicates)
+            let sorted = sort_pairs(entries);
             if sorted.len() < 3 {
                 return Ok(()); // need at least 3 entries to split meaningfully
             }
@@ -1576,14 +1611,14 @@ mod proptests {
             check_leaf_all_invariants(right.memory())
                 .map_err(|e| TestCaseError::fail(format!("right half: {}", e)))?;
 
-            // 7. Verify all keys in left < separator
+            // 7. Verify all keys in left <= separator (allow duplicates for MVCC)
             let left_acc = LeafPageAccessor::<K, V>::new(left.memory());
             for i in 0..left_acc.num_pairs() as usize {
                 let k = left_acc.get_key(i);
                 let kb = <K as Value>::as_bytes(&k);
-                if <K as Key>::compare(kb.as_ref(), &separator) != Ordering::Less {
+                if <K as Key>::compare(kb.as_ref(), &separator) == Ordering::Greater {
                     return Err(TestCaseError::fail(format!(
-                        "left key[{}] ({:?}) >= separator ({:?})",
+                        "left key[{}] ({:?}) > separator ({:?})",
                         i,
                         kb.as_ref(),
                         separator

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -1039,3 +1039,584 @@ mod tests {
         assert_eq!(LeafPageAccessor::<K, V>::new(buf.memory()).num_pairs(), 1);
     }
 }
+
+// ── Property-based tests ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod proptests {
+    use super::*;
+    use crate::page::PageBuffer;
+    use db_core::transaction_manager::TransactionManager;
+    use proptest::prelude::*;
+    use std::cmp::Ordering;
+
+    // ── Invariant checkers (raw-byte based) ───────────────────────────────────
+
+    /// Structural invariant checker that reads raw bytes directly, avoiding
+    /// circular trust with the `LeafPageAccessor` under test.
+    fn check_leaf_structural_invariants(page: &[u8]) -> Result<(), String> {
+        let page_type = read_u8(page, OFF_PAGE_TYPE);
+        if page_type != LEAF {
+            return Err(format!(
+                "page_type: expected {} (LEAF), got {}",
+                LEAF, page_type
+            ));
+        }
+
+        let slot_count = read_u16(page, OFF_LEAF_SLOT_COUNT) as usize;
+        let free_start = read_u16(page, OFF_LEAF_FREE_START) as usize;
+        let free_end = read_u16(page, OFF_LEAF_FREE_END) as usize;
+        let high_key_len = read_u16(page, OFF_LEAF_HIGH_KEY_LEN) as usize;
+
+        if free_start > free_end {
+            return Err(format!(
+                "space_accounting: free_start ({}) > free_end ({})",
+                free_start, free_end
+            ));
+        }
+        if free_end > PAGE_SIZE {
+            return Err(format!(
+                "space_accounting: free_end ({}) > PAGE_SIZE ({})",
+                free_end, PAGE_SIZE
+            ));
+        }
+
+        let expected_free_start = slot_base(high_key_len) + slot_count * SLOT_SIZE;
+        if free_start != expected_free_start {
+            return Err(format!(
+                "slot_directory_size: free_start ({}) != slot_base({}) + {} * {} = {}",
+                free_start, high_key_len, slot_count, SLOT_SIZE, expected_free_start
+            ));
+        }
+
+        let mut slot_ranges: Vec<(usize, usize, usize)> = Vec::with_capacity(slot_count);
+        for i in 0..slot_count {
+            let slot_off = slot_offset_at(high_key_len, i);
+            let rec_base = read_u16(page, slot_off) as usize;
+            let rec_size = read_u16(page, slot_off + 2) as usize;
+
+            // rec_base must be at or past free_end
+            if rec_base < free_end {
+                return Err(format!(
+                    "slot_{}_offset: rec_base ({}) < free_end ({})",
+                    i, rec_base, free_end
+                ));
+            }
+
+            // rec must fit within page
+            if rec_base + rec_size > PAGE_SIZE {
+                return Err(format!(
+                    "slot_{}_bounds: rec_base ({}) + rec_size ({}) = {} > PAGE_SIZE ({})",
+                    i,
+                    rec_base,
+                    rec_size,
+                    rec_base + rec_size,
+                    PAGE_SIZE
+                ));
+            }
+
+            // rec_size must be at least REC_HEADER_SIZE
+            if rec_size < REC_HEADER_SIZE {
+                return Err(format!(
+                    "slot_{}_size: rec_size ({}) < REC_HEADER_SIZE ({})",
+                    i, rec_size, REC_HEADER_SIZE
+                ));
+            }
+
+            let key_len = read_u16(page, rec_base + REC_OFF_KEY_LEN) as usize;
+            let val_len = read_u16(page, rec_base + REC_OFF_VAL_LEN) as usize;
+            let expected_rec_size = rec_total_size(key_len, val_len);
+            if rec_size != expected_rec_size {
+                return Err(format!(
+                    "slot_{}_consistency: rec_size ({}) != rec_total_size(key_len={}, val_len={}) = {}",
+                    i, rec_size, key_len, val_len, expected_rec_size
+                ));
+            }
+
+            slot_ranges.push((i, rec_base, rec_size));
+        }
+
+        for a in 0..slot_ranges.len() {
+            let (ia, base_a, size_a) = slot_ranges[a];
+            for b in (a + 1)..slot_ranges.len() {
+                let (ib, base_b, size_b) = slot_ranges[b];
+                let end_a = base_a + size_a;
+                let end_b = base_b + size_b;
+                // Two ranges [base_a, end_a) and [base_b, end_b) overlap iff
+                // base_a < end_b && base_b < end_a
+                if base_a < end_b && base_b < end_a {
+                    return Err(format!(
+                        "slot_overlap: slot {} [{}, {}) overlaps slot {} [{}, {})",
+                        ia, base_a, end_a, ib, base_b, end_b
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Key ordering checker. Uses `LeafPageAccessor`
+    fn check_leaf_key_ordering(page: &[u8]) -> Result<(), String> {
+        type K = &'static [u8];
+        type V = &'static [u8];
+
+        let acc = LeafPageAccessor::<K, V>::new(page);
+        let n = acc.num_pairs() as usize;
+
+        // 1. Keys sorted ascending
+        for i in 0..n.saturating_sub(1) {
+            let k1 = acc.get_key(i);
+            let k2 = acc.get_key(i + 1);
+            if <K as Key>::compare(
+                <K as Value>::as_bytes(&k1).as_ref(),
+                <K as Value>::as_bytes(&k2).as_ref(),
+            ) != Ordering::Less
+            {
+                return Err(format!(
+                    "keys_not_sorted: key[{}] ({:?}) >= key[{}] ({:?})",
+                    i,
+                    k1,
+                    i + 1,
+                    k2
+                ));
+            }
+        }
+
+        // 2. All keys < high_key
+        if let Some(hk) = acc.high_key_bytes() {
+            for i in 0..n {
+                let k = acc.get_key(i);
+                if <K as Key>::compare(<K as Value>::as_bytes(&k).as_ref(), hk) != Ordering::Less {
+                    return Err(format!(
+                        "key_exceeds_high_key: key[{}] ({:?}) >= high_key ({:?})",
+                        i, k, hk
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_leaf_all_invariants(page: &[u8]) -> Result<(), String> {
+        check_leaf_structural_invariants(page)?;
+        check_leaf_key_ordering(page)?;
+        Ok(())
+    }
+
+    /// Post-sequence read-back: verify all keys are readable, sorted, and unique
+    /// via the accessor. Catches data corruption that structural checks miss.
+    fn verify_leaf_readable_and_sorted(page: &[u8]) -> Result<(), String> {
+        type K = &'static [u8];
+        type V = &'static [u8];
+
+        let acc = LeafPageAccessor::<K, V>::new(page);
+        let n = acc.num_pairs() as usize;
+
+        let mut prev_key: Option<Vec<u8>> = None;
+        for i in 0..n {
+            let key = acc.get_key(i);
+            let _val = acc.get_value(i);
+            let key_bytes: Vec<u8> = <K as Value>::as_bytes(&key).as_ref().to_vec();
+
+            if let Some(ref pk) = prev_key {
+                if <K as Key>::compare(pk.as_slice(), key_bytes.as_slice()) != Ordering::Less {
+                    return Err(format!(
+                        "readback_not_sorted: key[{}] ({:?}) >= key[{}] ({:?})",
+                        i - 1,
+                        pk,
+                        i,
+                        key_bytes
+                    ));
+                }
+            }
+            prev_key = Some(key_bytes);
+        }
+
+        Ok(())
+    }
+
+    // ── Proptest strategies ───────────────────────────────────────────────────
+
+    /// Random key bytes (1-16 bytes, lexicographic comparison).
+    fn key_strategy() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(any::<u8>(), 1..=16usize)
+    }
+
+    /// Random value bytes (1-32 bytes) — small for denser pages.
+    fn small_value_strategy() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(any::<u8>(), 1..=32usize)
+    }
+
+    /// Random value bytes (1-256 bytes) — larger for space-accounting stress.
+    fn large_value_strategy() -> impl Strategy<Value = Vec<u8>> {
+        prop::collection::vec(any::<u8>(), 1..=256usize)
+    }
+
+    /// Operation for sequence testing.
+    #[derive(Debug, Clone)]
+    enum LeafOp {
+        Insert { key: Vec<u8>, value: Vec<u8> },
+        Remove { slot_index: usize },
+        SetXmax { slot_index: usize, xmax: u64 },
+        Compact { horizon: u64 },
+    }
+
+    fn leaf_op_strategy() -> impl Strategy<Value = LeafOp> {
+        prop_oneof![
+            50 => (key_strategy(), small_value_strategy())
+                .prop_map(|(k, v)| LeafOp::Insert { key: k, value: v }),
+            20 => (0usize..100)
+                .prop_map(|idx| LeafOp::Remove { slot_index: idx }),
+            15 => ((0usize..100), (1u64..200))
+                .prop_map(|(idx, xmax)| LeafOp::SetXmax { slot_index: idx, xmax }),
+            15 => (1u64..200)
+                .prop_map(|h| LeafOp::Compact { horizon: h }),
+        ]
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    type K = &'static [u8];
+    type V = &'static [u8];
+
+    /// Build a valid leaf page from sorted, unique key-value pairs.
+    /// Returns the number of pairs that actually fit.
+    fn build_leaf_from_sorted(
+        buf: &mut PageBuffer,
+        page_id: u64,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> usize {
+        LeafPageBuilder::<K, V>::new(page_id, buf.memory_mut()).finish();
+
+        let mut count = 0;
+        for (k, v) in pairs {
+            let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
+            if !m.as_accessor().can_fit_direct(k.len(), v.len()) {
+                break;
+            }
+            let (pos, found) = m.as_accessor().position(&k.as_slice());
+            if found {
+                continue; // skip duplicates
+            }
+            m.insert(pos, &k.as_slice(), &v.as_slice()).unwrap();
+            m.set_xmin(pos, 1); // dummy txn id
+            count += 1;
+        }
+        count
+    }
+
+    /// Sort and deduplicate a list of (key, value) pairs by key.
+    fn sort_dedup(mut pairs: Vec<(Vec<u8>, Vec<u8>)>) -> Vec<(Vec<u8>, Vec<u8>)> {
+        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        pairs.dedup_by(|a, b| a.0 == b.0);
+        pairs
+    }
+
+    // ── Step 4: Single-operation property tests ───────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        /// Building a page from sorted unique entries always produces a valid page.
+        #[test]
+        fn prop_builder_produces_valid_page(
+            entries in prop::collection::vec(
+                (key_strategy(), small_value_strategy()),
+                0..30
+            )
+        ) {
+            let sorted = sort_dedup(entries);
+            let mut buf = PageBuffer::new();
+            build_leaf_from_sorted(&mut buf, 1, &sorted);
+            check_leaf_all_invariants(buf.memory())
+                .map_err(|e| TestCaseError::fail(format!("after build: {}", e)))?;
+        }
+
+        /// A single insert into a valid page preserves all invariants.
+        #[test]
+        fn prop_insert_maintains_invariants(
+            initial in prop::collection::vec(
+                (key_strategy(), small_value_strategy()),
+                0..15
+            ),
+            new_key in key_strategy(),
+            new_val in large_value_strategy(),
+        ) {
+            let sorted = sort_dedup(initial);
+            let mut buf = PageBuffer::new();
+            build_leaf_from_sorted(&mut buf, 1, &sorted);
+
+            // Insert the new key
+            let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
+            let acc = m.as_accessor();
+            if acc.can_fit_direct(new_key.len(), new_val.len()) {
+                let (pos, found) = acc.position(&new_key.as_slice());
+                if !found {
+                    drop(acc);
+                    m.insert(pos, &new_key.as_slice(), &new_val.as_slice()).unwrap();
+                    m.set_xmin(pos, 1);
+                }
+            }
+
+            check_leaf_all_invariants(buf.memory())
+                .map_err(|e| TestCaseError::fail(format!("after insert: {}", e)))?;
+        }
+
+        /// A single remove from a valid page preserves all invariants.
+        #[test]
+        fn prop_remove_maintains_invariants(
+            initial in prop::collection::vec(
+                (key_strategy(), small_value_strategy()),
+                1..20
+            ),
+            remove_idx in 0usize..100,
+        ) {
+            let sorted = sort_dedup(initial);
+            let mut buf = PageBuffer::new();
+            let count = build_leaf_from_sorted(&mut buf, 1, &sorted);
+
+            if count > 0 {
+                let pos = remove_idx.min(count - 1);
+                LeafPageMutator::<K, V>::new(buf.memory_mut()).remove(pos);
+            }
+
+            check_leaf_all_invariants(buf.memory())
+                .map_err(|e| TestCaseError::fail(format!("after remove: {}", e)))?;
+        }
+
+        /// Building with a high key set produces a valid page where all keys < high_key.
+        #[test]
+        fn prop_builder_with_high_key_valid(
+            entries in prop::collection::vec(
+                (key_strategy(), small_value_strategy()),
+                0..20
+            ),
+        ) {
+            let sorted = sort_dedup(entries);
+            let mut buf = PageBuffer::new();
+
+            // Use a high key that's larger than all generated keys
+            let high_key = vec![0xFF; 17]; // 17 bytes > max key of 16
+
+            let mut builder = LeafPageBuilder::<K, V>::new(1, buf.memory_mut());
+            builder.set_high_key(&high_key);
+            builder.finish();
+
+            for (k, v) in &sorted {
+                let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
+                if !m.as_accessor().can_fit_direct(k.len(), v.len()) {
+                    break;
+                }
+                let (pos, found) = m.as_accessor().position(&k.as_slice());
+                if found {
+                    continue;
+                }
+                m.insert(pos, &k.as_slice(), &v.as_slice()).unwrap();
+            }
+
+            check_leaf_all_invariants(buf.memory())
+                .map_err(|e| TestCaseError::fail(format!("after build with high key: {}", e)))?;
+        }
+    }
+
+    // ── Step 5: Operation sequence property tests ─────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Arbitrary operation sequences on a leaf page always preserve invariants.
+        #[test]
+        fn prop_leaf_op_sequence_maintains_invariants(
+            ops in prop::collection::vec(leaf_op_strategy(), 1..30)
+        ) {
+            let mut buf = PageBuffer::new();
+            LeafPageBuilder::<K, V>::new(1, buf.memory_mut()).finish();
+
+            let tm = TransactionManager::new();
+            let mut next_txn: u64 = 1;
+
+            for (i, op) in ops.iter().enumerate() {
+                match op {
+                    LeafOp::Insert { key, value } => {
+                        let mut m = LeafPageMutator::<K, V>::new(buf.memory_mut());
+                        let acc = m.as_accessor();
+                        if !acc.can_fit_direct(key.len(), value.len()) {
+                            continue;
+                        }
+                        let (pos, found) = acc.position(&key.as_slice());
+                        if found {
+                            continue; // skip duplicates
+                        }
+                        drop(acc);
+                        m.insert(pos, &key.as_slice(), &value.as_slice()).unwrap();
+                        m.set_xmin(pos, next_txn);
+                        tm.mark_committed(next_txn);
+                        next_txn += 1;
+                    }
+                    LeafOp::Remove { slot_index } => {
+                        let n =
+                            LeafPageAccessor::<K, V>::new(buf.memory()).num_pairs() as usize;
+                        if n == 0 {
+                            continue;
+                        }
+                        let pos = (*slot_index).min(n - 1);
+                        LeafPageMutator::<K, V>::new(buf.memory_mut()).remove(pos);
+                    }
+                    LeafOp::SetXmax { slot_index, xmax } => {
+                        let n =
+                            LeafPageAccessor::<K, V>::new(buf.memory()).num_pairs() as usize;
+                        if n == 0 {
+                            continue;
+                        }
+                        let pos = (*slot_index).min(n - 1);
+                        LeafPageMutator::<K, V>::new(buf.memory_mut()).set_xmax(pos, *xmax);
+                    }
+                    LeafOp::Compact { horizon } => {
+                        LeafPageMutator::<K, V>::compact(1, buf.memory_mut(), *horizon, &tm);
+                    }
+                }
+
+                // Check structural invariants after EVERY operation
+                check_leaf_all_invariants(buf.memory()).map_err(|e| {
+                    TestCaseError::fail(format!(
+                        "Invariant violated after op #{} ({:?}): {}",
+                        i, op, e
+                    ))
+                })?;
+            }
+
+            // Final read-back: verify all keys are readable, sorted, and unique
+            verify_leaf_readable_and_sorted(buf.memory()).map_err(|e| {
+                TestCaseError::fail(format!("Post-sequence read-back failed: {}", e))
+            })?;
+        }
+    }
+
+    // ── Step 6: Split-at-page-level property tests ────────────────────────────
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Splitting a page at an arbitrary point produces two valid halves
+        /// with correct high keys and no data loss.
+        #[test]
+        fn prop_split_produces_valid_halves(
+            entries in prop::collection::vec(
+                (key_strategy(), small_value_strategy()),
+                5..40
+            ),
+            split_frac_pct in 20u32..80,
+        ) {
+            // 1. Build a source page with sorted, unique entries
+            let sorted = sort_dedup(entries);
+            if sorted.len() < 3 {
+                return Ok(()); // need at least 3 entries to split meaningfully
+            }
+            let mut src = PageBuffer::new();
+            let count = build_leaf_from_sorted(&mut src, 1, &sorted);
+            if count < 3 {
+                return Ok(());
+            }
+
+            // 2. Pick split point
+            let mid =
+                ((count as u32 * split_frac_pct) / 100).max(1).min(count as u32 - 1) as usize;
+
+            // 3. Snapshot all entries from the source page
+            let acc = LeafPageAccessor::<K, V>::new(src.memory());
+            let n = acc.num_pairs() as usize;
+            let entries_snap: Vec<(Vec<u8>, Vec<u8>, u64, u64)> = (0..n)
+                .map(|i| {
+                    let k = <K as Value>::as_bytes(&acc.get_key(i)).as_ref().to_vec();
+                    let v = <V as Value>::as_bytes(&acc.get_value(i)).as_ref().to_vec();
+                    (k, v, acc.get_xmin(i), acc.get_xmax(i))
+                })
+                .collect();
+
+            let separator = entries_snap[mid].0.clone();
+
+            // 4. Build left page: entries[..mid], high_key = separator
+            let mut left = PageBuffer::new();
+            {
+                let mut builder = LeafPageBuilder::<K, V>::new(1, left.memory_mut());
+                builder.set_high_key(&separator);
+                builder.set_rightlink(Some(2));
+                for (k, v, xmin, xmax) in &entries_snap[..mid] {
+                    builder.push_with_mvcc(
+                        &<K as Value>::from_bytes(k),
+                        &<V as Value>::from_bytes(v),
+                        *xmin,
+                        *xmax,
+                    );
+                }
+                builder.finish();
+            }
+
+            // 5. Build right page: entries[mid..], high_key = +∞ (rightmost)
+            let mut right = PageBuffer::new();
+            {
+                let mut builder = LeafPageBuilder::<K, V>::new(2, right.memory_mut());
+                builder.set_prev_page(Some(1));
+                for (k, v, xmin, xmax) in &entries_snap[mid..] {
+                    builder.push_with_mvcc(
+                        &<K as Value>::from_bytes(k),
+                        &<V as Value>::from_bytes(v),
+                        *xmin,
+                        *xmax,
+                    );
+                }
+                builder.finish();
+            }
+
+            // 6. Check invariants on both pages
+            check_leaf_all_invariants(left.memory())
+                .map_err(|e| TestCaseError::fail(format!("left half: {}", e)))?;
+            check_leaf_all_invariants(right.memory())
+                .map_err(|e| TestCaseError::fail(format!("right half: {}", e)))?;
+
+            // 7. Verify all keys in left < separator
+            let left_acc = LeafPageAccessor::<K, V>::new(left.memory());
+            for i in 0..left_acc.num_pairs() as usize {
+                let k = left_acc.get_key(i);
+                let kb = <K as Value>::as_bytes(&k);
+                if <K as Key>::compare(kb.as_ref(), &separator) != Ordering::Less {
+                    return Err(TestCaseError::fail(format!(
+                        "left key[{}] ({:?}) >= separator ({:?})",
+                        i,
+                        kb.as_ref(),
+                        separator
+                    )));
+                }
+            }
+
+            // 8. Verify all keys in right >= separator
+            let right_acc = LeafPageAccessor::<K, V>::new(right.memory());
+            for i in 0..right_acc.num_pairs() as usize {
+                let k = right_acc.get_key(i);
+                let kb = <K as Value>::as_bytes(&k);
+                if <K as Key>::compare(kb.as_ref(), &separator) == Ordering::Less {
+                    return Err(TestCaseError::fail(format!(
+                        "right key[{}] ({:?}) < separator ({:?})",
+                        i,
+                        kb.as_ref(),
+                        separator
+                    )));
+                }
+            }
+
+            // 9. Total records = left + right
+            let total = left_acc.num_pairs() as usize + right_acc.num_pairs() as usize;
+            if total != n {
+                return Err(TestCaseError::fail(format!(
+                    "data_loss: left ({}) + right ({}) = {} != source ({})",
+                    left_acc.num_pairs(),
+                    right_acc.num_pairs(),
+                    total,
+                    n
+                )));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Added property-based tests using proptest to verify B+Tree page invariants hold after random operation sequences.  This generates thousands of random insert/delete/compact operations and check structural invariants (keys sorted, no memory overlaps) after every single operation. These tests use raw byte validation to avoid circular dependencies and
 catch bugs that traditional unit tests miss. 
## Changes
- Added 6 prop tests for leaf pages
- Added 3 prop tests for internal pages

## Related Issue
Closes #47 

## Any design changes?

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes