### PR TITLE
Implement Checkpoint Status Guard for commit/abort atomicity

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -16,6 +16,7 @@ use common::{EngineError, Key, Value};
 use db_core::transaction_manager::TransactionManager;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::RwLock;
 use storage::buffer_pool::BufferPoolManager;
 use storage::disk::DiskManager;
 use storage::index::BTreeIndex;
@@ -45,6 +46,7 @@ where
     #[allow(dead_code)]
     pub(crate) buffer_pool: Arc<BufferPoolManager>,
     pub(crate) transaction_manager: Arc<TransactionManager>,
+    pub(crate) status_guard: RwLock<()>,
 }
 
 impl<K, V> Engine<K, V>
@@ -84,6 +86,7 @@ where
             buffer_pool,
             disk_manager,
             transaction_manager,
+            status_guard:RwLock::new(()),
         })
     }
     /// Opens an existing database.
@@ -124,6 +127,7 @@ where
             buffer_pool,
             disk_manager,
             transaction_manager,
+            status_guard:RwLock::new(()),
         })
     }
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -46,6 +46,10 @@ where
     #[allow(dead_code)]
     pub(crate) buffer_pool: Arc<BufferPoolManager>,
     pub(crate) transaction_manager: Arc<TransactionManager>,
+
+    /// Invariant: a checkpoint snapshot never falls between the two steps of a commit or abort.
+    /// Commit and abort hold this in shared mode across their WAL append and CLOG update.
+    /// Checkpoints hold it in exclusive mode while picking a redo point and snapshotting.
     pub(crate) status_guard: RwLock<()>,
 }
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -86,7 +86,7 @@ where
             buffer_pool,
             disk_manager,
             transaction_manager,
-            status_guard:RwLock::new(()),
+            status_guard: RwLock::new(()),
         })
     }
     /// Opens an existing database.
@@ -127,7 +127,7 @@ where
             buffer_pool,
             disk_manager,
             transaction_manager,
-            status_guard:RwLock::new(()),
+            status_guard: RwLock::new(()),
         })
     }
 

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -33,6 +33,8 @@ where
             self.transaction_manager.mark_committed(txn.txn_id);
             return Ok(());
         }
+        //Starting the RwLock which will be active until the its dropped
+        let _guard = self.status_guard.read().unwrap();
 
         let lsn_res = self.wal.log_commit(txn.txn_id);
         if let Ok(lsn) = lsn_res {

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -34,7 +34,8 @@ where
             return Ok(());
         }
         //Starting the RwLock which will be active until the its dropped
-        let _guard = self.status_guard.read().unwrap();
+        // Ignore poison: lock holds no data, and doing this ensures checkpoint panics never crash user commits.
+        let _guard = self.status_guard.read().unwrap_or_else(|e| e.into_inner());
 
         let lsn_res = self.wal.log_commit(txn.txn_id);
         if let Ok(lsn) = lsn_res {
@@ -64,7 +65,7 @@ where
             return Ok(());
         }
         {
-            let _guard = self.status_guard.read().unwrap();
+            let _guard = self.status_guard.read().unwrap_or_else(|e| e.into_inner());
 
             let _ = self.wal.log_abort(txn.txn_id)?;
 

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -165,3 +165,61 @@ impl<K: Key, V: Value> Drop for TxnHandle<'_, K, V> {
         }
     }
 }
+
+#[cfg(test)]
+
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::thread;
+    use std::time::Duration;
+    use std::sync::Arc;
+
+    // A checkpoint (exclusive write lock) blocks commits until released.
+    // Proves the status_guard correctly serializes checkpoint vs commit.
+    // When status_guard is write, every other action is blocked unlike read
+    #[test]
+    fn test_status_guard_checkpoint_blocks_commits() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.db");
+        let engine = Arc::new(Engine::<u32,u32>::create(path).unwrap());
+        
+        let engine_clone = Arc::clone(&engine);
+        
+        // Simulate a checkpoint acquiring the exclusive lock
+        let checkpoint_guard = engine.status_guard.write().unwrap();
+        
+         // Spawn a thread that tries to commit a write transaction
+        let commit_thread = thread::spawn(move || {
+            let mut txn = engine_clone.begin();
+            txn.insert(&1u32,&30u32).unwrap();
+            txn.commit().unwrap();
+        });
+
+        thread::sleep(Duration::from_millis(50));
+
+        assert!(!commit_thread.is_finished(),"Commit failed to block ");
+
+        drop(checkpoint_guard);
+        commit_thread.join().expect("commit thread panicked");
+    }
+
+    // Two commits can hold the shared lock simultaneously.
+    // When status_guard is read only, other concurrent commit can still happen
+    #[test]
+    fn concurrent_commits_do_not_deadlock(){
+        let dir = tempdir().unwrap();
+        let engine = Engine::<u32, u32>::create(dir.path()).unwrap();
+
+        // Simulate another concurrent commit already holding the shared lock
+        let _simulated_guard = engine.status_guard.read().unwrap();
+
+        let mut txn = engine.begin();
+        txn.insert(&1u32,&30u32).unwrap();
+
+        //read does not block commit
+        let result = txn.commit();
+        assert!(result.is_ok(),"");
+
+    }
+}

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -64,6 +64,8 @@ where
             return Ok(());
         }
         {
+            let _guard = self.status_guard.read().unwrap();
+
             let _ = self.wal.log_abort(txn.txn_id)?;
 
             self.transaction_manager.mark_aborted(txn.txn_id);
@@ -170,10 +172,10 @@ impl<K: Key, V: Value> Drop for TxnHandle<'_, K, V> {
 
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
-    use std::sync::Arc;
+    use tempfile::tempdir;
 
     // A checkpoint (exclusive write lock) blocks commits until released.
     // Proves the status_guard correctly serializes checkpoint vs commit.
@@ -182,23 +184,23 @@ mod tests {
     fn test_status_guard_checkpoint_blocks_commits() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.db");
-        let engine = Arc::new(Engine::<u32,u32>::create(path).unwrap());
-        
+        let engine = Arc::new(Engine::<u32, u32>::create(path).unwrap());
+
         let engine_clone = Arc::clone(&engine);
-        
+
         // Simulate a checkpoint acquiring the exclusive lock
         let checkpoint_guard = engine.status_guard.write().unwrap();
-        
-         // Spawn a thread that tries to commit a write transaction
+
+        // Spawn a thread that tries to commit a write transaction
         let commit_thread = thread::spawn(move || {
             let mut txn = engine_clone.begin();
-            txn.insert(&1u32,&30u32).unwrap();
+            txn.insert(&1u32, &30u32).unwrap();
             txn.commit().unwrap();
         });
 
         thread::sleep(Duration::from_millis(50));
 
-        assert!(!commit_thread.is_finished(),"Commit failed to block ");
+        assert!(!commit_thread.is_finished(), "Commit failed to block ");
 
         drop(checkpoint_guard);
         commit_thread.join().expect("commit thread panicked");
@@ -207,7 +209,7 @@ mod tests {
     // Two commits can hold the shared lock simultaneously.
     // When status_guard is read only, other concurrent commit can still happen
     #[test]
-    fn concurrent_commits_do_not_deadlock(){
+    fn concurrent_commits_do_not_deadlock() {
         let dir = tempdir().unwrap();
         let engine = Engine::<u32, u32>::create(dir.path()).unwrap();
 
@@ -215,11 +217,10 @@ mod tests {
         let _simulated_guard = engine.status_guard.read().unwrap();
 
         let mut txn = engine.begin();
-        txn.insert(&1u32,&30u32).unwrap();
+        txn.insert(&1u32, &30u32).unwrap();
 
         //read does not block commit
         let result = txn.commit();
-        assert!(result.is_ok(),"");
-
+        assert!(result.is_ok(), "");
     }
 }


### PR DESCRIPTION
## Summary
This PR implements the Checkpoint Status Guard as dictated by `DESIGN.md` Section 7.2. It ensures that a checkpoint snapshot can never fall between the two steps of a transaction commit or abort (WAL append -> CLOG update).

## Changes
- Added `status_guard: RwLock<()>` to the `Engine` struct.
- Modified `Engine::commit` and `Engine::abort` to acquire the `status_guard` in shared (`.read()`) mode across both of their steps.
- Added a documentation comment defining the checkpoint invariant.
- Added concurrency unit tests in `txn.rs` proving that commits run concurrently, but block when an exclusive checkpoint lock is held.

**Note on Task 3:** The third task from the issue ticket ("Make the checkpoint take it in exclusive mode...") is not wired up in this PR because the `checkpoint()` function and WAL payload do not exist in the codebase yet. By merging this lock now, the groundwork is fully prepared for whoever implements the upcoming Checkpoint WAL record issue.

## Related Issue
Closes #92 

## Any design changes?
**Performance Note (Heap Allocations):** 
- **Zero new heap allocations** were introduced in the production hot path (`commit`/`abort`). No `Vec`, `String`, or `.clone()` calls were added.
- (The only allocations added were `Arc::new()` calls purely within the isolated unit tests).


## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes