### PR TITLE
feat(vacuum): drive full sweep and publish vacuum_horizon (VAC-1)

### DIFF
--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -107,7 +107,7 @@ impl TransactionManager {
     pub fn publish_vacuum_horizon(&self, horizon: u64) {
         self.vacuum_horizon.fetch_max(horizon, AcqRel);
     }
-    
+
     /// The oldest-active-txn-id captured at the start of the most recent
     /// completed full sweep (0 until the first post-restart sweep completes).
     pub fn vacuum_horizon(&self) -> u64 {

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -64,6 +64,7 @@ type WaiterEntry = Arc<(Mutex<bool>, Condvar)>;
 pub struct TransactionManager {
     pub next_txn_id: AtomicU64,
     pub clog: RwLock<HashMap<u64, TransactionStatus>>,
+    pub vacuum_horizon: AtomicU64,
     pub active_txns: RwLock<HashSet<u64>>,
     waiters: Mutex<HashMap<u64, WaiterEntry>>,
 }
@@ -80,6 +81,7 @@ impl TransactionManager {
         Self {
             next_txn_id: AtomicU64::new(1),
             clog: RwLock::new(HashMap::new()),
+            vacuum_horizon: AtomicU64::new(0),
             active_txns: RwLock::new(HashSet::new()),
             waiters: Mutex::new(HashMap::new()),
         }
@@ -98,6 +100,18 @@ impl TransactionManager {
             .min()
             .copied()
             .unwrap_or_else(|| self.next_txn_id.load(Acquire))
+    }
+
+    /// Publishes the horizon of a COMPLETED full vacuum sweep. `fetch_max` so a
+    /// slower concurrent sweep can never move the horizon backward. (DESIGN §8.4)
+    pub fn publish_vacuum_horizon(&self, horizon: u64) {
+        self.vacuum_horizon.fetch_max(horizon, AcqRel);
+    }
+    
+    /// The oldest-active-txn-id captured at the start of the most recent
+    /// completed full sweep (0 until the first post-restart sweep completes).
+    pub fn vacuum_horizon(&self) -> u64 {
+        self.vacuum_horizon.load(Acquire)
     }
 
     /// Truncates the CLOG, removing entries older than `horizon`.

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -203,4 +203,10 @@ where
             poisoned: false,
         }
     }
+
+    /// Triggers a full vacuum sweep on demand. On a sweep that reaches the last
+    /// leaf this advances `vacuum_horizon`; a failed sweep publishes nothing.
+    pub fn vacuum(&self) -> Result<usize, EngineError> {
+        Ok(self.index.vacuum(&self.transaction_manager)?)
+    }
 }

--- a/crates/engine/src/proptests.rs
+++ b/crates/engine/src/proptests.rs
@@ -1412,3 +1412,30 @@ fn mid_split_crash_searches_via_rightlink_then_completes() {
     want.sort();
     assert_eq!(got, want);
 }
+
+// ── Engine::vacuum advances vacuum_horizon ────────────────────────────────────
+
+#[test]
+fn engine_vacuum_advances_horizon() {
+    let (_dir, engine) = tmp_engine::<u32, u32>();
+
+    assert_eq!(engine.transaction_manager.vacuum_horizon(), 0);
+
+    // Insert 100 keys (each insert begins + commits its own txn).
+    for i in 0u32..100 {
+        engine.insert(&i, &i).unwrap();
+    }
+    
+    // Delete 50, producing dead versions for vacuum to reclaim.
+    for i in 0u32..50 {
+        engine.delete(&i).unwrap();
+    }
+
+    // A completed sweep returns Ok and publishes the start-of-sweep global_xmin.
+    let removed = engine.vacuum().unwrap();
+    assert_eq!(removed, 50);
+    assert!(
+        engine.transaction_manager.vacuum_horizon() > 0,
+        "completed sweep must advance vacuum_horizon past 0",
+    );
+}

--- a/crates/engine/src/proptests.rs
+++ b/crates/engine/src/proptests.rs
@@ -1425,7 +1425,7 @@ fn engine_vacuum_advances_horizon() {
     for i in 0u32..100 {
         engine.insert(&i, &i).unwrap();
     }
-    
+
     // Delete 50, producing dead versions for vacuum to reclaim.
     for i in 0u32..50 {
         engine.delete(&i).unwrap();

--- a/crates/storage/src/index/mod.rs
+++ b/crates/storage/src/index/mod.rs
@@ -98,6 +98,7 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             }
         }
 
+        tm.publish_vacuum_horizon(global_xmin);
         Ok(total_dead)
     }
 

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -620,9 +620,19 @@ fn vacuum_reclaims_space() {
         tm.mark_committed(txn.txn_id);
     }
 
+        // vacuum_horizon is 0 until the first sweep completes.
+    assert_eq!(tm.vacuum_horizon(), 0);
+
+    // Capture the horizon the sweep will observe at its start.
+    // No txns are active (all committed), so this equals next_txn_id.
+    let expected_horizon = tm.global_xmin();
+
     // 3. Run vacuum. Since all transactions committed, it should reclaim 50 records.
     let removed = idx.vacuum(&tm).unwrap();
     assert_eq!(removed, 50);
+
+    // A completed sweep publishes the start-of-sweep global_xmin.
+    assert_eq!(tm.vacuum_horizon(), expected_horizon);
 
     // 4. Verify data is still visible for the 50 live keys.
     let results: Vec<_> = idx

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -620,7 +620,7 @@ fn vacuum_reclaims_space() {
         tm.mark_committed(txn.txn_id);
     }
 
-        // vacuum_horizon is 0 until the first sweep completes.
+    // vacuum_horizon is 0 until the first sweep completes.
     assert_eq!(tm.vacuum_horizon(), 0);
 
     // Capture the horizon the sweep will observe at its start.


### PR DESCRIPTION
## Summary
Drives the previously-uninvoked `BTreeIndex::vacuum` from an on-demand entry
point and adds `vacuum_horizon`, published only when a sweep completes.

## Changes
- Add `vacuum_horizon: AtomicU64` to `TransactionManager` with a `fetch_max`
  publisher and reader.
- `BTreeIndex::vacuum` captures `global_xmin` at sweep start, publishes it only
  after reaching the last leaf; a partial/failed sweep publishes nothing.
- Add `Engine::vacuum()` on-demand entry point.
- Tests for horizon publishing in storage and engine.

## Related Issue
Closes #86

## Any design changes?
None. Follows DESIGN.md §8.2 / §8.6. 'auto_vacuum' trigger intentionally deferred.

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes
