### PR TITLE
feat(storage): Implement dirty-page tracking with rec_lsn and FPI decision

### DIFF
--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -1,5 +1,6 @@
 use crate::buffer_pool::shard::{BufferPoolShard, PageReadGuard, PageWriteGuard};
 use crate::disk::DiskManager;
+use crate::page::Lsn;
 use crate::wal::Wal;
 use common::{BufferPoolError, MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
 use std::cmp::max;
@@ -288,5 +289,21 @@ impl BufferPoolManager {
             dirty: false,
             record_lsn: None,
         })
+    }
+
+    /// Returns the min rec_lsn among all the frame or None if no
+    ///This point is the redo point
+    pub fn min_rec_lsn(&self) -> Option<Lsn> {
+        self.shards
+            .iter()
+            .flat_map(|shard| {
+                let inner = shard.inner.lock().unwrap();
+                inner
+                    .metadata
+                    .iter()
+                    .filter_map(|m| if m.is_dirty { m.rec_lsn } else { None })
+                    .collect::<Vec<_>>()
+            })
+            .min()
     }
 }

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -291,19 +291,12 @@ impl BufferPoolManager {
         })
     }
 
-    /// Returns the min rec_lsn among all the frame or None if no
+    /// Returns the min rec_lsn among all the frame by comparing minimun lsn of the shards
     ///This point is the redo point
     pub fn min_rec_lsn(&self) -> Option<Lsn> {
         self.shards
             .iter()
-            .flat_map(|shard| {
-                let inner = shard.inner.lock().unwrap();
-                inner
-                    .metadata
-                    .iter()
-                    .filter_map(|m| if m.is_dirty { m.rec_lsn } else { None })
-                    .collect::<Vec<_>>()
-            })
+            .filter_map(|shard| shard.inner.lock().unwrap().min_rec_lsn)
             .min()
     }
 }

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -10,8 +10,8 @@ pub type Result<T> = std::result::Result<T, BufferPoolError>;
 
 /// The main manager for the buffer pool, providing a partitioned cache for disk pages.
 pub struct BufferPoolManager {
-    pub shards: Vec<BufferPoolShard>,
-    pub next_page_id: Mutex<u64>,
+    pub(crate) shards: Vec<BufferPoolShard>,
+     next_page_id: Mutex<u64>,
 }
 
 impl BufferPoolManager {

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -11,7 +11,7 @@ pub type Result<T> = std::result::Result<T, BufferPoolError>;
 /// The main manager for the buffer pool, providing a partitioned cache for disk pages.
 pub struct BufferPoolManager {
     pub(crate) shards: Vec<BufferPoolShard>,
-     next_page_id: Mutex<u64>,
+    next_page_id: Mutex<u64>,
 }
 
 impl BufferPoolManager {

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -78,6 +78,7 @@ impl BufferPoolManager {
             page_id,
             guard: Some(data),
             dirty: false,
+            record_lsn: None,
         })
     }
 
@@ -184,6 +185,7 @@ impl BufferPoolManager {
             page_id,
             guard: Some(data),
             dirty: false,
+            record_lsn: None,
         })
     }
 
@@ -284,6 +286,7 @@ impl BufferPoolManager {
             page_id,
             guard: Some(data),
             dirty: false,
+            record_lsn: None,
         })
     }
 }

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -10,8 +10,8 @@ pub type Result<T> = std::result::Result<T, BufferPoolError>;
 
 /// The main manager for the buffer pool, providing a partitioned cache for disk pages.
 pub struct BufferPoolManager {
-    shards: Vec<BufferPoolShard>,
-    next_page_id: Mutex<u64>,
+    pub shards: Vec<BufferPoolShard>,
+    pub next_page_id: Mutex<u64>,
 }
 
 impl BufferPoolManager {

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -12,6 +12,7 @@ use common::{INVALID_FRAME_ID, MAX_PAGE_SIZE};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Condvar, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::atomic::{AtomicU64,Ordering};
 
 type Result<T> = std::result::Result<T, BufferPoolError>;
 
@@ -118,6 +119,7 @@ pub struct FrameMetadata {
     pub pin_count: u64,
     pub is_dirty: bool,
     pub loading: bool, // true while a load is in flight; frame not usable yet
+    pub rec_lsn: Option<u64>, // Added a recovery lsn for each lsn, the lowest rec_lsn among all dirty page is selected for new redo point
 }
 
 /// Internal state of a buffer pool shard, protected by a mutex.
@@ -135,6 +137,7 @@ pub struct BufferPoolShard {
     pub inner: Mutex<ShardInner>,
     pub load_done: Condvar, // singalled when any load finishes(success or fail)
     pub wal: Arc<Wal>,
+    pub last_checkpoint_redo_point: AtomicU64, // it contains the last checkpoint redo point
 }
 
 impl BufferPoolShard {
@@ -148,6 +151,7 @@ impl BufferPoolShard {
                 pin_count: 0,
                 is_dirty: false,
                 loading: false,
+                rec_lsn: None,
             });
             free_list.push(size - 1 - frame_id);
         }
@@ -163,6 +167,8 @@ impl BufferPoolShard {
             }),
             load_done: Condvar::new(),
             wal,
+            last_checkpoint_redo_point: AtomicU64::new(0), //lsn 0 is null pageLsn
+
         }
     }
 
@@ -422,4 +428,5 @@ impl BufferPoolShard {
             return Ok(());
         }
     }
+    
 }

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -147,7 +147,7 @@ pub struct FrameMetadata {
 
 /// Internal state of a buffer pool shard, protected by a mutex.
 pub struct ShardInner {
-    pub metadata: Vec<FrameMetadata>, 
+    pub metadata: Vec<FrameMetadata>,
     pub page_table: HashMap<u64, usize>,
     pub free_list: Vec<usize>,
     pub replacer: ClockReplacer,

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -7,6 +7,7 @@
 use crate::buffer_pool::replacer::ClockReplacer;
 use crate::disk::DiskManager;
 use crate::wal::Wal;
+use crate::page::Lsn;
 use common::BufferPoolError;
 use common::{INVALID_FRAME_ID, MAX_PAGE_SIZE};
 use std::collections::HashMap;
@@ -429,4 +430,23 @@ impl BufferPoolShard {
         }
     }
     
+    /// returns 'true' if the FPI is to be attached with WAL record
+    /// page_lsn_before <= redo_point ensures that this is the first change in page after the last checkpoint
+    pub fn mark_dirty(&self, page_id:u64 ,lsn:Lsn,page_lsn_before: Lsn) -> bool{
+        let redo_point = self.last_checkpoint_redo_point.load(Ordering::Relaxed);
+        let mut inner = self.inner.lock().unwrap() ;
+
+        if let Some(&frame_id) = inner.page_table.get(&page_id){
+            let meta = &mut inner.metadata[frame_id];
+            let was_clean = meta.is_dirty;
+            meta.is_dirty = true;
+
+            if was_clean{
+                meta.rec_lsn = Some(lsn);
+                return page_lsn_before<= redo_point;
+            }
+
+        }
+        false
+    }
 }

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -6,14 +6,14 @@
 
 use crate::buffer_pool::replacer::ClockReplacer;
 use crate::disk::DiskManager;
-use crate::wal::Wal;
 use crate::page::Lsn;
+use crate::wal::Wal;
 use common::BufferPoolError;
 use common::{INVALID_FRAME_ID, MAX_PAGE_SIZE};
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::sync::atomic::{AtomicU64,Ordering};
 
 type Result<T> = std::result::Result<T, BufferPoolError>;
 
@@ -83,6 +83,7 @@ pub struct PageWriteGuard<'a> {
     pub(crate) page_id: u64,
     pub(crate) guard: Option<RwLockWriteGuard<'a, PageData>>,
     pub(crate) dirty: bool,
+    pub(crate) record_lsn: Option<Lsn>,
 }
 
 impl<'a> Deref for PageWriteGuard<'a> {
@@ -110,7 +111,23 @@ impl<'a> Drop for PageWriteGuard<'a> {
         if let Some(guard) = self.guard.take() {
             drop(guard);
         }
-        self.shard.unpin_page(self.page_id, self.dirty);
+        let needs_dirty_unpin = self.dirty && self.record_lsn.is_none();
+        self.shard.unpin_page(self.page_id, needs_dirty_unpin);
+    }
+}
+
+impl<'a> PageWriteGuard<'a> {
+    pub fn mark_dirty_with_lsn(&mut self, lsn: Lsn) -> bool {
+        self.dirty = true;
+        self.record_lsn = Some(lsn);
+
+        let old_page_lsn = if let Some(guard) = &self.guard {
+            crate::page::page_lsn(&guard[..])
+        } else {
+            0
+        };
+
+        self.shard.mark_dirty(self.page_id, lsn, old_page_lsn)
     }
 }
 
@@ -169,7 +186,6 @@ impl BufferPoolShard {
             load_done: Condvar::new(),
             wal,
             last_checkpoint_redo_point: AtomicU64::new(0), //lsn 0 is null pageLsn
-
         }
     }
 
@@ -323,6 +339,9 @@ impl BufferPoolShard {
         if let Err(e) = res {
             inner.metadata[frame_id].is_dirty = true;
             return Err(e);
+        } else {
+            //When WRITE is succeded it is safe to clear the lsn
+            inner.metadata[frame_id].rec_lsn = None;
         }
 
         Ok(true)
@@ -429,23 +448,22 @@ impl BufferPoolShard {
             return Ok(());
         }
     }
-    
+
     /// returns 'true' if the FPI is to be attached with WAL record
     /// page_lsn_before <= redo_point ensures that this is the first change in page after the last checkpoint
-    pub fn mark_dirty(&self, page_id:u64 ,lsn:Lsn,page_lsn_before: Lsn) -> bool{
+    pub fn mark_dirty(&self, page_id: u64, lsn: Lsn, page_lsn_before: Lsn) -> bool {
         let redo_point = self.last_checkpoint_redo_point.load(Ordering::Relaxed);
-        let mut inner = self.inner.lock().unwrap() ;
+        let mut inner = self.inner.lock().unwrap();
 
-        if let Some(&frame_id) = inner.page_table.get(&page_id){
+        if let Some(&frame_id) = inner.page_table.get(&page_id) {
             let meta = &mut inner.metadata[frame_id];
             let was_clean = meta.is_dirty;
             meta.is_dirty = true;
 
-            if was_clean{
+            if was_clean {
                 meta.rec_lsn = Some(lsn);
-                return page_lsn_before<= redo_point;
+                return page_lsn_before <= redo_point;
             }
-
         }
         false
     }

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -462,7 +462,7 @@ impl BufferPoolShard {
 
         if let Some(&frame_id) = inner.page_table.get(&page_id) {
             let meta = &mut inner.metadata[frame_id];
-            let was_clean = meta.is_dirty;
+            let was_clean = !meta.is_dirty;
             meta.is_dirty = true;
 
             //Check if it is the first change after the checkpoint

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -142,12 +142,12 @@ pub struct FrameMetadata {
     pub pin_count: u64,
     pub is_dirty: bool,
     pub loading: bool, // true while a load is in flight; frame not usable yet
-    pub rec_lsn: Option<u64>, // Added a recovery lsn for each lsn, the lowest rec_lsn among all dirty page is selected for new redo point
+    pub rec_lsn: Option<Lsn>, // Added a recovery lsn for each lsn, the lowest rec_lsn among all dirty page is selected for new redo point
 }
 
 /// Internal state of a buffer pool shard, protected by a mutex.
 pub struct ShardInner {
-    pub metadata: Vec<FrameMetadata>,
+    pub metadata: Vec<FrameMetadata>, 
     pub page_table: HashMap<u64, usize>,
     pub free_list: Vec<usize>,
     pub replacer: ClockReplacer,

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -116,6 +116,11 @@ impl<'a> Drop for PageWriteGuard<'a> {
     }
 }
 
+/// Marks the page as dirty and associates it with the WAL record LSN that caused the change.
+///
+/// This reads the old page LSN before the mutation occurs and passes it to the shard.
+/// Returns `true` if this is the first change since the last checkpoint, indicating
+/// the caller must log a Full-Page Image (FPI).
 impl<'a> PageWriteGuard<'a> {
     pub fn mark_dirty_with_lsn(&mut self, lsn: Lsn) -> bool {
         self.dirty = true;
@@ -460,6 +465,7 @@ impl BufferPoolShard {
             let was_clean = meta.is_dirty;
             meta.is_dirty = true;
 
+            //Check if it is the first change after the checkpoint
             if was_clean {
                 meta.rec_lsn = Some(lsn);
                 return page_lsn_before <= redo_point;

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -151,6 +151,7 @@ pub struct ShardInner {
     pub page_table: HashMap<u64, usize>,
     pub free_list: Vec<usize>,
     pub replacer: ClockReplacer,
+    pub min_rec_lsn: Option<Lsn>,
 }
 
 /// A shard of the buffer pool, managing a subset of the total frames.
@@ -187,6 +188,7 @@ impl BufferPoolShard {
                 page_table: HashMap::with_capacity(size),
                 free_list,
                 replacer: ClockReplacer::new(size),
+                min_rec_lsn: None,
             }),
             load_done: Condvar::new(),
             wal,
@@ -345,8 +347,19 @@ impl BufferPoolShard {
             inner.metadata[frame_id].is_dirty = true;
             return Err(e);
         } else {
+            let old_rec_lsn = inner.metadata[frame_id].rec_lsn; //saving before clearing it
             //When WRITE is succeded it is safe to clear the lsn
             inner.metadata[frame_id].rec_lsn = None;
+
+            //when page with min_rec_lsn itself is flushed
+            if old_rec_lsn == inner.min_rec_lsn {
+                inner.min_rec_lsn = inner
+                    .metadata
+                    .iter()
+                    .filter(|m| m.is_dirty)
+                    .filter_map(|m| m.rec_lsn)
+                    .min()
+            }
         }
 
         Ok(true)
@@ -468,6 +481,11 @@ impl BufferPoolShard {
             //Check if it is the first change after the checkpoint
             if was_clean {
                 meta.rec_lsn = Some(lsn);
+
+                //Comparing the recent lsn with min_rec_lsn of the shard and update it
+                if inner.min_rec_lsn == None || lsn < inner.min_rec_lsn.unwrap() {
+                    inner.min_rec_lsn = Some(lsn);
+                }
                 return page_lsn_before <= redo_point;
             }
         }

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -483,7 +483,7 @@ impl BufferPoolShard {
                 meta.rec_lsn = Some(lsn);
 
                 //Comparing the recent lsn with min_rec_lsn of the shard and update it
-                if inner.min_rec_lsn == None || lsn < inner.min_rec_lsn.unwrap() {
+                if inner.min_rec_lsn.is_none() || lsn < inner.min_rec_lsn.unwrap() {
                     inner.min_rec_lsn = Some(lsn);
                 }
                 return page_lsn_before <= redo_point;

--- a/crates/storage/src/buffer_pool/tests.rs
+++ b/crates/storage/src/buffer_pool/tests.rs
@@ -366,7 +366,7 @@ fn test_rec_lsn_and_fpi_flag() {
         crate::page::set_lsn(&mut *guard_b, 15);
     }
 
-    // set_lsn make page dirty, flush them to make clean 
+    // set_lsn make page dirty, flush them to make clean
     // successful fpi check requires page to be clean
     bpm.flush_page(page_a_id).unwrap();
     bpm.flush_page(page_b_id).unwrap();

--- a/crates/storage/src/buffer_pool/tests.rs
+++ b/crates/storage/src/buffer_pool/tests.rs
@@ -339,3 +339,75 @@ fn test_buffer_pool_manager_pin_count() {
     drop(pages);
     assert!(bpm.new_page().is_ok());
 }
+
+#[test]
+fn test_rec_lsn_and_fpi_flag() {
+    use std::sync::atomic::Ordering;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("test.db");
+
+    let disk_manager = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
+    let bpm = make_bpm(disk_manager, &dir);
+
+    let page_a_id;
+    let page_b_id;
+
+    //Manually assigning lsn value to different pages
+    //Page A : LSN = 5 <= Last_checkpoint_redo_point:10 (requires FPI)
+    //Page B : LSN = 15 >= Last_checkpoint_redo_point:10 (doesnt require FPI)
+    {
+        let mut guard_a = bpm.new_page().unwrap();
+        page_a_id = guard_a.page_id;
+        crate::page::set_lsn(&mut *guard_a, 5);
+
+        let mut guard_b = bpm.new_page().unwrap();
+        page_b_id = guard_b.page_id;
+        crate::page::set_lsn(&mut *guard_b, 15);
+    }
+
+    // set_lsn make page dirty, flush them to make clean 
+    // successful fpi check requires page to be clean
+    bpm.flush_page(page_a_id).unwrap();
+    bpm.flush_page(page_b_id).unwrap();
+
+    for shard in &bpm.shards {
+        shard
+            .last_checkpoint_redo_point
+            .store(10, Ordering::Relaxed);
+    }
+
+    let mut guard_a = bpm.fetch_page_mut(page_a_id).unwrap();
+    let needs_fpi_a = guard_a.mark_dirty_with_lsn(20);
+    assert!(needs_fpi_a, "Page A:First write needs fpi");
+
+    let mut guard_b = bpm.fetch_page_mut(page_b_id).unwrap();
+    let needs_fpi_b = guard_b.mark_dirty_with_lsn(21);
+    assert!(!needs_fpi_b, "Page B: No fpi needed");
+
+    drop(guard_a);
+    drop(guard_b);
+
+    // After dirtying A (LSN 20) and B (LSN 21), before any flush:
+    assert_eq!(
+        bpm.min_rec_lsn(),
+        Some(20),
+        "redo point should be min of rec_lsns"
+    );
+    bpm.flush_page(page_a_id).unwrap();
+
+    //After flushing page A, only page B rec_lsn should remain
+    assert_eq!(
+        bpm.min_rec_lsn(),
+        Some(21),
+        "After flushing Page A, min_rec_lsn should only see Page B's rec_lsn (21)"
+    );
+
+    // No dirty page remained -> None
+    bpm.flush_page(page_b_id).unwrap();
+    assert_eq!(
+        bpm.min_rec_lsn(),
+        None,
+        "After flushing all pages, min_rec_lsn must be None"
+    );
+}


### PR DESCRIPTION
## Summary
This PR implements dirty-page tracking by introducing `rec_lsn` for buffer pool frames. It ensures that the checkpointer can correctly compute the next redo point, and accurately triggers Full-Page Image (FPI) generation on the clean-to-dirty edge for the first mutation after a checkpoint, preventing torn-page data loss during recovery.

## Changes
- Added `last_checkpoint_redo_point` to `BufferPoolShard` to track the boundary of the last checkpoint.
- Added `rec_lsn` to `FrameMetadata` to track the WAL record LSN that first dirtied the page, and clear it safely upon a successful `flush_page_inner`.
- Implemented `mark_dirty` on `BufferPoolShard` to calculate the `needs_fpi` flag dynamically when a page crosses the clean-to-dirty edge.
- Updated `PageWriteGuard` to carry `record_lsn` via a new `mark_dirty_with_lsn` hook, ensuring LSNs are captured directly from the write site rather than implicitly on drop.
- Added `min_rec_lsn()` to `BufferPoolManager` so the checkpointer can quickly compute the lowest redo point across all shards.
- Wrote `test_rec_lsn_and_fpi_flag` to verify proper state transitions and FPI boundary calculations.

## Related Issue
Closes #91 

## Any design changes?
Yes, the core structures of the buffer pool were updated to track checkpoint state:
- **`BufferPoolManager`**: The `shards` field was changed to `pub(crate)` to allow testing while maintaining encapsulation.
- **`BufferPoolShard`**: Added `last_checkpoint_redo_point` to track the boundary of the last checkpoint.
- **`FrameMetadata`**: Added `rec_lsn` to track the WAL record LSN that first dirtied the page.
- **`PageWriteGuard`**: Added `record_lsn` to capture LSNs directly from the write site.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated
- [x] No breaking changes