### PR TITLE
fix(index): abort stale writer instead of duplicating a live version

### DIFF
--- a/crates/engine/tests/stale_update.rs
+++ b/crates/engine/tests/stale_update.rs
@@ -1,0 +1,78 @@
+//! Deterministic check of the first-writer-wins contract on a stale snapshot.
+//!
+//! Project model (CLAUDE.md): "first-writer-wins — if two transactions try to
+//! write the same key, the second gets `WriteConflict`."
+//!
+//! Scenario:
+//!   1. K = 0, committed.
+//!   2. T begins (snapshot sees K=0).
+//!   3. C updates K = 100 and commits — C started AFTER T's snapshot.
+//!   4. T updates K = 200 on its now-stale snapshot.
+//!
+//! C committed first, so T is the second writer → T's update MUST fail with a
+//! conflict, and the durable value MUST stay 100. If T's update returns `Ok`
+//! and the final value is 200, C's committed write was silently lost.
+
+use engine::{Engine, EngineError};
+use tempfile::TempDir;
+
+fn engine() -> (Engine<u32, u32>, TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let e = Engine::<u32, u32>::create(dir.path()).unwrap();
+    (e, dir)
+}
+
+/// The decisive corruption check: after the scenario the key must have EXACTLY
+/// one coherent committed value. It can be either:
+///   - 100, if T correctly conflicted (first-writer-wins), or
+///   - 200, if the engine chose last-writer-wins and T's commit truly applied.
+/// The bug produces a THIRD, incoherent outcome: T's update returns `Ok` and
+/// commits, yet the read returns 100 — proving T's committed write is a phantom
+/// shadowed by a second live version left on the key.
+#[test]
+fn stale_snapshot_update_stays_coherent() {
+    let (e, _dir) = engine();
+    e.insert(&1, &0).unwrap();
+
+    let mut t = e.begin();
+    e.update(&1, &100).unwrap(); // C commits after T's snapshot
+
+    let t_ok = matches!(t.update(&1, &200), Ok(())) && t.commit().is_ok();
+    let final_val = u32::from_le_bytes(e.get(&1).unwrap().unwrap().try_into().unwrap());
+
+    println!("T.update+commit ok = {t_ok}, final value = {final_val}");
+
+    if t_ok {
+        // T believes it committed 200 → read-your-committed-write demands 200.
+        assert_eq!(
+            final_val, 200,
+            "CORRUPTION: T's update returned Ok and committed, but the key reads \
+             {final_val}. Two live versions coexist (C's 100 shadows T's 200) — \
+             the single-visible-version invariant is broken."
+        );
+    } else {
+        // T conflicted → C's value stands.
+        assert_eq!(final_val, 100, "T conflicted, so C's committed 100 must stand");
+    }
+}
+
+/// Same setup, but assert on the returned error kind: the second writer should
+/// see a conflict, never a silent success. Split out so the lost-update
+/// assertion above and the API-contract assertion here fail independently.
+#[test]
+fn stale_snapshot_update_must_report_conflict() {
+    let (e, _dir) = engine();
+    e.insert(&1, &0).unwrap();
+
+    let mut t = e.begin();
+    e.update(&1, &100).unwrap();
+
+    match t.update(&1, &200) {
+        Err(EngineError::TransactionConflict) => { /* correct: first-writer-wins */ }
+        Err(other) => panic!("expected TransactionConflict, got {other:?}"),
+        Ok(()) => panic!(
+            "stale second writer got Ok — first-writer-wins violated \
+             (should be WriteConflict/TransactionConflict)"
+        ),
+    }
+}

--- a/crates/engine/tests/stale_update.rs
+++ b/crates/engine/tests/stale_update.rs
@@ -1,7 +1,13 @@
-//! Deterministic check of the first-writer-wins contract on a stale snapshot.
+//! Deterministic check that a stale writer loses to an ALREADY-COMMITTED writer.
 //!
-//! Project model (CLAUDE.md): "first-writer-wins — if two transactions try to
-//! write the same key, the second gets `WriteConflict`."
+//! FluxDB resolves conflicts between two *in-progress* transactions with
+//! Wait-Die: the check returns `WaitFor`, then the older txn waits on a condvar
+//! (`wait_until_settled`) and retries while the younger dies with
+//! `WriteConflict`. This test targets a different branch of `check_write_conflict`
+//! — the one this PR fixes — where the conflicting writer has already COMMITTED
+//! before the stale txn writes. Nothing is in progress to wait on
+//! (`is_in_progress` is false), so Wait-Die never applies; the stale writer must
+//! simply lose with `WriteConflict` rather than overwrite the committed version.
 //!
 //! Scenario:
 //!   1. K = 0, committed.
@@ -9,9 +15,11 @@
 //!   3. C updates K = 100 and commits — C started AFTER T's snapshot.
 //!   4. T updates K = 200 on its now-stale snapshot.
 //!
-//! C committed first, so T is the second writer → T's update MUST fail with a
-//! conflict, and the durable value MUST stay 100. If T's update returns `Ok`
-//! and the final value is 200, C's committed write was silently lost.
+//! C is already committed when T writes, so T (a stale writer over a superseded
+//! version) MUST fail with `WriteConflict`, and the durable value MUST stay 100.
+//! If T's update returns `Ok` and the final value is 200, C's committed write was
+//! silently lost. Note T is the *older* txn here: it loses not by Wait-Die (an
+//! older txn would wait), but because C has already settled as committed.
 
 use engine::{Engine, EngineError};
 use tempfile::TempDir;
@@ -24,7 +32,7 @@ fn engine() -> (Engine<u32, u32>, TempDir) {
 
 /// The decisive corruption check: after the scenario the key must have EXACTLY
 /// one coherent committed value. It can be either:
-///   - 100, if T correctly conflicted (first-writer-wins), or
+///   - 100, if T correctly lost to the committed writer (WriteConflict), or
 ///   - 200, if the engine chose last-writer-wins and T's commit truly applied.
 /// The bug produces a THIRD, incoherent outcome: T's update returns `Ok` and
 /// commits, yet the read returns 100 — proving T's committed write is a phantom
@@ -68,11 +76,11 @@ fn stale_snapshot_update_must_report_conflict() {
     e.update(&1, &100).unwrap();
 
     match t.update(&1, &200) {
-        Err(EngineError::TransactionConflict) => { /* correct: first-writer-wins */ }
+        Err(EngineError::TransactionConflict) => { /* correct: stale writer loses to committed C */ }
         Err(other) => panic!("expected TransactionConflict, got {other:?}"),
         Ok(()) => panic!(
-            "stale second writer got Ok — first-writer-wins violated \
-             (should be WriteConflict/TransactionConflict)"
+            "stale second writer got Ok — a write over a committed-superseded version \
+             must fail with WriteConflict/TransactionConflict"
         ),
     }
 }

--- a/crates/engine/tests/stale_update.rs
+++ b/crates/engine/tests/stale_update.rs
@@ -60,7 +60,10 @@ fn stale_snapshot_update_stays_coherent() {
         );
     } else {
         // T conflicted → C's value stands.
-        assert_eq!(final_val, 100, "T conflicted, so C's committed 100 must stand");
+        assert_eq!(
+            final_val, 100,
+            "T conflicted, so C's committed 100 must stand"
+        );
     }
 }
 
@@ -76,7 +79,8 @@ fn stale_snapshot_update_must_report_conflict() {
     e.update(&1, &100).unwrap();
 
     match t.update(&1, &200) {
-        Err(EngineError::TransactionConflict) => { /* correct: stale writer loses to committed C */ }
+        Err(EngineError::TransactionConflict) => { /* correct: stale writer loses to committed C */
+        }
         Err(other) => panic!("expected TransactionConflict, got {other:?}"),
         Ok(()) => panic!(
             "stale second writer got Ok — a write over a committed-superseded version \

--- a/crates/storage/src/index/mod.rs
+++ b/crates/storage/src/index/mod.rs
@@ -795,9 +795,13 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         if txn.is_in_progress(rec_xmax) {
             return Err(IndexError::WaitFor(rec_xmax));
         }
-        // The modifier committed → version is already dead.
-        // Caller will get KeyNotFound since find_visible_slot won't find it.
-        Ok(())
+        // Settled. An aborted deleter's xmax is void → version still live → proceed.
+        if txn.tm.is_aborted(rec_xmax) {
+            return Ok(());
+        }
+        // A committed deleter superseded this version. Our snapshot is stale;
+        // first-writer-wins makes us the loser.
+        Err(IndexError::WriteConflict)
     }
 
     // ── Tree navigation ───────────────────────────────────────────────────────


### PR DESCRIPTION
### Problem
`check_write_conflict` returned `Ok(())` for any *settled* `rec_xmax`, without distinguishing commit from abort. When another transaction had already **committed** a write to a version, a transaction holding an older snapshot still (correctly) saw the old version as visible, and was then wrongly allowed to write over it.

This is the **already-committed conflict** case — distinct from the in-progress case, which Wait-Die handles correctly (`WaitFor` → older waits on a condvar and retries, younger dies with `WriteConflict`). Here nothing is in progress to wait on, so the stale writer should simply lose. Instead it proceeded: it stamped a second `xmax` on the old version and inserted its own new version → **two live versions of one key**. A later read returns whichever comes first, so a committed update can silently vanish. The accumulating extra live versions are the upstream cause of the transient `KeyNotFound` seen under contended updates.

### Fix
Split the settled case in `check_write_conflict`:
- **aborted** deleter → its `xmax` is void, version still live → proceed (`Ok`);
- **committed** deleter → version superseded → stale writer loses (`WriteConflict`).

Sequential paths are unaffected (a fresh snapshot always sees `rec_xmax == 0` on the visible version).

### Test
`crates/engine/tests/stale_update.rs` — deterministic two-transaction regression test. T snapshots, C updates+commits, T updates: before the fix T got `Ok` and the key ended with two live versions; after, T correctly gets `TransactionConflict`. Red before, green after; existing engine + storage suites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)