### PR TITLE
feat: implement checkpoint WAL record writing

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -13,7 +13,7 @@
 //! transaction CLOG have been rebuilt.
 
 use common::{EngineError, Key, Value};
-use db_core::transaction_manager::TransactionManager;
+use db_core::transaction_manager::{TransactionManager, TransactionStatus};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -136,6 +136,65 @@ where
     }
 
     // implement close() when checkpoint lands.
+
+    /// Writes a Checkpoint record to the WAL.
+    ///
+    /// Snapshots the redo point, active-transaction set, pinned-aborted set,
+    /// and page/txn counters under the status guard (exclusive), then appends
+    /// and flushes the record so recovery can start from the redo point.
+    pub fn checkpoint(&self) -> Result<(), EngineError> {
+        use std::sync::atomic::Ordering::Acquire;
+
+        // Take the status guard in exclusive mode so that no commit/abort
+        // can transition a transaction while we are snapshotting.
+        let _guard = self.status_guard.write().unwrap();
+
+        let redo_point = self
+            .buffer_pool
+            .min_rec_lsn()
+            .unwrap_or_else(|| self.wal.next_lsn());
+        let next_txn_id = self.transaction_manager.next_txn_id.load(Acquire);
+
+        let active_txns: Vec<u64> = self
+            .transaction_manager
+            .active_txns
+            .read()
+            .unwrap()
+            .keys()
+            .copied()
+            .collect();
+
+        let vacuum_horizon = self.transaction_manager.vacuum_horizon();
+
+        let pinned_aborted: Vec<u64> = self
+            .transaction_manager
+            .clog
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|(txn_id, status)| {
+                **status == TransactionStatus::Aborted && **txn_id >= vacuum_horizon
+            })
+            .map(|(txn_id, _)| *txn_id)
+            .collect();
+
+        let root_pid = self.index.root_page_id();
+        let next_page_id = self.buffer_pool.next_page_id();
+
+        let lsn = self.wal.log_checkpoint(
+            redo_point,
+            next_txn_id,
+            &active_txns,
+            &pinned_aborted,
+            vacuum_horizon,
+            root_pid,
+            next_page_id,
+        )?;
+
+        self.wal.flush_up_to(lsn)?;
+
+        Ok(())
+    }
 
     // ── PUBLIC API ─────────────────────────────────────────────
     pub fn insert(

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -181,6 +181,9 @@ where
         let root_pid = self.index.root_page_id();
         let next_page_id = self.buffer_pool.next_page_id();
 
+        // Drop the guard before performing disk I/O to avoid blocking concurrent transactions.
+        drop(_guard);
+
         let lsn = self.wal.log_checkpoint(
             redo_point,
             next_txn_id,

--- a/crates/engine/tests/checkpoint.rs
+++ b/crates/engine/tests/checkpoint.rs
@@ -1,0 +1,112 @@
+use engine::Engine;
+use storage::wal::{WalIterator, WalRecordType};
+use tempfile::TempDir;
+
+type TestEngine = Engine<&'static [u8], &'static [u8]>;
+
+fn fresh_engine() -> (TempDir, TestEngine) {
+    let dir = TempDir::new().unwrap();
+    let engine = TestEngine::create(dir.path()).unwrap();
+    (dir, engine)
+}
+
+#[test]
+fn test_checkpoint_record_written() {
+    let (dir, engine) = fresh_engine();
+
+    // Transaction IDs are allocated sequentially starting at 1.
+    // 1. A committed transaction (txn_id = 1)
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+
+    // 2. An aborted transaction (txn_id = 2)
+    {
+        let mut txn = engine.begin();
+        txn.insert(&b"k2".as_slice(), &b"v2".as_slice()).unwrap();
+        // drop aborts
+    }
+
+    // 3. An active transaction (txn_id = 3) — kept alive across checkpoint
+    let _active_handle = engine.begin();
+    let expected_active_txn_id: u64 = 3;
+    let expected_aborted_txn_id: u64 = 2;
+
+    engine.checkpoint().expect("Checkpoint failed");
+
+    // Read back the WAL and find the Checkpoint record
+    let wal_dir = dir.path().join("wal");
+    let mut iter = WalIterator::new(wal_dir).expect("Failed to open WalIterator");
+
+    let mut found_checkpoint = false;
+    while let Some(record) = iter.next_record() {
+        let record = record.expect("Failed to read record");
+        if record.entry_type == WalRecordType::Checkpoint {
+            found_checkpoint = true;
+            let data = record.main_data.expect("Checkpoint should have main data");
+
+            // Fixed-size header = 5 × 8 = 40 bytes
+            // + active_len (4) + aborted_len (4) = 48 minimum
+            assert!(data.len() >= 48, "Checkpoint payload too small");
+
+            // Parse the fixed fields
+            let _redo_point = u64::from_le_bytes(data[0..8].try_into().unwrap());
+            let next_txn_id = u64::from_le_bytes(data[8..16].try_into().unwrap());
+
+            // 1 committed + 1 aborted + 1 active = 3 txns consumed,
+            // so next_txn_id should be at least 4.
+            assert!(
+                next_txn_id >= 4,
+                "next_txn_id should be >= 4, got {next_txn_id}"
+            );
+
+            let _vacuum_horizon = u64::from_le_bytes(data[16..24].try_into().unwrap());
+            let _root_pid = u64::from_le_bytes(data[24..32].try_into().unwrap());
+            let _next_page_id = u64::from_le_bytes(data[32..40].try_into().unwrap());
+
+            // Parse active set
+            let active_len = u32::from_le_bytes(data[40..44].try_into().unwrap()) as usize;
+            let mut offset = 44;
+            let mut active_txns = Vec::new();
+            for _ in 0..active_len {
+                active_txns.push(u64::from_le_bytes(
+                    data[offset..offset + 8].try_into().unwrap(),
+                ));
+                offset += 8;
+            }
+
+            assert_eq!(active_len, 1, "expected exactly 1 active transaction");
+            assert!(
+                active_txns.contains(&expected_active_txn_id),
+                "active set should contain txn {expected_active_txn_id}, \
+                 got {active_txns:?}"
+            );
+
+            // Parse pinned-aborted set
+            let aborted_len =
+                u32::from_le_bytes(data[offset..offset + 4].try_into().unwrap()) as usize;
+            offset += 4;
+            let mut aborted_txns = Vec::new();
+            for _ in 0..aborted_len {
+                aborted_txns.push(u64::from_le_bytes(
+                    data[offset..offset + 8].try_into().unwrap(),
+                ));
+                offset += 8;
+            }
+
+            assert!(aborted_len >= 1, "expected at least 1 aborted transaction");
+            assert!(
+                aborted_txns.contains(&expected_aborted_txn_id),
+                "pinned-aborted set should contain txn \
+                 {expected_aborted_txn_id}, got {aborted_txns:?}"
+            );
+
+            // Verify we consumed all bytes
+            assert_eq!(
+                offset,
+                data.len(),
+                "unparsed trailing bytes in checkpoint payload"
+            );
+        }
+    }
+
+    assert!(found_checkpoint, "Checkpoint record not found in WAL");
+}

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -46,6 +46,11 @@ impl BufferPoolManager {
         }
     }
 
+    /// Returns the next page id that will be allocated.
+    pub fn next_page_id(&self) -> u64 {
+        *self.next_page_id.lock().unwrap()
+    }
+
     /// Creates a new page in the buffer pool.
     ///
     /// This will allocate a new `PageId`, find a free frame (potentially evicting

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -1125,6 +1125,49 @@ impl Wal {
         self.append(WalRecordType::OverflowFree, txn_id, &[], Some(&payload))
     }
 
+    /// Appends a Checkpoint record to the WAL.
+    ///
+    /// The checkpoint is not transactional (`txn_id = 0`). Its main-data
+    /// payload carries the consistent snapshot needed by recovery to start
+    /// replay from the redo point instead of the beginning of the log:
+    ///
+    /// ```text
+    /// redo_point(8) | next_txn_id(8) | vacuum_horizon(8) | root_pid(8)
+    /// | next_page_id(8) | active_len(4) | active_txns(8×N)
+    /// | aborted_len(4) | pinned_aborted(8×M)
+    /// ```
+    #[allow(clippy::too_many_arguments)]
+    pub fn log_checkpoint(
+        &self,
+        redo_point: Lsn,
+        next_txn_id: u64,
+        active_txns: &[u64],
+        pinned_aborted: &[u64],
+        vacuum_horizon: u64,
+        root_pid: u64,
+        next_page_id: u64,
+    ) -> Result<Lsn> {
+        let capacity = 40 + 4 + active_txns.len() * 8 + 4 + pinned_aborted.len() * 8;
+        let mut main_data = Vec::with_capacity(capacity);
+        main_data.extend_from_slice(&redo_point.to_le_bytes());
+        main_data.extend_from_slice(&next_txn_id.to_le_bytes());
+        main_data.extend_from_slice(&vacuum_horizon.to_le_bytes());
+        main_data.extend_from_slice(&root_pid.to_le_bytes());
+        main_data.extend_from_slice(&next_page_id.to_le_bytes());
+
+        main_data.extend_from_slice(&(active_txns.len() as u32).to_le_bytes());
+        for txn in active_txns {
+            main_data.extend_from_slice(&txn.to_le_bytes());
+        }
+
+        main_data.extend_from_slice(&(pinned_aborted.len() as u32).to_le_bytes());
+        for txn in pinned_aborted {
+            main_data.extend_from_slice(&txn.to_le_bytes());
+        }
+
+        self.append(WalRecordType::Checkpoint, 0, &[], Some(&main_data))
+    }
+
     /// Appends a new physiological record to the WAL buffer.
     ///
     /// This method assigns the next available LSN, serializes the record according to the


### PR DESCRIPTION
## Summary
This PR implements the functionality to serialize and write the Checkpoint record to the WAL, as defined in `DESIGN.md`. It adds the main `checkpoint()` method to the Engine, ensuring the snapshot is safely captured while holding the `status_guard` in exclusive mode.

## Changes
- Added `next_page_id()` to `BufferPoolManager` to expose the ID of the next allocated page.
- Added `log_checkpoint` to `Wal` to properly structure and append the Checkpoint payload (variable-length arrays for active and aborted txns).
- Added `checkpoint()` to `Engine` to take a consistent snapshot of the redo point, active transactions, pinned-aborted transactions, vacuum horizon, root page ID, and next page ID. Note: aborted entries are correctly truncated if they are below the `vacuum_horizon`.
- Added a comprehensive end-to-end integration test (`crates/engine/tests/checkpoint.rs`) to verify the payload is formatted correctly.

## Related Issue
Closes #93, and implements aborted truncation related to #109

## Any design changes?

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes