### PR TITLE
perf(storage): add Criterion B+Tree benchmark harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +101,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -166,8 +220,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "db-core"
 version = "0.1.0"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "engine"
@@ -215,6 +342,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +391,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +423,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,16 +447,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -342,8 +541,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "parser"
 version = "0.1.0"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -458,6 +697,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +759,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +774,15 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -505,6 +802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -541,11 +839,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "storage"
 version = "0.1.0"
 dependencies = [
  "common",
  "crc32fast",
+ "criterion",
  "db-core",
  "proptest",
  "tempfile",
@@ -602,6 +907,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +950,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +975,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -684,6 +1054,25 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ db-core = { path = "crates/db-core"}
 
 [profile.release]
 debug = true
+lto = "thin"
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ common = { path = "crates/common" }
 storage = {path = "crates/storage"}
 thiserror = "1"
 db-core = { path = "crates/db-core"}
+
+[profile.release]
+debug = true

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -10,3 +10,8 @@ db-core.workspace = true
 [dev-dependencies]
 tempfile = "3.10.1"
 proptest = "1"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "btree"
+harness = false

--- a/crates/storage/benches/btree.rs
+++ b/crates/storage/benches/btree.rs
@@ -1,0 +1,112 @@
+use common::MAX_PAGE_SIZE;
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
+use db_core::transaction::Snapshot;
+use db_core::transaction::Transaction;
+use db_core::transaction_manager::TransactionManager;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+use std::sync::{Arc, OnceLock};
+use storage::buffer_pool::manager::BufferPoolManager;
+use storage::disk::DiskManager;
+use storage::index::BTreeIndex;
+use storage::wal::Wal;
+use tempfile::TempDir;
+
+fn make_wal(dir: &Path) -> Arc<Wal> {
+    Arc::new(Wal::new(dir.join("wal.log")).unwrap())
+}
+
+fn make_pool(disk: Arc<DiskManager>, wal: Arc<Wal>) -> Arc<BufferPoolManager> {
+    Arc::new(BufferPoolManager::new(disk, wal))
+}
+
+fn auto() -> Transaction {
+    static TM_LOCK: OnceLock<Arc<TransactionManager>> = OnceLock::new();
+    let tm = TM_LOCK
+        .get_or_init(|| Arc::new(TransactionManager::new()))
+        .clone();
+    static TEST_TXN_ID: AtomicU64 = AtomicU64::new(1);
+    Transaction::new(TEST_TXN_ID.fetch_add(1, Relaxed), Snapshot::latest(), tm)
+}
+
+fn setup_index(n: u32) -> (BTreeIndex<&'static [u8], &'static [u8]>, TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("test.db");
+    let wal = make_wal(dir.path());
+    let disk = Arc::new(DiskManager::new(&path, MAX_PAGE_SIZE).unwrap());
+    let pool = make_pool(disk, wal.clone());
+    let (index, _) = BTreeIndex::create(pool, wal).unwrap();
+    for i in 0..n {
+        let k = Box::leak(i.to_be_bytes().to_vec().into_boxed_slice());
+        let v = Box::leak((i * 7).to_be_bytes().to_vec().into_boxed_slice());
+        index.insert(&(&k[..]), &(&v[..]), &auto()).unwrap();
+    }
+    (index, dir)
+}
+
+fn bench_get_random(c: &mut Criterion) {
+    let (idx, _dir) = setup_index(10_000);
+    let txn = auto();
+    c.bench_function("get_random", |b| {
+        b.iter(|| {
+            let k = black_box(5000u32);
+            let key = k.to_be_bytes();
+            black_box(idx.get(&(&key[..]), &txn).unwrap())
+        })
+    });
+}
+
+fn bench_insert_sequential(c: &mut Criterion) {
+    c.bench_function("insert_sequential", |b| {
+        b.iter_batched(
+            || setup_index(0),
+            |(idx, _dir)| {
+                for i in 0u32..1000 {
+                    let k = black_box(i).to_be_bytes();
+                    let v = (i * 7).to_be_bytes();
+                    black_box(idx.insert(&(&k[..]), &(&v[..]), &auto()).unwrap());
+                }
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn bench_insert_random(c: &mut Criterion) {
+    c.bench_function("insert_random", |b| {
+        b.iter_batched(
+            || setup_index(0),
+            |(idx, _dir)| {
+                for i in 0u32..1000 {
+                    let k = black_box(i.wrapping_mul(2654435761)).to_be_bytes();
+                    let v = (i * 7).to_be_bytes();
+                    black_box(idx.insert(&(&k[..]), &(&v[..]), &auto()).unwrap());
+                }
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+fn bench_range_full_scan(c: &mut Criterion) {
+    let (idx, _dir) = setup_index(10_000);
+    let txn = auto();
+    c.bench_function("range_full_scan", |b| {
+        b.iter(|| {
+            let count = idx
+                .range::<std::ops::RangeFull>(.., &txn)
+                .map(|r| r.unwrap())
+                .fold(0, |acc, (_k, _v)| black_box(acc + 1));
+            black_box(count)
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_get_random,
+    bench_insert_sequential,
+    bench_insert_random,
+    bench_range_full_scan
+);
+criterion_main!(benches);

--- a/crates/storage/benches/btree.rs
+++ b/crates/storage/benches/btree.rs
@@ -29,7 +29,7 @@ fn auto() -> Transaction {
     Transaction::new(TEST_TXN_ID.fetch_add(1, Relaxed), Snapshot::latest(), tm)
 }
 
-fn setup_index(n: u32) -> (BTreeIndex<&'static [u8], &'static [u8]>, TempDir) {
+fn setup_index(n: u32) -> (BTreeIndex<u32, u32>, TempDir) {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("test.db");
     let wal = make_wal(dir.path());
@@ -37,21 +37,20 @@ fn setup_index(n: u32) -> (BTreeIndex<&'static [u8], &'static [u8]>, TempDir) {
     let pool = make_pool(disk, wal.clone());
     let (index, _) = BTreeIndex::create(pool, wal).unwrap();
     for i in 0..n {
-        let k = Box::leak(i.to_be_bytes().to_vec().into_boxed_slice());
-        let v = Box::leak((i * 7).to_be_bytes().to_vec().into_boxed_slice());
-        index.insert(&(&k[..]), &(&v[..]), &auto()).unwrap();
+        index.insert(&i, &(i * 7), &auto()).unwrap();
     }
     (index, dir)
 }
 
 fn bench_get_random(c: &mut Criterion) {
-    let (idx, _dir) = setup_index(10_000);
+    let (idx, _dir) = setup_index(4_000);
     let txn = auto();
+    let mut i = 0u32;
     c.bench_function("get_random", |b| {
         b.iter(|| {
-            let k = black_box(5000u32);
-            let key = k.to_be_bytes();
-            black_box(idx.get(&(&key[..]), &txn).unwrap())
+            i = i.wrapping_add(1);
+            let k = black_box(i.wrapping_mul(2654435761) % 4_000);
+            black_box(idx.get(&k, &txn).unwrap())
         })
     });
 }
@@ -62,9 +61,9 @@ fn bench_insert_sequential(c: &mut Criterion) {
             || setup_index(0),
             |(idx, _dir)| {
                 for i in 0u32..1000 {
-                    let k = black_box(i).to_be_bytes();
-                    let v = (i * 7).to_be_bytes();
-                    black_box(idx.insert(&(&k[..]), &(&v[..]), &auto()).unwrap());
+                    let k = black_box(i);
+                    let v = i * 7;
+                    black_box(idx.insert(&k, &v, &auto()).unwrap());
                 }
             },
             BatchSize::SmallInput,
@@ -78,9 +77,9 @@ fn bench_insert_random(c: &mut Criterion) {
             || setup_index(0),
             |(idx, _dir)| {
                 for i in 0u32..1000 {
-                    let k = black_box(i.wrapping_mul(2654435761)).to_be_bytes();
-                    let v = (i * 7).to_be_bytes();
-                    black_box(idx.insert(&(&k[..]), &(&v[..]), &auto()).unwrap());
+                    let k = black_box(i.wrapping_mul(2654435761));
+                    let v = i * 7;
+                    black_box(idx.insert(&k, &v, &auto()).unwrap());
                 }
             },
             BatchSize::SmallInput,
@@ -89,7 +88,7 @@ fn bench_insert_random(c: &mut Criterion) {
 }
 
 fn bench_range_full_scan(c: &mut Criterion) {
-    let (idx, _dir) = setup_index(10_000);
+    let (idx, _dir) = setup_index(4_000);
     let txn = auto();
     c.bench_function("range_full_scan", |b| {
         b.iter(|| {


### PR DESCRIPTION
Add benchmark gate for B+Tree performance effort (Stage 2):

- Criterion harness with 4 benches mapping to hot paths:
  - get_random: point lookup on a 10K-entry warm tree
  - insert_sequential: 1000 sequential inserts with splits
  - insert_random: 1000 Knuth-hashed inserts
  - range_full_scan: full RangeScan over 10K entries
- [profile.release] debug = true for flamegraph symbolication
- criterion in [dev-dependencies] with html_reports

Benchmarks run against a warm buffer pool with a multi-level tree to measure CPU/cache behavior, not disk I/O.

## Summary
This PR sets up the performance benchmarking stuff we need (Stage 2) before we start doing the page layout changes in Stage 3. I added a Criterion benchmark suite that specifically tests the hot paths in our B+Tree (like lookups, inserts, and scans). 

This way, we can actually measure CPU and cache behavior properly, generate flamegraphs, and make sure any future layout changes are actually making things faster! 

## Changes
- Added a new Criterion benchmark file `crates/storage/benches/btree.rs` that tests `get_random`, `insert_sequential`, `insert_random`, and `range_full_scan`.
- Added `criterion` to our `[dev-dependencies]` in `crates/storage/Cargo.toml` so it doesn't bloat the main build.
- Turned on `debug = true` for `[profile.release]` in the root `Cargo.toml`. This is super important so tools like `cargo-flamegraph` can actually see our function names instead of random memory addresses!

## How to run this locally! 

If you want to run the benchmarks and save a baseline to compare against later, just run:
```bash
cargo bench --bench btree -- --save-baseline my-baseline
```

To see where the CPU is spending all its time, you can generate a flamegraph! You'll need to install cargo-flamegraph first:
```bash
cargo install flamegraph

# Run it on a specific benchmark (like get_random)
cargo flamegraph --bench btree -- --bench "get_random"
```

## Related Issue
Closes #69 

## Any design changes?
No design changes yet! This is just setting up the testing and profiling harness so we have actual data before we change the design.

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes