### PR TITLE
add checkpoint thread and db wrapper 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "proptest",
  "storage",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -921,6 +922,37 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,6 @@ common = { path = "crates/common" }
 storage = {path = "crates/storage"}
 thiserror = "1"
 db-core = { path = "crates/db-core"}
-# Observability: libraries depend on the `tracing` facade only and emit
-# events/spans. The subscriber is the caller's job (add `tracing-subscriber`
-# in whatever binary eventually runs the DB). See observability.md.
 tracing = "0.1"
 
 # Bench what you ship: cross-crate inlining on, debug symbols kept for flamegraphs.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ common = { path = "crates/common" }
 storage = {path = "crates/storage"}
 thiserror = "1"
 db-core = { path = "crates/db-core"}
+# Observability: libraries depend on the `tracing` facade only and emit
+# events/spans. The subscriber is the caller's job (add `tracing-subscriber`
+# in whatever binary eventually runs the DB). See observability.md.
+tracing = "0.1"
 
 # Bench what you ship: cross-crate inlining on, debug symbols kept for flamegraphs.
 [profile.release]

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -184,4 +184,6 @@ pub enum EngineError {
     Index(#[from] IndexError),
     #[error("write conflict: the transaction was aborted and may be retried")]
     TransactionConflict,
+    #[error("a background thread panicked")]
+    BackgroundThreadPanicked,
 }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 storage.workspace = true
 common.workspace = true
 db-core.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/engine/src/checkpointer.rs
+++ b/crates/engine/src/checkpointer.rs
@@ -1,0 +1,85 @@
+//! Background checkpointer thread.
+//!
+//! One `std::thread` owned by [`crate::Db`]. It runs a checkpoint every
+//! [`CHECKPOINT_INTERVAL`](crate::CHECKPOINT_INTERVAL) and exits after a final
+//! checkpoint on `Shutdown`.
+
+use std::sync::Arc;
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::Duration;
+
+use common::{Key, Value};
+use storage::page::Lsn;
+
+use crate::engine::Engine;
+
+pub(crate) enum Msg {
+    /// Run one final checkpoint, then exit.
+    Shutdown,
+}
+
+
+enum Wake {
+    /// Interval elapsed with no message → periodic checkpoint. The only trigger.
+    Tick,
+    /// `Shutdown` received, or all senders dropped → final checkpoint + exit.
+    Shutdown,
+}
+
+fn next_wake(rx: &Receiver<Msg>, interval: Duration) -> Wake {
+    match rx.recv_timeout(interval) {
+        Err(RecvTimeoutError::Timeout) => Wake::Tick,
+        // A dropped sender shouldn't happen with the Db design, but fold it into
+        // Shutdown so we never busy-spin on repeated `Disconnected`.
+        Ok(Msg::Shutdown) | Err(RecvTimeoutError::Disconnected) => Wake::Shutdown,
+    }
+}
+
+/// The checkpointer loop. Owns a strong `Arc<Engine>` on purpose: `Db`'s
+/// deterministic `join()` guarantees this returns and releases the Arc.
+pub(crate) fn run<K, V>(engine: Arc<Engine<K, V>>, rx: Receiver<Msg>, interval: Duration)
+where
+    K: Key,
+    V: Value,
+{
+    // For the stall warning: remember the last redo point.
+    let mut last_redo: Option<Lsn> = None;
+
+    loop {
+        match next_wake(&rx, interval) {
+            Wake::Tick => do_checkpoint(&engine, &mut last_redo),
+            Wake::Shutdown => {
+                do_checkpoint(&engine, &mut last_redo); // one final checkpoint
+                break;
+            }
+        }
+    }
+    // Returning here drops this thread's `Arc<Engine>` clone.
+}
+
+/// Runs a checkpoint and warns if the redo point didn't advance. Errors are
+/// logged, not propagated: a failed periodic checkpoint must not kill the
+/// thread (the next tick retries).
+fn do_checkpoint<K, V>(engine: &Engine<K, V>, last_redo: &mut Option<Lsn>)
+where
+    K: Key,
+    V: Value,
+{
+    let _span = tracing::info_span!("checkpoint").entered();
+    match engine.checkpoint() {
+        Ok(redo) => {
+            if *last_redo == Some(redo) {
+                // A frozen redo point across checkpoints means a dirty frame is
+                // pinned. 
+                tracing::warn!(
+                    redo_point = redo,
+                    "redo point stalled; WAL will keep growing"
+                );
+            } else {
+                tracing::debug!(redo_point = redo, "checkpoint complete");
+            }
+            *last_redo = Some(redo);
+        }
+        Err(e) => tracing::error!(error = %e, "checkpoint failed"),
+    }
+}

--- a/crates/engine/src/checkpointer.rs
+++ b/crates/engine/src/checkpointer.rs
@@ -18,7 +18,6 @@ pub(crate) enum Msg {
     Shutdown,
 }
 
-
 enum Wake {
     /// Interval elapsed with no message → periodic checkpoint. The only trigger.
     Tick,
@@ -70,7 +69,7 @@ where
         Ok(redo) => {
             if *last_redo == Some(redo) {
                 // A frozen redo point across checkpoints means a dirty frame is
-                // pinned. 
+                // pinned.
                 tracing::warn!(
                     redo_point = redo,
                     "redo point stalled; WAL will keep growing"

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -20,7 +20,7 @@ use std::sync::RwLock;
 use storage::buffer_pool::BufferPoolManager;
 use storage::disk::DiskManager;
 use storage::index::BTreeIndex;
-use storage::page::PAGE_SIZE;
+use storage::page::{Lsn, PAGE_SIZE};
 use storage::recovery::RecoveryManager;
 use storage::wal::Wal;
 
@@ -82,8 +82,6 @@ where
         let (index, _root) = BTreeIndex::create(Arc::clone(&buffer_pool), Arc::clone(&wal))?;
         // index needs Arc because vacuum will later clone it.
         let index = Arc::new(index);
-        // TODO! spawn checkpoint thread once checkpoint is there
-        // TODO! spawn vacuum thread once vacuum is implemented
         Ok(Engine {
             index,
             wal,
@@ -124,7 +122,6 @@ where
             Arc::clone(&buffer_pool),
             Arc::clone(&wal),
         )?);
-        // TODO! spawn checkpoint + vacuum threads
         Ok(Engine {
             index,
             wal,
@@ -142,7 +139,11 @@ where
     /// Snapshots the redo point, active-transaction set, pinned-aborted set,
     /// and page/txn counters under the status guard (exclusive), then appends
     /// and flushes the record so recovery can start from the redo point.
-    pub fn checkpoint(&self) -> Result<(), EngineError> {
+    ///
+    /// Returns the chosen `redo_point` (the same LSN written to the record).
+    /// The background checkpointer compares it across ticks to detect a stalled
+    /// redo point (WAL that can't be reclaimed).
+    pub fn checkpoint(&self) -> Result<Lsn, EngineError> {
         use std::sync::atomic::Ordering::Acquire;
 
         // Take the status guard in exclusive mode so that no commit/abort
@@ -196,7 +197,7 @@ where
 
         self.wal.flush_up_to(lsn)?;
 
-        Ok(())
+        Ok(redo_point)
     }
 
     // ── PUBLIC API ─────────────────────────────────────────────

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,10 +1,126 @@
+mod checkpointer;
 mod engine;
 mod ops;
 mod txn;
 
 #[cfg(test)]
 mod proptests;
+
+use std::path::Path;
+use std::sync::Arc;
+use std::sync::mpsc::{self, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use crate::checkpointer::Msg;
+
 pub use common::{BufferPoolError, DiskError, EngineError, IndexError, WalError};
 pub use common::{Key, Value};
 pub use engine::Engine;
 pub use txn::TxnHandle;
+
+/// How often the background checkpointer runs. TODO: make configurable.
+pub(crate) const CHECKPOINT_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Owning handle for an open database.
+///
+/// `Db` wraps the shared [`Engine`] and owns the background threads (the
+/// checkpointer today; vacuum later). Callers clone `db.engine` into worker
+/// threads.
+/// # Shutdown
+///
+/// `Db` is an embedded library and installs **no** signal handler. The caller
+/// must call [`Db::close`] for a clean final checkpoint. Skipping `close` is never a correctness bug: the next
+/// [`Db::open`] replays the WAL and reconstructs everything; only replay time
+/// is lost.
+pub struct Db<K, V>
+where
+    K: Key + Send + Sync + 'static,
+    V: Value + Send + Sync + 'static,
+{
+    /// The database. Clone this into worker threads (`db.engine.clone()`).
+    pub engine: Arc<Engine<K, V>>,
+
+    /// `Option` so `shutdown` can `take()` it and run exactly once.
+    ckpt_handle: Option<JoinHandle<()>>,
+    /// Owner-only; used solely to signal `Shutdown`. Never exposed.
+    ckpt_tx: Sender<Msg>,
+}
+
+impl<K, V> Db<K, V>
+where
+    K: Key + Send + Sync + 'static,
+    V: Value + Send + Sync + 'static,
+{
+    /// Creates a fresh database, then starts the background threads.
+    ///
+    /// Propagates any [`Engine::create`] error (e.g. [`EngineError::AlreadyExists`])
+    /// before spawning anything.
+    pub fn create(dir_path: impl AsRef<Path>) -> Result<Self, EngineError> {
+        let engine = Arc::new(Engine::create(dir_path)?);
+        Ok(Self::start(engine))
+    }
+
+    /// Opens an existing database, then starts the background threads.
+    ///
+    /// Propagates a missing/corrupt-database error ([`EngineError::NotFound`],
+    /// recovery errors) **before** any thread is spawned.
+    pub fn open(dir_path: impl AsRef<Path>) -> Result<Self, EngineError> {
+        let engine = Arc::new(Engine::open(dir_path)?);
+        Ok(Self::start(engine))
+    }
+
+    /// Shared constructor tail. Must run last: the engine is fully built and
+    /// recovered here, so a checkpoint may safely fire.
+    fn start(engine: Arc<Engine<K, V>>) -> Self {
+        let (ckpt_tx, rx) = mpsc::channel();
+        let engine_for_ckpt = Arc::clone(&engine);
+        let ckpt_handle = thread::Builder::new()
+            .name("fluxdb-checkpointer".into())
+            .spawn(move || checkpointer::run(engine_for_ckpt, rx, CHECKPOINT_INTERVAL))
+            .expect("spawn checkpointer thread");
+
+        // TODO (later PR): spawn the vacuum thread here the same way, storing
+        // its own handle + sender; `shutdown` will then join both.
+
+        Db {
+            engine,
+            ckpt_handle: Some(ckpt_handle),
+            ckpt_tx,
+        }
+    }
+
+    /// Explicit graceful shutdown: signals the checkpointer to run one final
+    /// checkpoint and joins it. Surfaces a thread panic as
+    /// [`EngineError::BackgroundThreadPanicked`]. Consumes the `Db`.
+    pub fn close(mut self) -> Result<(), EngineError> {
+        self.shutdown()
+        // `self` drops here; `Drop` calls `shutdown` again → no-op (handle taken).
+    }
+
+    /// Idempotent: `take()` ensures the signal + join happen at most once, so
+    /// `close` followed by `Drop` (or a double `Drop`) is safe.
+    fn shutdown(&mut self) -> Result<(), EngineError> {
+        if let Some(handle) = self.ckpt_handle.take() {
+            // Ignore the send error: if the thread already exited, the channel
+            // is closed — we still want to join.
+            let _ = self.ckpt_tx.send(Msg::Shutdown);
+            handle
+                .join()
+                .map_err(|_| EngineError::BackgroundThreadPanicked)?;
+        }
+        Ok(())
+    }
+}
+
+/// Backstop for callers who forget `close` (or on unwind). Runs the same
+/// idempotent shutdown so the final checkpoint still fires on normal exit.
+impl<K, V> Drop for Db<K, V>
+where
+    K: Key + Send + Sync + 'static,
+    V: Value + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        let _ = self.shutdown();
+    }
+}

--- a/crates/engine/tests/db.rs
+++ b/crates/engine/tests/db.rs
@@ -1,0 +1,77 @@
+//! End-to-end tests for the `Db` handle: it must spawn the checkpointer,
+//! serve reads/writes through `db.engine`, and shut the thread down cleanly on
+//! both `close()` and `Drop`.
+
+use engine::Db;
+use tempfile::TempDir;
+
+type TestDb = Db<&'static [u8], &'static [u8]>;
+
+#[test]
+fn create_insert_close_then_reopen_sees_data() {
+    let dir = TempDir::new().unwrap();
+
+    let db: TestDb = Db::create(dir.path()).unwrap();
+    db.engine
+        .insert(&b"k1".as_slice(), &b"v1".as_slice())
+        .unwrap();
+    assert_eq!(
+        db.engine.get(&b"k1".as_slice()).unwrap().as_deref(),
+        Some(b"v1".as_ref())
+    );
+    db.close().expect("clean shutdown"); // signals + joins the checkpointer
+
+    // Reopen: recovery replays the WAL; the row is still there.
+    let db2: TestDb = Db::open(dir.path()).unwrap();
+    assert_eq!(
+        db2.engine.get(&b"k1".as_slice()).unwrap().as_deref(),
+        Some(b"v1".as_ref())
+    );
+    db2.close().unwrap();
+}
+
+#[test]
+fn drop_without_close_still_shuts_down() {
+    let dir = TempDir::new().unwrap();
+    {
+        let db: TestDb = Db::create(dir.path()).unwrap();
+        db.engine
+            .insert(&b"k".as_slice(), &b"v".as_slice())
+            .unwrap();
+        // No close(): Drop must signal + join the checkpointer here without hanging.
+    }
+    // Reopening proves the previous handle released its files/threads cleanly.
+    let db: TestDb = Db::open(dir.path()).unwrap();
+    assert_eq!(
+        db.engine.get(&b"k".as_slice()).unwrap().as_deref(),
+        Some(b"v".as_ref())
+    );
+    db.close().unwrap();
+}
+
+#[test]
+fn open_missing_database_errors_and_spawns_nothing() {
+    let dir = TempDir::new().unwrap();
+    // No database created at this path → open must fail before any thread spawns.
+    let res: Result<TestDb, _> = Db::open(dir.path());
+    assert!(res.is_err());
+}
+
+#[test]
+fn engine_clones_into_worker_threads() {
+    let dir = TempDir::new().unwrap();
+    let db: TestDb = Db::create(dir.path()).unwrap();
+
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let e = db.engine.clone();
+        handles.push(std::thread::spawn(move || {
+            e.insert(&b"shared".as_slice(), &b"x".as_slice()).ok();
+            e.get(&b"shared".as_slice()).unwrap()
+        }));
+    }
+    for h in handles {
+        let _ = h.join().unwrap();
+    }
+    db.close().unwrap();
+}


### PR DESCRIPTION
## Summary
Adds the checkpoint thread and the database wrapper for direct ownership of checkpoint, engine and a later vaccum. 

## Changes
- adds checkpoint thread
- adds db wrapper

## Related Issue
Closes #95 

## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes