### PR TITLE
feat: two-tier CLOG truncation (VAC-2)

### DIFF
--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -115,17 +115,19 @@ impl TransactionManager {
     }
 
     /// Truncates the CLOG, removing entries older than `horizon`.
-    ///
-    /// Note: We ONLY remove `Committed` entries. `Aborted` entries must be retained forever
-    /// (or until a physical vacuum confirms their records are gone) because dropping an `Aborted`
-    /// entry before its dirty records are vacuumed would cause our presumed-commit logic to
-    /// suddenly treat those aborted records as visible `Committed` records, breaking isolation.
-    pub fn truncate_clog(&self, horizon: u64) {
+    /// Now the removal of entries has been made two-tier, such that the entries that are 
+    /// committed and their txn_id lying below committed_horizon are deleted directly because
+    /// they have already been committed into the tree. However, the transactions that aborted are removed
+    /// once a successful sweep returns a vacuum_horizon value that can be used to check if the rows 
+    /// concerning that aborted entry in the CLOG have been deleted or not. This physical vacuum confirms 
+    /// that the records of aborted transactions are gone, allowing the truncation of aborted entries in CLOG. 
+    pub fn truncate_clog(&self, committed_horizon: u64) {
+        let aborted_horizon = self.vacuum_horizon();
         let mut clog = self.clog.write().unwrap();
-        clog.retain(|&txn_id, status| {
-            txn_id >= horizon
-                || *status == TransactionStatus::Active
-                || *status == TransactionStatus::Aborted
+        clog.retain(|&txn_id, status| match status {
+            TransactionStatus::Active => true,
+            TransactionStatus::Committed => txn_id >= committed_horizon,
+            TransactionStatus::Aborted => txn_id >= aborted_horizon,
         });
     }
 

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -115,12 +115,12 @@ impl TransactionManager {
     }
 
     /// Truncates the CLOG, removing entries older than `horizon`.
-    /// Now the removal of entries has been made two-tier, such that the entries that are 
+    /// Now the removal of entries has been made two-tier, such that the entries that are
     /// committed and their txn_id lying below committed_horizon are deleted directly because
     /// they have already been committed into the tree. However, the transactions that aborted are removed
-    /// once a successful sweep returns a vacuum_horizon value that can be used to check if the rows 
-    /// concerning that aborted entry in the CLOG have been deleted or not. This physical vacuum confirms 
-    /// that the records of aborted transactions are gone, allowing the truncation of aborted entries in CLOG. 
+    /// once a successful sweep returns a vacuum_horizon value that can be used to check if the rows
+    /// concerning that aborted entry in the CLOG have been deleted or not. This physical vacuum confirms
+    /// that the records of aborted transactions are gone, allowing the truncation of aborted entries in CLOG.
     pub fn truncate_clog(&self, committed_horizon: u64) {
         let aborted_horizon = self.vacuum_horizon();
         let mut clog = self.clog.write().unwrap();
@@ -556,12 +556,12 @@ mod tests {
     #[test]
     fn test_truncate_clog_retains_aborted_above_vacuum_horizon() {
         let tm = std::sync::Arc::new(TransactionManager::new());
-        
-        //make a dummy entry into the database, followed by an aborted entry 
+
+        //make a dummy entry into the database, followed by an aborted entry
         //and then a dummy entry again to mark global_xmin > aborted_txn.txn_id
 
         //txc2 was not committed - which means global_xmin will set to it's txn_id
-        //when a sweep runs 
+        //when a sweep runs
         let txc1 = tm.begin();
         let tx_abort = tm.begin();
         let _txc2 = tm.begin();
@@ -570,7 +570,7 @@ mod tests {
         tm.mark_aborted(tx_abort.txn_id);
 
         //now, we run a full sweep
-        tm.publish_vacuum_horizon(tx_abort.txn_id-1); // so that the horizon is below the aborted txn's id 
+        tm.publish_vacuum_horizon(tx_abort.txn_id - 1); // so that the horizon is below the aborted txn's id 
 
         let committed_horizon = tm.global_xmin();
         assert!(tx_abort.txn_id < committed_horizon);
@@ -578,14 +578,17 @@ mod tests {
 
         tm.truncate_clog(committed_horizon);
 
-        //Now the mandatory asserts - the transaction is still present in the map 
+        //Now the mandatory asserts - the transaction is still present in the map
         assert_eq!(
-           tm.clog.read().unwrap().get(&tx_abort.txn_id),
-           Some(&TransactionStatus::Aborted),
-           "aborted entry below global_xmin but above vacuum_horizon must survive",
+            tm.clog.read().unwrap().get(&tx_abort.txn_id),
+            Some(&TransactionStatus::Aborted),
+            "aborted entry below global_xmin but above vacuum_horizon must survive",
         );
-        // And settled_status is unchanged for it, that is it did not flip to committed. 
-        assert_eq!(tm.settled_status(tx_abort.txn_id), TransactionStatus::Aborted);
+        // And settled_status is unchanged for it, that is it did not flip to committed.
+        assert_eq!(
+            tm.settled_status(tx_abort.txn_id),
+            TransactionStatus::Aborted
+        );
     }
 
     #[test]

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -587,4 +587,26 @@ mod tests {
         // And settled_status is unchanged for it, that is it did not flip to committed. 
         assert_eq!(tm.settled_status(tx_abort.txn_id), TransactionStatus::Aborted);
     }
+
+    #[test]
+    fn test_truncate_clog_drops_aborted_below_vacuum_horizon() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+
+        let tx_abort = tm.begin();
+        tm.mark_aborted(tx_abort.txn_id);
+
+        let txc1 = tm.begin();
+        tm.mark_committed(txc1.txn_id);
+        let _txc2 = tm.begin();
+
+        tm.publish_vacuum_horizon(txc1.txn_id);
+        let committed_horizon = tm.global_xmin();
+        tm.truncate_clog(committed_horizon);
+
+        assert_eq!(
+            tm.clog.read().unwrap().get(&tx_abort.txn_id),
+            None,
+            "aborted entry below vacuum_horizon must not survive",
+        );
+    }
 }

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -552,4 +552,39 @@ mod tests {
             Some(&TransactionStatus::Active)
         );
     }
+
+    #[test]
+    fn test_truncate_clog_retains_aborted_above_vacuum_horizon() {
+        let tm = std::sync::Arc::new(TransactionManager::new());
+        
+        //make a dummy entry into the database, followed by an aborted entry 
+        //and then a dummy entry again to mark global_xmin > aborted_txn.txn_id
+
+        //txc2 was not committed - which means global_xmin will set to it's txn_id
+        //when a sweep runs 
+        let txc1 = tm.begin();
+        let tx_abort = tm.begin();
+        let _txc2 = tm.begin();
+
+        tm.mark_committed(txc1.txn_id);
+        tm.mark_aborted(tx_abort.txn_id);
+
+        //now, we run a full sweep
+        tm.publish_vacuum_horizon(tx_abort.txn_id-1); // so that the horizon is below the aborted txn's id 
+
+        let committed_horizon = tm.global_xmin();
+        assert!(tx_abort.txn_id < committed_horizon);
+        assert!(tm.vacuum_horizon() < tx_abort.txn_id);
+
+        tm.truncate_clog(committed_horizon);
+
+        //Now the mandatory asserts - the transaction is still present in the map 
+        assert_eq!(
+           tm.clog.read().unwrap().get(&tx_abort.txn_id),
+           Some(&TransactionStatus::Aborted),
+           "aborted entry below global_xmin but above vacuum_horizon must survive",
+        );
+        // And settled_status is unchanged for it, that is it did not flip to committed. 
+        assert_eq!(tm.settled_status(tx_abort.txn_id), TransactionStatus::Aborted);
+    }
 }


### PR DESCRIPTION
## Summary
Makes CLOG truncation two-tier so `Aborted` entries aren't pinned forever. They can
now be dropped once a completed sweep's `vacuum_horizon` (VAC-1, #86) proves their
tuples are physically gone (DESIGN §8.4).

## Changes
- `truncate_clog` rewritten as a `match` over `TransactionStatus`: `Committed` dropped below `committed_horizon` (`global_xmin`); `Aborted` dropped only below `vacuum_horizon()`; `Active` always kept.
- Renamed `horizon` → `committed_horizon`, same single-`u64` signature (drop-in). On restart `vacuum_horizon == 0` ⇒ no aborts dropped (safe default).
- Added 2 tests: aborted entry above `vacuum_horizon` survives below `global_xmin`; below `vacuum_horizon` it's dropped.

## Related Issue
Closes #87

## Any design changes?
No — implements DESIGN §8.4. Signature unchanged; engine wiring and checkpoint serialization out of scope.

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes