### PR TITLE
wal: optimize next_lsn with AtomicU64 to reduce lock contention

### DIFF
--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -56,9 +56,9 @@ use std::collections::VecDeque;
 use std::fs::{File, OpenOptions, create_dir_all, metadata, read_dir};
 use std::io::{self, BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
-use std::sync::atomic::{AtomicU64,Ordering};
 
 use crate::disk::DiskManager;
 use crate::page::{Lsn, PAGE_SIZE, PageId};
@@ -176,7 +176,7 @@ struct WalBuffer {
 }
 
 struct WalState {
-    buffer: WalBuffer,//
+    buffer: WalBuffer, //
     flushed_lsn: Option<Lsn>,
     flush_error: Option<String>,
     shutdown: bool,
@@ -1025,11 +1025,10 @@ impl Wal {
                 lsn: self.shared.next_lsn.load(Ordering::Relaxed),
                 record_len: record_size,
                 capacity: max_allowed_size,
-             });
+            });
         }
 
-
-        let lsn = self.shared.next_lsn.fetch_add(1,Ordering::Relaxed);
+        let lsn = self.shared.next_lsn.fetch_add(1, Ordering::Relaxed);
 
         let mut record = Vec::with_capacity(record_size);
         record.reserve(record_size);
@@ -1066,9 +1065,9 @@ impl Wal {
         let checksum = hasher.finalize();
 
         record.extend_from_slice(&checksum.to_le_bytes());
-        
+
         let mut state = self.shared.state.lock().unwrap();
-        if let Some(err) = state.flush_error.as_ref(){
+        if let Some(err) = state.flush_error.as_ref() {
             return Err(WalError::FlushFailed(err.clone()));
         }
 
@@ -1618,5 +1617,43 @@ mod tests {
         Ok(())
     }
 
-}
+    #[test]
+    fn test_atomic_lsn_isunique() -> Result<()> {
+        let dir = tempdir().map_err(WalError::Io)?;
+        let wal_dir = dir.path().join("atomic-lsn-wal");
 
+        let wal = Arc::new(Wal::new(&wal_dir)?);
+
+        let number_thread = 8;
+        let record_per_thread = 500;
+
+        let handle: Vec<_> = (0..number_thread)
+            .map(|thread_id| {
+                let wal = Arc::clone(&wal);
+                thread::spawn(move || -> Vec<Lsn> {
+                    (0..record_per_thread)
+                        .map(|i| {
+                            let tx_id = (thread_id * 100 + i) as u64;
+                            wal.log_commit(tx_id)
+                                .expect("concurrent append must not fail")
+                        })
+                        .collect()
+                })
+            })
+            .collect();
+
+        let mut all_lsns: Vec<Lsn> = handle
+            .into_iter()
+            .flat_map(|h| h.join().expect("thread panicked"))
+            .collect();
+
+        all_lsns.sort_unstable();
+
+        let total = number_thread * record_per_thread;
+
+        // Exactly the right number of LSNs were handed out.
+        assert_eq!(all_lsns.len(), total, "wrong number of LSNs collected");
+
+        Ok(())
+    }
+}

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -1329,7 +1329,6 @@ mod tests {
 
         let wal = Wal::new_with_buffer_capacity(&wal_dir, 27)?;
         let result = wal.append(WalRecordType::Commit, 1, &[], None);
-        println!("LSN right after creation: {}", wal.next_lsn());
 
         assert!(matches!(
             result,

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -58,6 +58,7 @@ use std::io::{self, BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
+use std::sync::atomic::{AtomicU64,Ordering};//
 
 use crate::disk::DiskManager;
 use crate::page::{Lsn, PAGE_SIZE, PageId};
@@ -175,8 +176,7 @@ struct WalBuffer {
 }
 
 struct WalState {
-    buffer: WalBuffer,
-    next_lsn: Lsn,
+    buffer: WalBuffer,//
     flushed_lsn: Option<Lsn>,
     flush_error: Option<String>,
     shutdown: bool,
@@ -187,6 +187,7 @@ struct WalShared {
     flush_requested: Condvar,
     durable: Condvar,
     segment_size: u64,
+    next_lsn: AtomicU64,//
 }
 
 /// Write-ahead log manager for one WAL segment directory.
@@ -771,8 +772,7 @@ impl Wal {
 
         let shared = Arc::new(WalShared {
             state: Mutex::new(WalState {
-                buffer: WalBuffer::with_capacity(buffer_capacity),
-                next_lsn,
+                buffer: WalBuffer::with_capacity(buffer_capacity),//
                 flushed_lsn,
                 flush_error: None,
                 shutdown: false,
@@ -780,6 +780,7 @@ impl Wal {
             flush_requested: Condvar::new(),
             durable: Condvar::new(),
             segment_size,
+            next_lsn: AtomicU64::new(next_lsn),
         });
 
         let flusher = Some(Self::spawn_flush_thread(Arc::clone(&shared), writer)?);
@@ -798,7 +799,7 @@ impl Wal {
     }
 
     pub fn next_lsn(&self) -> Lsn {
-        self.shared.state.lock().unwrap().next_lsn
+        self.shared.next_lsn.load(Ordering::Relaxed)
     }
 
     pub fn flushed_lsn(&self) -> Option<Lsn> {
@@ -1015,12 +1016,12 @@ impl Wal {
             });
         }
 
-        let mut state = self.shared.state.lock().unwrap();
-        if let Some(err) = state.flush_error.as_ref() {
-            return Err(WalError::FlushFailed(err.clone()));
-        }
+        // let mut state = self.shared.state.lock().unwrap();
+        // if let Some(err) = state.flush_error.as_ref() {
+        //     return Err(WalError::FlushFailed(err.clone()));
+        // }
 
-        let lsn = state.next_lsn;
+        let lsn = self.shared.next_lsn.fetch_add(1,Ordering::Relaxed);
 
         let mut record = Vec::with_capacity(record_size);
         record.reserve(record_size);
@@ -1057,8 +1058,13 @@ impl Wal {
         let checksum = hasher.finalize();
 
         record.extend_from_slice(&checksum.to_le_bytes());
+        
+        let mut state = self.shared.state.lock().unwrap();
+        if let Some(err) = state.flush_error.as_ref(){
+            return Err(WalError::FlushFailed(err.clone()));
+        }
+
         state.buffer.push_record(lsn, &record)?;
-        state.next_lsn += 1;
 
         Ok(lsn)
     }
@@ -1070,13 +1076,12 @@ impl Wal {
     /// 0, the call is a no-op — preventing a permanent park on the `durable`
     /// condvar.
     pub fn flush_up_to(&self, lsn: Lsn) -> Result<()> {
-        let mut state = self.shared.state.lock().unwrap();
+        let current_next_lsn = self.shared.next_lsn.load(Ordering::Relaxed);
 
         // Guard the *clamped target*, not just the argument. When next_lsn == 1
         // (no records appended), checked_sub(1) yields Some(0) and the flusher
         // has nothing buffered, so parking on `durable` would hang forever.
-        let target_lsn = state
-            .next_lsn
+        let target_lsn = current_next_lsn
             .checked_sub(1)
             .map(|last| lsn.min(last))
             .unwrap_or(0);
@@ -1084,6 +1089,7 @@ impl Wal {
             return Ok(());
         }
 
+        let mut state = self.shared.state.lock().unwrap();
         loop {
             if state
                 .flushed_lsn

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -58,7 +58,7 @@ use std::io::{self, BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::{self, JoinHandle};
-use std::sync::atomic::{AtomicU64,Ordering};//
+use std::sync::atomic::{AtomicU64,Ordering};
 
 use crate::disk::DiskManager;
 use crate::page::{Lsn, PAGE_SIZE, PageId};
@@ -187,7 +187,8 @@ struct WalShared {
     flush_requested: Condvar,
     durable: Condvar,
     segment_size: u64,
-    next_lsn: AtomicU64,//
+    buffer_capacity: usize,
+    next_lsn: AtomicU64,
 }
 
 /// Write-ahead log manager for one WAL segment directory.
@@ -772,7 +773,7 @@ impl Wal {
 
         let shared = Arc::new(WalShared {
             state: Mutex::new(WalState {
-                buffer: WalBuffer::with_capacity(buffer_capacity),//
+                buffer: WalBuffer::with_capacity(buffer_capacity),
                 flushed_lsn,
                 flush_error: None,
                 shutdown: false,
@@ -780,6 +781,7 @@ impl Wal {
             flush_requested: Condvar::new(),
             durable: Condvar::new(),
             segment_size,
+            buffer_capacity,
             next_lsn: AtomicU64::new(next_lsn),
         });
 
@@ -1008,6 +1010,9 @@ impl Wal {
         let record_size = 8 + 4 + 1 + 1 + 8 + 2 + blocks_size + main_data_size + 4;
 
         let segment_limit = self.shared.segment_size as usize;
+        let buffer_limit = self.shared.buffer_capacity;
+        let max_allowed_size = segment_limit.min(buffer_limit);
+
         if record_size > segment_limit {
             return Err(WalError::RecordTooLarge {
                 lsn: 0,
@@ -1015,11 +1020,14 @@ impl Wal {
                 capacity: segment_limit,
             });
         }
+        if record_size > max_allowed_size {
+            return Err(WalError::RecordTooLarge {
+                lsn: self.shared.next_lsn.load(Ordering::Relaxed),
+                record_len: record_size,
+                capacity: max_allowed_size,
+             });
+        }
 
-        // let mut state = self.shared.state.lock().unwrap();
-        // if let Some(err) = state.flush_error.as_ref() {
-        //     return Err(WalError::FlushFailed(err.clone()));
-        // }
 
         let lsn = self.shared.next_lsn.fetch_add(1,Ordering::Relaxed);
 
@@ -1322,6 +1330,7 @@ mod tests {
 
         let wal = Wal::new_with_buffer_capacity(&wal_dir, 27)?;
         let result = wal.append(WalRecordType::Commit, 1, &[], None);
+        println!("LSN right after creation: {}", wal.next_lsn());
 
         assert!(matches!(
             result,
@@ -1608,4 +1617,6 @@ mod tests {
 
         Ok(())
     }
+
 }
+

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -1654,6 +1654,15 @@ mod tests {
         // Exactly the right number of LSNs were handed out.
         assert_eq!(all_lsns.len(), total, "wrong number of LSNs collected");
 
+        all_lsns.dedup();
+        assert_eq!(
+            all_lsns.len(),
+            total,
+            "Duplicate LSNs detected! Atomic implementation is broken."
+        );
+
+        assert_eq!(wal.next_lsn(), (total + 1) as u64);
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
Migrates the Write-Ahead Log's next_lsn assignment from a Mutex-bound variable to a lock-free AtomicU64. This resolves a major contention point where all concurrent transactions were forced to serialize behind the WAL state lock just to reserve a sequence number.

## Changes
- Relocated next_lsn from WalState (which is guarded by a Mutex) into WalShared as an AtomicU64.
- Updated append() to reserve LSNs concurrently via fetch_add, pulling the sequence generation out of the Mutex hot loop.
- Added lock-free pre-flight validation (checking both segment_size and buffer_capacity) before fetch_add to prevent deterministic size errors from burning LSNs.
- Maintained flushed_lsn inside the WalState Mutex to preserve correct coordination with the background flush Condvar.
- Added a high-concurrency stress test (test_atomic_lsn_correctness) to mathematically prove the atomics never issue duplicate LSNs or unexpected gaps.

## Related Issue
Closes #56

## Any design changes?
Yes, there are two main design changes:

- Struct Layout: We moved next_lsn out of the Mutex-protected WalState struct and placed it directly into the lock-free WalShared struct.Also  added a new buffer_capacity field to the lock-free WalShared struct. This enables us to perform a pre-flight validation check to immediately reject oversized records before they consume an LSN.
- Accepting Sequence Gaps: Because sequence numbers are now assigned lock-free, we cannot easily "undo" an assignment if an append fails later (e.g., due to a disk error). Instead of ensuring perfect, gap-less sequence numbers, we now check for obvious errors early, and simply accept that unpredictable errors will leave harmless gaps in the sequence.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated
- [x] No breaking changes