### PR TITLE
[VAC-4] feat: empty-page deletion, page-id recycling + autovacuum worker

### DIFF
--- a/crates/common/src/constants.rs
+++ b/crates/common/src/constants.rs
@@ -1,8 +1,16 @@
+use std::time::Duration;
+
 pub const MAX_PAGE_SIZE: usize = 4 * 1024; // 4KB, Maybe 8KB, 16KB, etc, will have to check
 pub const MAX_FRAMES: usize = 80;
 pub const INVALID_FRAME_ID: u64 = u64::MAX;
 pub const NUM_SHARDS: usize = 8;
 pub const SHARD_MASK: u64 = (NUM_SHARDS - 1) as u64;
+
+pub const AUTOVACUUM_DEAD_THRESHOLD: u64 = 1_000;
+/// Nap per page a vacuum batch dirtied — busy batches earn longer naps.
+pub const AUTOVACUUM_COST_DELAY: Duration = Duration::from_millis(10);
+/// Leaves swept per `vacuum_batch` call before yielding to foreground work.
+pub const VACUUM_BATCH_MAX_LEAVES: usize = 64;
 
 pub const MAX_KEY_SIZE: usize = 512;
 /// Maximum value size in bytes for a single record.

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -142,6 +142,12 @@ impl TransactionManager {
         self.dead_versions.swap(0, AcqRel)
     }
 
+    /// Returns a taken count after a failed sweep, so the next tick retries
+    /// instead of waiting for a fresh threshold's worth of dead versions.
+    pub fn restore_dead_versions(&self, n: u64) {
+        self.dead_versions.fetch_add(n, AcqRel);
+    }
+
     /// Truncates the CLOG, removing entries older than `horizon`.
     /// Now the removal of entries has been made two-tier, such that the entries that are
     /// committed and their txn_id lying below committed_horizon are deleted directly because

--- a/crates/db-core/src/transaction_manager.rs
+++ b/crates/db-core/src/transaction_manager.rs
@@ -31,6 +31,7 @@ use std::sync::atomic::{
 use std::{
     collections::HashMap,
     sync::{Arc, Condvar, Mutex, RwLock},
+    time::{Duration, Instant},
 };
 
 use crate::transaction::{Snapshot, Transaction};
@@ -65,8 +66,10 @@ pub struct TransactionManager {
     pub next_txn_id: AtomicU64,
     pub clog: RwLock<HashMap<u64, TransactionStatus>>,
     pub vacuum_horizon: AtomicU64,
-    /// In-flight `txn_id` → its snapshot's `xmin` (feeds `global_xmin`).
-    pub active_txns: RwLock<HashMap<u64, u64>>,
+    pub dead_versions: AtomicU64,
+    /// In-flight `txn_id` → (its snapshot's `xmin`, when it began). The xmin
+    /// feeds `global_xmin`; the timestamp feeds `oldest_active_txn_age`.
+    pub active_txns: RwLock<HashMap<u64, (u64, Instant)>>,
     waiters: Mutex<HashMap<u64, WaiterEntry>>,
 }
 
@@ -83,6 +86,7 @@ impl TransactionManager {
             next_txn_id: AtomicU64::new(1),
             clog: RwLock::new(HashMap::new()),
             vacuum_horizon: AtomicU64::new(0),
+            dead_versions: AtomicU64::new(0),
             active_txns: RwLock::new(HashMap::new()),
             waiters: Mutex::new(HashMap::new()),
         }
@@ -95,9 +99,17 @@ impl TransactionManager {
         let active = self.active_txns.read().unwrap();
         active
             .values()
+            .map(|(xmin, _)| *xmin)
             .min()
-            .copied()
             .unwrap_or_else(|| self.next_txn_id.load(Acquire))
+    }
+
+    /// Age of the oldest still-open transaction, `None` if nothing is in
+    /// flight. A large value here means `global_xmin` is pinned and vacuum
+    /// cannot reclaim anything — the classic forgotten-transaction stall.
+    pub fn oldest_active_txn_age(&self) -> Option<Duration> {
+        let active = self.active_txns.read().unwrap();
+        active.values().map(|(_, began)| began.elapsed()).max()
     }
 
     /// Publishes the horizon of a COMPLETED full vacuum sweep. `fetch_max` so a
@@ -110,6 +122,24 @@ impl TransactionManager {
     /// completed full sweep (0 until the first post-restart sweep completes).
     pub fn vacuum_horizon(&self) -> u64 {
         self.vacuum_horizon.load(Acquire)
+    }
+
+    /// Counts dead row versions created since the last autovacuum sweep.
+    /// One per tombstoned version (update/delete success paths).
+    pub fn note_dead_version(&self) {
+        self.dead_versions.fetch_add(1, AcqRel);
+    }
+
+    /// Current dead-version count (for stats/tests).
+    pub fn dead_versions(&self) -> u64 {
+        self.dead_versions.load(Acquire)
+    }
+
+    /// Atomically resets the counter and returns what it was. The autovacuum
+    /// worker calls this once it has decided to sweep; the swap ensures
+    /// concurrent increments are never lost or double-counted.
+    pub fn take_dead_versions(&self) -> u64 {
+        self.dead_versions.swap(0, AcqRel)
     }
 
     /// Truncates the CLOG, removing entries older than `horizon`.
@@ -144,7 +174,7 @@ impl TransactionManager {
         let txn_id = self.next_txn_id.fetch_add(1, AcqRel);
         // Snapshot xmin = oldest in-flight txn; stored for global_xmin().
         let xmin = active.keys().min().copied().unwrap_or(txn_id);
-        active.insert(txn_id, xmin);
+        active.insert(txn_id, (xmin, Instant::now()));
 
         let xmax = self.next_txn_id.load(Acquire);
         let active_vec: Vec<u64> = active.keys().cloned().collect();
@@ -291,7 +321,6 @@ impl TransactionManager {
         }
     }
 }
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -280,4 +280,11 @@ where
     pub fn vacuum(&self) -> Result<usize, EngineError> {
         Ok(self.index.vacuum(&self.transaction_manager)?)
     }
+
+    /// Like [`Engine::vacuum`], but yields to `pacer` between leaf batches,
+    /// passing it the number of pages the batch dirtied (for cost throttling).
+    /// A `false` from the pacer abandons the pass: no drain, no horizon publish.
+    pub fn vacuum_paced(&self, pacer: impl FnMut(usize) -> bool) -> Result<usize, EngineError> {
+        Ok(self.index.vacuum_paced(&self.transaction_manager, pacer)?)
+    }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2,6 +2,7 @@ mod checkpointer;
 mod engine;
 mod ops;
 mod txn;
+mod vacuum;
 
 #[cfg(test)]
 mod proptests;
@@ -13,6 +14,7 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crate::checkpointer::Msg;
+use crate::vacuum::Msg as VacMsg;
 
 pub use common::{BufferPoolError, DiskError, EngineError, IndexError, WalError};
 pub use common::{Key, Value};
@@ -21,12 +23,14 @@ pub use txn::TxnHandle;
 
 /// How often the background checkpointer runs. TODO: make configurable.
 pub(crate) const CHECKPOINT_INTERVAL: Duration = Duration::from_secs(30);
+/// How often the autovacuum worker wakes to check its trigger. TODO: make configurable.
+pub(crate) const VAC_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Owning handle for an open database.
 ///
 /// `Db` wraps the shared [`Engine`] and owns the background threads (the
-/// checkpointer today; vacuum later). Callers clone `db.engine` into worker
-/// threads.
+/// checkpointer and the autovacuum worker). Callers clone `db.engine` into
+/// worker threads.
 /// # Shutdown
 ///
 /// `Db` is an embedded library and installs **no** signal handler. The caller
@@ -41,6 +45,8 @@ where
     /// The database. Clone this into worker threads (`db.engine.clone()`).
     pub engine: Arc<Engine<K, V>>,
 
+    vac_handle: Option<JoinHandle<()>>,
+    vac_tx: Sender<VacMsg>,
     /// `Option` so `shutdown` can `take()` it and run exactly once.
     ckpt_handle: Option<JoinHandle<()>>,
     /// Owner-only; used solely to signal `Shutdown`. Never exposed.
@@ -80,19 +86,25 @@ where
             .spawn(move || checkpointer::run(engine_for_ckpt, rx, CHECKPOINT_INTERVAL))
             .expect("spawn checkpointer thread");
 
-        // TODO (later PR): spawn the vacuum thread here the same way, storing
-        // its own handle + sender; `shutdown` will then join both.
+        let (vac_tx, rx) = mpsc::channel();
+        let engine_for_vac = Arc::clone(&engine);
+        let vac_handle = thread::Builder::new()
+            .name("fluxdb-vacuum".into())
+            .spawn(move || vacuum::run(engine_for_vac, rx, VAC_INTERVAL))
+            .expect("spawn vacuum thread");
 
         Db {
             engine,
             ckpt_handle: Some(ckpt_handle),
             ckpt_tx,
+            vac_handle: Some(vac_handle),
+            vac_tx,
         }
     }
 
-    /// Explicit graceful shutdown: signals the checkpointer to run one final
-    /// checkpoint and joins it. Surfaces a thread panic as
-    /// [`EngineError::BackgroundThreadPanicked`]. Consumes the `Db`.
+    /// Explicit graceful shutdown: signals both background threads (the
+    /// checkpointer runs one final checkpoint) and joins them. Surfaces a
+    /// thread panic as [`EngineError::BackgroundThreadPanicked`]. Consumes the `Db`.
     pub fn close(mut self) -> Result<(), EngineError> {
         self.shutdown()
         // `self` drops here; `Drop` calls `shutdown` again → no-op (handle taken).
@@ -101,10 +113,19 @@ where
     /// Idempotent: `take()` ensures the signal + join happen at most once, so
     /// `close` followed by `Drop` (or a double `Drop`) is safe.
     fn shutdown(&mut self) -> Result<(), EngineError> {
-        if let Some(handle) = self.ckpt_handle.take() {
-            // Ignore the send error: if the thread already exited, the channel
-            // is closed — we still want to join.
+        let ckpt = self.ckpt_handle.take();
+        let vac = self.vac_handle.take();
+
+        // Signal both before joining either, so the threads wind down in parallel.
+        // Ignore send errors: if a thread already exited, its channel is closed —
+        // we still want to join.
+        if ckpt.is_some() {
             let _ = self.ckpt_tx.send(Msg::Shutdown);
+        }
+        if vac.is_some() {
+            let _ = self.vac_tx.send(VacMsg::Shutdown);
+        }
+        for handle in [ckpt, vac].into_iter().flatten() {
             handle
                 .join()
                 .map_err(|_| EngineError::BackgroundThreadPanicked)?;

--- a/crates/engine/src/ops.rs
+++ b/crates/engine/src/ops.rs
@@ -22,7 +22,11 @@ where
         key: &K::SelfType<'_>,
     ) -> Result<(), EngineError> {
         txn.note_write();
-        self.index.delete(key, txn).map_err(map_conflict)
+        self.index.delete(key, txn).map_err(map_conflict)?;
+        // Counted at op time, not commit: an aborted delete also leaves a
+        // dead version for vacuum to clean.
+        self.transaction_manager.note_dead_version();
+        Ok(())
     }
 
     /// Reads take `&Transaction` — they never set the wrote-flag.
@@ -41,7 +45,10 @@ where
         value: &V::SelfType<'_>,
     ) -> Result<(), EngineError> {
         txn.note_write();
-        self.index.update(key, value, txn).map_err(map_conflict)
+        self.index.update(key, value, txn).map_err(map_conflict)?;
+        // An update tombstones the previous version — same accounting as delete.
+        self.transaction_manager.note_dead_version();
+        Ok(())
     }
 }
 

--- a/crates/engine/src/vacuum.rs
+++ b/crates/engine/src/vacuum.rs
@@ -1,0 +1,184 @@
+//! Background autovacuum thread.
+//!
+//! One `std::thread` owned by [`crate::Db`]. Each tick it sweeps if enough
+//! dead versions have piled up ([`AUTOVACUUM_DEAD_THRESHOLD`]). Exits on
+//! `Shutdown` without a final sweep — vacuum is maintenance, not durability.
+
+use std::sync::Arc;
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::Duration;
+
+use common::{AUTOVACUUM_COST_DELAY, AUTOVACUUM_DEAD_THRESHOLD, Key, Value};
+
+use crate::engine::Engine;
+
+pub(crate) enum Msg {
+    /// Stop after the current tick, then exit.
+    Shutdown,
+}
+
+enum Wake {
+    /// Interval elapsed with no message → run the trigger check.
+    Tick,
+    /// `Shutdown` received, or all senders dropped → exit.
+    Shutdown,
+}
+
+fn next_wake(rx: &Receiver<Msg>, interval: Duration) -> Wake {
+    match rx.recv_timeout(interval) {
+        Err(RecvTimeoutError::Timeout) => Wake::Tick,
+        // A dropped sender shouldn't happen with the Db design, but fold it into
+        // Shutdown so we never busy-spin on repeated `Disconnected`.
+        Ok(Msg::Shutdown) | Err(RecvTimeoutError::Disconnected) => Wake::Shutdown,
+    }
+}
+
+/// The autovacuum loop. Owns a strong `Arc<Engine>` on purpose: `Db`'s
+/// deterministic `join()` guarantees this returns and releases the Arc.
+pub(crate) fn run<K, V>(engine: Arc<Engine<K, V>>, rx: Receiver<Msg>, interval: Duration)
+where
+    K: Key,
+    V: Value,
+{
+    // Unlike the checkpointer there is no final pass on shutdown: a sweep is
+    // pure maintenance, and the next open can always run one.
+    while let Wake::Tick = next_wake(&rx, interval) {
+        if engine.transaction_manager.dead_versions() >= AUTOVACUUM_DEAD_THRESHOLD {
+            engine.transaction_manager.take_dead_versions();
+            if !do_vacuum(&engine, &rx) {
+                break;
+            }
+        }
+    }
+
+    // Returning here drops this thread's `Arc<Engine>` clone.
+}
+
+/// Runs one paced sweep, napping `AUTOVACUUM_COST_DELAY` per page the last
+/// batch dirtied — busy batches earn longer naps, clean batches none.
+/// Returns `false` if `Shutdown` arrived mid-sweep — the pacer consumed the
+/// message, so the caller must exit instead of waiting for a second one.
+/// Errors are logged, not propagated: a failed sweep must not kill the thread.
+fn do_vacuum<K, V>(engine: &Engine<K, V>, rx: &Receiver<Msg>) -> bool
+where
+    K: Key,
+    V: Value,
+{
+    let _span = tracing::info_span!("autovacuum").entered();
+    let mut shutting_down = false;
+    let result = engine.vacuum_paced(|touched| {
+        let nap = AUTOVACUUM_COST_DELAY.saturating_mul(touched.try_into().unwrap_or(u32::MAX));
+        match next_wake(rx, nap) {
+            Wake::Tick => true,
+            Wake::Shutdown => {
+                shutting_down = true;
+                false
+            }
+        }
+    });
+    match result {
+        Ok(dead) => tracing::debug!(dead_versions = dead, "vacuum sweep complete"),
+        Err(e) => tracing::error!(error = %e, "vacuum sweep failed"),
+    }
+    !shutting_down
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::AUTOVACUUM_DEAD_THRESHOLD;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Instant;
+    use tempfile::TempDir;
+
+    type TestEngine = Engine<&'static [u8], &'static [u8]>;
+
+    /// Issue done-when (test 9): dead tuples get reclaimed with no `vacuum()`
+    /// call anywhere — the worker must notice the threshold on its own tick.
+    #[test]
+    fn autovacuum_fires_without_manual_trigger() {
+        let dir = TempDir::new().unwrap();
+        let engine: Arc<TestEngine> = Arc::new(Engine::create(dir.path()).unwrap());
+
+        // The worker under test, on a fast tick instead of the production one.
+        let (tx, rx) = mpsc::channel();
+        let worker_engine = Arc::clone(&engine);
+        let worker = thread::spawn(move || run(worker_engine, rx, Duration::from_millis(25)));
+
+        // Two batched transactions, not 2×N autocommits: dead versions are
+        // counted at op time, so the deletes alone cross the threshold.
+        let n = AUTOVACUUM_DEAD_THRESHOLD as usize + 1;
+        let keys: Vec<Vec<u8>> = (0..n).map(|i| format!("k{i:05}").into_bytes()).collect();
+        let mut txn = engine.begin();
+        for key in &keys {
+            txn.insert(&key.as_slice(), &b"v".as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+        let mut txn = engine.begin();
+        for key in &keys {
+            txn.delete(&key.as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+
+        // The worker may consume the counter mid-delete (op-time counting), so
+        // poll for both sweep signals: the counter back below the threshold AND
+        // a published horizon, which only a completed full pass produces.
+        let tm = &engine.transaction_manager;
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while tm.dead_versions() >= AUTOVACUUM_DEAD_THRESHOLD || tm.vacuum_horizon() == 0 {
+            assert!(
+                Instant::now() < deadline,
+                "autovacuum never swept: dead={}, horizon={}",
+                tm.dead_versions(),
+                tm.vacuum_horizon()
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+
+        tx.send(Msg::Shutdown).unwrap();
+        worker.join().unwrap();
+    }
+
+    /// Issue done-when (test 10): one long-open transaction pins `global_xmin`
+    /// — reclamation visibly stalls and `oldest_active_txn_age` names the
+    /// culprit; finishing the transaction lets the same sweep reclaim it all.
+    #[test]
+    fn pinned_global_xmin_stalls_reclamation_and_is_observable() {
+        let dir = TempDir::new().unwrap();
+        let engine: TestEngine = Engine::create(dir.path()).unwrap();
+
+        // The culprit: opened before the deletes, then "forgotten".
+        let pin = engine.begin();
+
+        const N: usize = 100;
+        let keys: Vec<Vec<u8>> = (0..N).map(|i| format!("k{i:03}").into_bytes()).collect();
+        let mut txn = engine.begin();
+        for key in &keys {
+            txn.insert(&key.as_slice(), &b"v".as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+        let mut txn = engine.begin();
+        for key in &keys {
+            txn.delete(&key.as_slice()).unwrap();
+        }
+        txn.commit().unwrap();
+
+        // Pinned: a full sweep completes but reclaims nothing — every dead
+        // version postdates the culprit's snapshot — and the stat reports it.
+        assert_eq!(engine.vacuum().unwrap(), 0);
+        let stalled_horizon = engine.transaction_manager.vacuum_horizon();
+        let age = engine
+            .transaction_manager
+            .oldest_active_txn_age()
+            .expect("open transaction must be reported");
+        assert!(age > Duration::ZERO);
+
+        // Finish the culprit: the very same sweep now reclaims everything and
+        // the horizon moves past where the stall held it.
+        pin.commit().unwrap();
+        assert_eq!(engine.transaction_manager.oldest_active_txn_age(), None);
+        assert_eq!(engine.vacuum().unwrap(), N);
+        assert!(engine.transaction_manager.vacuum_horizon() > stalled_horizon);
+    }
+}

--- a/crates/engine/src/vacuum.rs
+++ b/crates/engine/src/vacuum.rs
@@ -44,8 +44,8 @@ where
     // pure maintenance, and the next open can always run one.
     while let Wake::Tick = next_wake(&rx, interval) {
         if engine.transaction_manager.dead_versions() >= AUTOVACUUM_DEAD_THRESHOLD {
-            engine.transaction_manager.take_dead_versions();
-            if !do_vacuum(&engine, &rx) {
+            let taken = engine.transaction_manager.take_dead_versions();
+            if !do_vacuum(&engine, &rx, taken) {
                 break;
             }
         }
@@ -59,7 +59,9 @@ where
 /// Returns `false` if `Shutdown` arrived mid-sweep — the pacer consumed the
 /// message, so the caller must exit instead of waiting for a second one.
 /// Errors are logged, not propagated: a failed sweep must not kill the thread.
-fn do_vacuum<K, V>(engine: &Engine<K, V>, rx: &Receiver<Msg>) -> bool
+/// On error the `taken` counter is restored so the next tick retries the sweep
+/// instead of waiting for a fresh threshold's worth of dead versions.
+fn do_vacuum<K, V>(engine: &Engine<K, V>, rx: &Receiver<Msg>, taken: u64) -> bool
 where
     K: Key,
     V: Value,
@@ -78,7 +80,10 @@ where
     });
     match result {
         Ok(dead) => tracing::debug!(dead_versions = dead, "vacuum sweep complete"),
-        Err(e) => tracing::error!(error = %e, "vacuum sweep failed"),
+        Err(e) => {
+            engine.transaction_manager.restore_dead_versions(taken);
+            tracing::error!(error = %e, "vacuum sweep failed");
+        }
     }
     !shutting_down
 }

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -34,10 +34,10 @@ impl BufferPoolManager {
             free_pool: Mutex::new(Vec::new()),
             free_page: Mutex::new(0),
         };
-        if existing_pages > 0 {
-            if let Ok(meta) = pool.fetch_page(0) {
-                *pool.free_page.lock().unwrap() = crate::page::meta::read_free_space(&meta[..]);
-            }
+        if existing_pages > 0
+            && let Ok(meta) = pool.fetch_page(0)
+        {
+            *pool.free_page.lock().unwrap() = crate::page::meta::read_free_space(&meta[..]);
         }
 
         pool
@@ -74,9 +74,9 @@ impl BufferPoolManager {
     pub fn new_page(&self) -> Result<PageWriteGuard<'_>> {
         let page_id = {
             if let Some(pid) = self.free_pool.lock().unwrap().pop() {
-                //this fetches the page id of the free space page
+                // Recycle: claim the id in the bitmap page and journal the
+                // allocation, so a replayed bitmap never re-offers it.
                 let free_space_id = *self.free_page.lock().unwrap();
-                //guard over page mutation - exclusive latch
                 let mut fs_guard = self.fetch_page_mut(free_space_id)?;
                 crate::page::free_space::clear_free(&mut fs_guard[..], pid);
                 let image: &[u8; PAGE_SIZE] = (&fs_guard[..]).try_into().unwrap();
@@ -95,7 +95,9 @@ impl BufferPoolManager {
         };
 
         let shard = self.get_shard(page_id);
-        // (needs_load = true): the frame is published in the loading state
+        // A fresh id is always a miss; a recycled id may hit a frame still
+        // caching the page's previous life. Either way the fill(0) below
+        // starts the page from a clean slate.
         let (frame_id, _needs_load) = shard.acquire_frame(page_id)?;
 
         let mut data = shard.pages[frame_id].write().unwrap();

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -1,6 +1,6 @@
 use crate::buffer_pool::shard::{BufferPoolShard, PageReadGuard, PageWriteGuard};
 use crate::disk::DiskManager;
-use crate::page::Lsn;
+use crate::page::{Lsn, PAGE_SIZE, PageId};
 use crate::wal::Wal;
 use common::{BufferPoolError, MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
 use std::cmp::max;
@@ -12,6 +12,8 @@ pub type Result<T> = std::result::Result<T, BufferPoolError>;
 pub struct BufferPoolManager {
     pub(crate) shards: Vec<BufferPoolShard>,
     next_page_id: Mutex<u64>,
+    pub(crate) free_pool: Mutex<Vec<PageId>>,
+    pub(crate) free_page: Mutex<u64>,
 }
 
 impl BufferPoolManager {
@@ -26,10 +28,19 @@ impl BufferPoolManager {
             .map(|_| BufferPoolShard::new(disk_manager.clone(), shard_size, Arc::clone(&wal)))
             .collect();
 
-        Self {
+        let pool = Self {
             shards,
             next_page_id: Mutex::new(existing_pages),
+            free_pool: Mutex::new(Vec::new()),
+            free_page: Mutex::new(0),
+        };
+        if existing_pages > 0 {
+            if let Ok(meta) = pool.fetch_page(0) {
+                *pool.free_page.lock().unwrap() = crate::page::meta::read_free_space(&meta[..]);
+            }
         }
+
+        pool
     }
 
     #[inline]
@@ -62,15 +73,29 @@ impl BufferPoolManager {
     /// * Returns [`BufferPoolError::InternalError`] if a disk I/O error occurs during eviction.
     pub fn new_page(&self) -> Result<PageWriteGuard<'_>> {
         let page_id = {
-            let mut id = self.next_page_id.lock().unwrap();
-            let pid = *id;
-            *id += 1;
-            pid
+            if let Some(pid) = self.free_pool.lock().unwrap().pop() {
+                //this fetches the page id of the free space page
+                let free_space_id = *self.free_page.lock().unwrap();
+                //guard over page mutation - exclusive latch
+                let mut fs_guard = self.fetch_page_mut(free_space_id)?;
+                crate::page::free_space::clear_free(&mut fs_guard[..], pid);
+                let image: &[u8; PAGE_SIZE] = (&fs_guard[..]).try_into().unwrap();
+                let lsn = self.shards[0]
+                    .wal
+                    .log_page_compact(0, free_space_id, image)?;
+                crate::page::set_lsn(&mut fs_guard[..], lsn);
+
+                pid
+            } else {
+                let mut id = self.next_page_id.lock().unwrap();
+                let pid = *id;
+                *id += 1;
+                pid
+            }
         };
 
         let shard = self.get_shard(page_id);
-        // A freshly allocated page id is unique, so this is always a miss
-        // (needs_load = true): the frame is published in the loading state.
+        // (needs_load = true): the frame is published in the loading state
         let (frame_id, _needs_load) = shard.acquire_frame(page_id)?;
 
         let mut data = shard.pages[frame_id].write().unwrap();

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -62,13 +62,14 @@ impl BufferPoolManager {
         *self.next_page_id.lock().unwrap()
     }
 
-
     fn claim_recycled(&self, pid: PageId) -> Result<()> {
         let free_space_id = *self.free_page.lock().unwrap();
         let mut fs_guard = self.fetch_page_mut(free_space_id)?;
         crate::page::free_space::clear_free(&mut fs_guard[..], pid);
         let image: &[u8; PAGE_SIZE] = (&fs_guard[..]).try_into().unwrap();
-        let lsn = self.shards[0].wal.log_page_compact(0, free_space_id, image)?;
+        let lsn = self.shards[0]
+            .wal
+            .log_page_compact(0, free_space_id, image)?;
         crate::page::set_lsn(&mut fs_guard[..], lsn);
         Ok(())
     }

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -62,6 +62,17 @@ impl BufferPoolManager {
         *self.next_page_id.lock().unwrap()
     }
 
+
+    fn claim_recycled(&self, pid: PageId) -> Result<()> {
+        let free_space_id = *self.free_page.lock().unwrap();
+        let mut fs_guard = self.fetch_page_mut(free_space_id)?;
+        crate::page::free_space::clear_free(&mut fs_guard[..], pid);
+        let image: &[u8; PAGE_SIZE] = (&fs_guard[..]).try_into().unwrap();
+        let lsn = self.shards[0].wal.log_page_compact(0, free_space_id, image)?;
+        crate::page::set_lsn(&mut fs_guard[..], lsn);
+        Ok(())
+    }
+
     /// Creates a new page in the buffer pool.
     ///
     /// This will allocate a new `PageId`, find a free frame (potentially evicting
@@ -72,26 +83,23 @@ impl BufferPoolManager {
     /// * Returns [`BufferPoolError::NoEvictableFrames`] if all frames are pinned.
     /// * Returns [`BufferPoolError::InternalError`] if a disk I/O error occurs during eviction.
     pub fn new_page(&self) -> Result<PageWriteGuard<'_>> {
-        let page_id = {
-            if let Some(pid) = self.free_pool.lock().unwrap().pop() {
-                // Recycle: claim the id in the bitmap page and journal the
-                // allocation, so a replayed bitmap never re-offers it.
-                let free_space_id = *self.free_page.lock().unwrap();
-                let mut fs_guard = self.fetch_page_mut(free_space_id)?;
-                crate::page::free_space::clear_free(&mut fs_guard[..], pid);
-                let image: &[u8; PAGE_SIZE] = (&fs_guard[..]).try_into().unwrap();
-                let lsn = self.shards[0]
-                    .wal
-                    .log_page_compact(0, free_space_id, image)?;
-                crate::page::set_lsn(&mut fs_guard[..], lsn);
-
-                pid
-            } else {
-                let mut id = self.next_page_id.lock().unwrap();
-                let pid = *id;
-                *id += 1;
-                pid
+        let recycled = self.free_pool.lock().unwrap().pop();
+        let page_id = if let Some(pid) = recycled {
+            // Recycle: claim the id in the bitmap page and journal the
+            // allocation, so a replayed bitmap never re-offers it. On any
+            // error the id would otherwise be lost — re-park it.
+            match self.claim_recycled(pid) {
+                Ok(()) => pid,
+                Err(e) => {
+                    self.free_pool.lock().unwrap().push(pid);
+                    return Err(e);
+                }
             }
+        } else {
+            let mut id = self.next_page_id.lock().unwrap();
+            let pid = *id;
+            *id += 1;
+            pid
         };
 
         let shard = self.get_shard(page_id);

--- a/crates/storage/src/index/mod.rs
+++ b/crates/storage/src/index/mod.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use std::ops::{Bound, RangeBounds};
 use std::sync::{Arc, Mutex};
 
-use common::{Key, MAX_KEY_SIZE, Value};
+use common::{Key, MAX_KEY_SIZE, VACUUM_BATCH_MAX_LEAVES, Value};
 use db_core::transaction_manager::TransactionManager;
 
 use crate::buffer_pool::{BufferPoolManager, PageReadGuard, PageWriteGuard};
@@ -65,6 +65,7 @@ pub struct BTreeIndex<K: Key, V: Value> {
     wal: Arc<Wal>,
     root: Mutex<PageId>,
     pending_recycle: Mutex<Vec<(PageId, u64)>>,
+    vacuum_lock: Mutex<()>,
     _key: PhantomData<K>,
     _val: PhantomData<V>,
 }
@@ -98,12 +99,36 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
     ///
     /// Returns the total number of records removed across all pages.
     pub fn vacuum(&self, tm: &TransactionManager) -> Result<usize> {
-        let global_xmin = tm.global_xmin();
-        let root = self.root_page_id();
-        let mut leaf_pid = self.find_leftmost_leaf(root)?;
-        let mut total_dead = 0;
+        self.vacuum_paced(tm, |_| true)
+    }
 
-        loop {
+    /// Returns `(records removed, pages touched, next cursor)`. "Pages
+    /// touched" counts the pages this batch dirtied — compacted leaves, freed
+    /// overflow pages, deleted leaves — and feeds the pacer's cost throttling.
+    fn vacuum_batch(
+        &self,
+        tm: &TransactionManager,
+        global_xmin: u64,
+        cursor: Option<PageId>,
+        max_leaves: usize,
+    ) -> Result<(usize, usize, Option<PageId>)> {
+        let mut leaf_pid = match cursor {
+            Some(pid) => {
+                let guard = self.pool.fetch_page(pid)?;
+                let still_leaf = guard[0] == page::LEAF;
+                drop(guard);
+                if still_leaf {
+                    pid
+                } else {
+                    self.find_leftmost_leaf(self.root_page_id())?
+                }
+            }
+            None => self.find_leftmost_leaf(self.root_page_id())?,
+        };
+        let mut total_dead = 0;
+        let mut touched = 0;
+
+        for _ in 0..max_leaves {
             let mut guard = self.pool.fetch_page_mut(leaf_pid)?;
 
             let (dead, chains) =
@@ -119,6 +144,7 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                 let image: &[u8; PAGE_SIZE] = (&guard[..]).try_into().unwrap();
                 let lsn = self.wal.log_page_compact(SYSTEM_TXN_ID, leaf_pid, image)?;
                 LeafPageMutator::<K, V>::new(&mut guard[..]).set_lsn(lsn);
+                touched += 1;
             }
 
             let acc = LeafPageAccessor::<K, V>::new(&guard[..]);
@@ -135,24 +161,57 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                 let ids = collect_overflow_page_ids(first_page_id, &self.pool)?;
                 self.wal.log_overflow_free(SYSTEM_TXN_ID, &ids)?;
                 free_overflow_chain(first_page_id, &self.pool)?;
+                touched += ids.len();
             }
 
             if (leaf_count == 0 || was_half_dead) && leaf_pid != self.root_page_id() {
                 self.delete_empty_leaf(leaf_pid, tm)?;
+                // An unlink dirties the leaf, both siblings, and the parent;
+                // count the attempt as one — close enough for throttling.
+                touched += 1;
             }
 
             match next {
                 Some(pid) => leaf_pid = pid,
-                None => break,
+                // End of the leaf chain: the pass is complete.
+                None => return Ok((total_dead, touched, None)),
+            }
+        }
+        // Budget exhausted mid-chain: hand back where the next batch starts.
+        Ok((total_dead, touched, Some(leaf_pid)))
+    }
+
+    pub fn vacuum_paced(
+        &self,
+        tm: &TransactionManager,
+        mut pacer: impl FnMut(usize) -> bool,
+    ) -> Result<usize> {
+        let _sweep = self.vacuum_lock.lock().unwrap();
+        let global_xmin = tm.global_xmin();
+        let mut cursor = None;
+        let mut total_dead = 0;
+
+        loop {
+            let (dead, touched, next) =
+                self.vacuum_batch(tm, global_xmin, cursor, VACUUM_BATCH_MAX_LEAVES)?;
+            total_dead += dead;
+            if next.is_none() {
+                break;
+            }
+            cursor = next;
+            // Nap between batches, scaled by how many pages the batch dirtied;
+            // a `false` pacer abandons the pass. Return WITHOUT draining or
+            // publishing — a partial pass covers nothing.
+            if !pacer(touched) {
+                return Ok(total_dead);
             }
         }
 
-        //this fetches the page id of the free space page
+        // Pass complete: graduate parked ids whose stamp the horizon has
+        // passed — no live snapshot can still walk to those pages.
         let free_space_id = *self.pool.free_page.lock().unwrap();
         if free_space_id != 0 {
-            //guard over page mutation - exclusive latch
             let mut fs_guard = self.pool.fetch_page_mut(free_space_id)?;
-            //checks how many ids are to be marked empty
             let mut pending = self.pending_recycle.lock().unwrap();
             let mut graduated = Vec::new();
             pending.retain(|&(pid, stamp)| {
@@ -164,15 +223,16 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                 }
             });
             drop(pending);
-            // journal after mutating - the fpi is a photograph of the page, so taking
-            // it earlier would make recovery restore the pre-drain bitmap. the lsn
-            // stamp keeps the ordering safe since the wal record is forced to disk
-            // before the mutated page can be
 
-            //sets the pages free
+            // `set_free` rejects ids beyond the bitmap's capacity; dropping
+            // them here leaks those pages (the bounded-leak path).
             graduated.retain(|&pid| crate::page::free_space::set_free(&mut fs_guard[..], pid));
 
-            //writes a wal record if the graduation vector was not empty
+            // Journal AFTER mutating: the FPI is a photograph of the page, so
+            // taking it earlier would make recovery restore the pre-drain
+            // bitmap. Write-ahead ordering still holds via the LSN stamp —
+            // eviction forces the WAL through the page LSN before the page
+            // can reach disk.
             if !graduated.is_empty() {
                 let image: &[u8; PAGE_SIZE] = (&fs_guard[..]).try_into().unwrap();
                 let lsn = self
@@ -229,6 +289,7 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             wal,
             root: Mutex::new(root),
             pending_recycle: Mutex::new(Vec::new()),
+            vacuum_lock: Mutex::new(()),
             _val: PhantomData,
             _key: PhantomData,
         }

--- a/crates/storage/src/index/mod.rs
+++ b/crates/storage/src/index/mod.rs
@@ -16,7 +16,7 @@ use db_core::transaction_manager::TransactionManager;
 
 use crate::buffer_pool::{BufferPoolManager, PageReadGuard, PageWriteGuard};
 use crate::page::{
-    INTERNAL, InternalPageAccessor, InternalPageBuilder, InternalPageMutator, LEAF,
+    self, INTERNAL, InternalPageAccessor, InternalPageBuilder, InternalPageMutator, LEAF,
     LeafPageAccessor, LeafPageBuilder, LeafPageMutator, OVERFLOW_THRESHOLD, PAGE_SIZE, PageId,
     REC_TYPE_INLINE, REC_TYPE_OVERFLOW, collect_overflow_page_ids, free_overflow_chain,
     read_overflow_chain, write_overflow_chain,
@@ -64,6 +64,7 @@ pub struct BTreeIndex<K: Key, V: Value> {
     pool: Arc<BufferPoolManager>,
     wal: Arc<Wal>,
     root: Mutex<PageId>,
+    pending_recycle: Mutex<Vec<(PageId, u64)>>,
     _key: PhantomData<K>,
     _val: PhantomData<V>,
 }
@@ -79,6 +80,12 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             IndexError::CorruptMetadata("page 0 is not a FluxDB superblock".into())
         })?;
         drop(meta);
+        let free_space_id = *pool.free_page.lock().unwrap();
+        if free_space_id != 0 {
+            let guard = pool.fetch_page(free_space_id)?;
+            let vec = crate::page::free_space::scan_free(&guard[..]);
+            *pool.free_pool.lock().unwrap() = vec;
+        }
         Ok(Self::from_root(pool, wal, root))
     }
 
@@ -115,6 +122,8 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             }
 
             let acc = LeafPageAccessor::<K, V>::new(&guard[..]);
+            let leaf_count = acc.num_pairs();
+            let was_half_dead = page::is_half_dead(&guard[..]);
             let next = acc.rightlink();
             drop(guard);
 
@@ -128,10 +137,55 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                 free_overflow_chain(first_page_id, &self.pool)?;
             }
 
+            if (leaf_count == 0 || was_half_dead) && leaf_pid != self.root_page_id() {
+                self.delete_empty_leaf(leaf_pid, tm)?;
+            }
+
             match next {
                 Some(pid) => leaf_pid = pid,
                 None => break,
             }
+        }
+
+        //this fetches the page id of the free space page
+        let free_space_id = *self.pool.free_page.lock().unwrap();
+        if free_space_id != 0 {
+            //guard over page mutation - exclusive latch
+            let mut fs_guard = self.pool.fetch_page_mut(free_space_id)?;
+            //checks how many ids are to be marked empty
+            let mut pending = self.pending_recycle.lock().unwrap();
+            let mut graduated = Vec::new();
+            pending.retain(|&(pid, stamp)| {
+                if stamp < global_xmin {
+                    graduated.push(pid);
+                    false // remove from waiting area
+                } else {
+                    true // not safe yet — keep waiting
+                }
+            });
+            drop(pending);
+            // journal after mutating - the fpi is a photograph of the page, so taking
+            // it earlier would make recovery restore the pre-drain bitmap. the lsn
+            // stamp keeps the ordering safe since the wal record is forced to disk
+            // before the mutated page can be
+
+            //sets the pages free
+            graduated.retain(|&pid| crate::page::free_space::set_free(&mut fs_guard[..], pid));
+
+            //writes a wal record if the graduation vector was not empty
+            if !graduated.is_empty() {
+                let image: &[u8; PAGE_SIZE] = (&fs_guard[..]).try_into().unwrap();
+                let lsn = self
+                    .wal
+                    .log_page_compact(SYSTEM_TXN_ID, free_space_id, image)?;
+                crate::page::set_lsn(&mut fs_guard[..], lsn);
+            }
+            drop(fs_guard);
+            self.pool
+                .free_pool
+                .lock()
+                .unwrap()
+                .extend_from_slice(&graduated);
         }
 
         tm.publish_vacuum_horizon(global_xmin);
@@ -146,10 +200,19 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         let root_pid = root_guard.page_id;
         LeafPageBuilder::<K, V>::new(root_pid, &mut root_guard[..]);
         drop(root_guard);
-        // Make the root durable BEFORE the superblock that points to it, so a
-        // crash can never leave page 0 referencing a not-yet-written root page.
+        // Free-space bitmap page, allocated right after the root.
+        let mut fs_guard = pool.new_page()?;
+        let fs_pid = fs_guard.page_id;
+        crate::page::free_space::init(&mut fs_guard[..], fs_pid);
+        drop(fs_guard);
+        // make the root and bitmap durable BEFORE the superblock that points
+        // at them, so a crash can never leave page 0 referencing pages that
+        // were never written
         pool.flush_page(root_pid)?;
+        pool.flush_page(fs_pid)?;
         crate::page::meta::init(&mut meta_guard[..], root_pid);
+        crate::page::meta::set_free_space(&mut meta_guard[..], fs_pid);
+        *pool.free_page.lock().unwrap() = fs_pid;
         drop(meta_guard);
         pool.flush_page(meta_pid)?;
 
@@ -165,6 +228,7 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             pool,
             wal,
             root: Mutex::new(root),
+            pending_recycle: Mutex::new(Vec::new()),
             _val: PhantomData,
             _key: PhantomData,
         }
@@ -329,6 +393,10 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             let mut leaf_guard = self.pool.fetch_page_mut(leaf_pid)?;
             // Rightlink correction: follow splits that happened during descent.
             loop {
+                if page::is_half_dead(&leaf_guard[..]) {
+                    drop(leaf_guard);
+                    continue 'restart;
+                }
                 let acc = LeafPageAccessor::<K, V>::new(&leaf_guard[..]);
                 if let Some(hk) = acc.high_key_bytes()
                     && K::compare(key_bytes.as_ref(), hk) != Ordering::Less

--- a/crates/storage/src/index/smo.rs
+++ b/crates/storage/src/index/smo.rs
@@ -170,15 +170,13 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         leaf_pid: PageId,
         tm: &TransactionManager,
     ) -> Result<()> {
-        // links and high key under a shared latch
-        let (left_sibling, right_sibling, high_key) = {
+        // high key under a shared latch — the descent target below. The
+        // sibling links are NOT read here: they can go stale at any time and
+        // are re-derived under exclusive latches before the unlink is logged.
+        let high_key = {
             let guard = self.pool.fetch_page(leaf_pid)?;
             let acc = LeafPageAccessor::<K, V>::new(&guard[..]);
-            (
-                acc.prev_page(),
-                acc.rightlink(),
-                acc.high_key_bytes().map(|b| b.to_vec()),
-            )
+            acc.high_key_bytes().map(|b| b.to_vec())
         };
 
         // re-descend from the root toward the leaf's key range, collecting the
@@ -251,14 +249,22 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         };
         let mut parent_pid = entry.page_id;
 
-        // find the downlink index j, moving right if the parent split after the
-        // stack was collected
-        let (child_idx, parent_keys) = loop {
+        // Pre-check under a shared latch, moving right if the parent split
+        // after the stack was collected. This runs BEFORE the half-dead mark
+        // so bailing is still harmless: a half-dead leaf that can never be
+        // unlinked would make inserts routed to it back off forever.
+        loop {
             let guard = self.pool.fetch_page(parent_pid)?;
             let acc = InternalPageAccessor::<K>::new(&guard[..]);
             let n = acc.num_keys() as usize;
-            if let Some(j) = (0..=n).find(|&i| acc.child_page_at(i) == leaf_pid) {
-                break (j, n);
+            if (0..=n).any(|i| acc.child_page_at(i) == leaf_pid) {
+                // Only-child leaves are skipped: removing the downlink would
+                // leave a degenerate empty internal. Concurrent splits only
+                // ADD parent keys, so this pre-check cannot be invalidated.
+                if n == 0 {
+                    return Ok(());
+                }
+                break;
             }
             match acc.rightlink() {
                 Some(right) => {
@@ -269,39 +275,84 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                 // leaf (or it was never linked), nothing to do this sweep
                 None => return Ok(()),
             }
-        };
-
-        //only-child leaves are skipped, removing the downlink
-        // would leave a degenerate empty internal
-        if parent_keys == 0 {
-            return Ok(());
         }
 
-        //parent removal mapping for remove_key_at(index, ChildSide)
-        let (remove_index, keep_right_child) = if child_idx == 0 {
-            (0u16, true) // UNLINK_KEEP_RIGHT
-        } else {
-            ((child_idx - 1) as u16, false) // UNLINK_KEEP_LEFT
-        };
-
-        // ── A3: emit MarkHalfDead + UnlinkPage and apply, one latch at a time,
-        //        using left_sibling / right_sibling / parent_pid / remove_index /
-        //        keep_right_child. ──
-
-        let mut guard = self.pool.fetch_page_mut(leaf_pid)?;
-        let acc = LeafPageAccessor::<K, V>::new(&guard[..]);
-        if !page::is_half_dead(&guard[..]) {
-            if acc.num_pairs() != 0 {
-                return Ok(());
-            } else {
+        // Mark the leaf half-dead and take a fresh read of its links. After
+        // the mark the leaf can never split again (it is empty and inserts
+        // back off), so its rightlink is frozen from here on; its prev is
+        // only a hint — the true left neighbor is verified below.
+        let (prev_hint, right_sibling) = {
+            let mut guard = self.pool.fetch_page_mut(leaf_pid)?;
+            if !page::is_half_dead(&guard[..]) {
+                if LeafPageAccessor::<K, V>::new(&guard[..]).num_pairs() != 0 {
+                    return Ok(());
+                }
                 let lsn = self.wal.log_mark_half_dead(SYSTEM_TXN_ID, leaf_pid)?;
                 page::set_half_dead(&mut guard[..]);
-                let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
-                mutator.set_lsn(lsn);
+                LeafPageMutator::<K, V>::new(&mut guard[..]).set_lsn(lsn);
             }
-        }
-        drop(guard);
+            let acc = LeafPageAccessor::<K, V>::new(&guard[..]);
+            (acc.prev_page(), acc.rightlink())
+        };
 
+        // Find the true left neighbor and HOLD its exclusive latch through
+        // logging and both chain splices: the hint goes stale the moment the
+        // neighbor splits, and splicing with a stale left would orphan the
+        // split's new page from the chain. Walking right converges — pages
+        // are only ever inserted between the hint and the leaf, never removed
+        // (vacuum is the only remover and this sweep IS vacuum).
+        let mut left_guard = match prev_hint {
+            None => None,
+            Some(mut pid) => loop {
+                let guard = self.pool.fetch_page_mut(pid)?;
+                match LeafPageAccessor::<K, V>::new(&guard[..]).rightlink() {
+                    Some(next) if next == leaf_pid => break Some(guard),
+                    Some(next) => {
+                        drop(guard);
+                        pid = next;
+                    }
+                    // Chain ended before reaching the leaf — it is no longer
+                    // linked; leave it for a later sweep.
+                    None => return Ok(()),
+                }
+            },
+        };
+        let left_sibling = left_guard.as_ref().map(|g| g.page_id);
+
+        // Re-find the downlink under the parent's EXCLUSIVE latch and hold it
+        // through logging: concurrent splits insert downlinks and shift
+        // indices, so `remove_index` is only trustworthy while the latch that
+        // serializes those inserts is held. Taking an internal latch while
+        // holding a leaf latch matches finish_split's leaf→parent order.
+        let (mut parent_guard, remove_index, keep_right_child) = loop {
+            let guard = self.pool.fetch_page_mut(parent_pid)?;
+            let acc = InternalPageAccessor::<K>::new(&guard[..]);
+            let n = acc.num_keys() as usize;
+            if let Some(j) = (0..=n).find(|&i| acc.child_page_at(i) == leaf_pid) {
+                if n == 0 {
+                    return Ok(());
+                }
+                // Mapping for remove_key_at(index, ChildSide): removing child
+                // 0 keeps the right child of key 0; any other child j is the
+                // right child of key j-1.
+                let mapping = if j == 0 {
+                    (guard, 0u16, true) // UNLINK_KEEP_RIGHT
+                } else {
+                    (guard, (j - 1) as u16, false) // UNLINK_KEEP_LEFT
+                };
+                break mapping;
+            }
+            match acc.rightlink() {
+                Some(right) => {
+                    drop(guard);
+                    parent_pid = right;
+                }
+                None => return Ok(()),
+            }
+        };
+
+        // Every arm below was validated under a latch that is still held, so
+        // the record can no longer go stale between append and apply.
         let unlink_lsn = self.wal.log_unlink_page(
             SYSTEM_TXN_ID,
             leaf_pid,
@@ -312,27 +363,35 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             keep_right_child,
         )?;
 
-        if let Some(left) = &left_sibling {
-            let mut guard = self.pool.fetch_page_mut(*left)?;
-            let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
-            mutator.set_lsn(unlink_lsn);
-            mutator.set_rightlink(right_sibling);
-        }
-        if let Some(right) = &right_sibling {
-            let mut guard = self.pool.fetch_page_mut(*right)?;
-            let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
-            mutator.set_lsn(unlink_lsn);
-            mutator.set_prev_page(left_sibling);
-        }
+        // Parent first, and its latch dropped before any leaf is acquired —
+        // holding an internal latch while waiting on a leaf would deadlock
+        // against finish_split's leaf→parent order. The leaf stays reachable
+        // through the left sibling's rightlink until the splice below.
         {
-            let mut guard = self.pool.fetch_page_mut(parent_pid)?;
-            let mut mutator = InternalPageMutator::<K>::new(&mut guard[..]);
+            let mut mutator = InternalPageMutator::<K>::new(&mut parent_guard[..]);
             mutator.set_lsn(unlink_lsn);
             mutator.remove_key_at(
                 remove_index as usize,
                 if keep_right_child { Right } else { Left },
             );
         }
+        drop(parent_guard);
+
+        // Chain splice. The left latch stays held until the right sibling's
+        // back-link is fixed, so a left-sibling split cannot race its own
+        // back-link fix against this one.
+        if let Some(guard) = left_guard.as_mut() {
+            let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
+            mutator.set_lsn(unlink_lsn);
+            mutator.set_rightlink(right_sibling);
+        }
+        if let Some(right) = right_sibling {
+            let mut guard = self.pool.fetch_page_mut(right)?;
+            let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
+            mutator.set_lsn(unlink_lsn);
+            mutator.set_prev_page(left_sibling);
+        }
+        drop(left_guard);
         // snapshot that could still walk to it has drained
         self.pending_recycle
             .lock()

--- a/crates/storage/src/index/smo.rs
+++ b/crates/storage/src/index/smo.rs
@@ -1,6 +1,9 @@
 //! Structure-modification operations: leaf/internal splits, downlink
 //! propagation, and lazy split completion (self-heal).
 
+use crate::page::ChildSide::{Left, Right};
+use db_core::transaction_manager::TransactionManager;
+
 use super::*;
 
 impl<K: Key, V: Value> BTreeIndex<K, V> {
@@ -160,6 +163,183 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             split.new_page_id,
             leaf_pid_actual,
         )
+    }
+
+    pub(super) fn delete_empty_leaf(
+        &self,
+        leaf_pid: PageId,
+        tm: &TransactionManager,
+    ) -> Result<()> {
+        // links and high key under a shared latch
+        let (left_sibling, right_sibling, high_key) = {
+            let guard = self.pool.fetch_page(leaf_pid)?;
+            let acc = LeafPageAccessor::<K, V>::new(&guard[..]);
+            (
+                acc.prev_page(),
+                acc.rightlink(),
+                acc.high_key_bytes().map(|b| b.to_vec()),
+            )
+        };
+
+        // re-descend from the root toward the leaf's key range, collecting the
+        // ancestor stack, same pattern as insert's phase 1
+        // target is "just below high_key" — high_key
+        // == None means rightmost spine
+        let mut stack = BTStack::new();
+        let mut pid = *self.root.lock().unwrap();
+        loop {
+            let page = self.pool.fetch_page(pid)?;
+            if crate::page::is_incomplete_split(&page[..]) {
+                drop(page);
+                self.finish_split(pid, &stack)?;
+                stack.clear();
+                pid = *self.root.lock().unwrap();
+                continue;
+            }
+            match page[0] {
+                INTERNAL => {
+                    let acc = InternalPageAccessor::<K>::new(&page[..]);
+                    // move right only when the leaf's range can't sit under this
+                    // node, strictly greater for a keyed target, always for the
+                    // rightmost target while a rightlink exists
+                    let move_right = match (&high_key, acc.high_key_bytes()) {
+                        (Some(hk), Some(node_hk)) => K::compare(hk, node_hk) == Ordering::Greater,
+                        (None, _) => acc.rightlink().is_some(),
+                        (_, None) => false,
+                    };
+                    if move_right {
+                        let right = acc.rightlink().unwrap();
+                        drop(page);
+                        pid = right;
+                        continue;
+                    }
+                    let n = acc.num_keys() as usize;
+                    let child_idx = match &high_key {
+                        // Route left on equality- the leaf's high key is its
+                        // separator in the parent, and the leaf sits left of it
+                        // (find_child would route to the right sibling)
+                        Some(hk) => (0..n)
+                            .find(|&i| {
+                                K::compare(K::as_bytes(&acc.key_at(i)).as_ref(), hk)
+                                    != Ordering::Less
+                            })
+                            .unwrap_or(n),
+                        None => n,
+                    };
+                    let child = acc.child_page_at(child_idx);
+                    stack.push(BTStackEntry { page_id: pid });
+                    drop(page);
+                    pid = child;
+                }
+                LEAF => {
+                    drop(page);
+                    break;
+                }
+                found => {
+                    return Err(IndexError::UnexpectedPageType {
+                        expected: LEAF,
+                        found,
+                    });
+                }
+            }
+        }
+
+        // parent is last internal on the stack, empty stack means
+        //the leaf is the root
+        let Some(entry) = stack.last() else {
+            return Ok(());
+        };
+        let mut parent_pid = entry.page_id;
+
+        // find the downlink index j, moving right if the parent split after the
+        // stack was collected
+        let (child_idx, parent_keys) = loop {
+            let guard = self.pool.fetch_page(parent_pid)?;
+            let acc = InternalPageAccessor::<K>::new(&guard[..]);
+            let n = acc.num_keys() as usize;
+            if let Some(j) = (0..=n).find(|&i| acc.child_page_at(i) == leaf_pid) {
+                break (j, n);
+            }
+            match acc.rightlink() {
+                Some(right) => {
+                    drop(guard);
+                    parent_pid = right;
+                }
+                // downlink gone, now a concurrent completer already unlinked the
+                // leaf (or it was never linked), nothing to do this sweep
+                None => return Ok(()),
+            }
+        };
+
+        //only-child leaves are skipped, removing the downlink
+        // would leave a degenerate empty internal
+        if parent_keys == 0 {
+            return Ok(());
+        }
+
+        //parent removal mapping for remove_key_at(index, ChildSide)
+        let (remove_index, keep_right_child) = if child_idx == 0 {
+            (0u16, true) // UNLINK_KEEP_RIGHT
+        } else {
+            ((child_idx - 1) as u16, false) // UNLINK_KEEP_LEFT
+        };
+
+        // ── A3: emit MarkHalfDead + UnlinkPage and apply, one latch at a time,
+        //        using left_sibling / right_sibling / parent_pid / remove_index /
+        //        keep_right_child. ──
+
+        let mut guard = self.pool.fetch_page_mut(leaf_pid)?;
+        let acc = LeafPageAccessor::<K, V>::new(&guard[..]);
+        if !page::is_half_dead(&guard[..]) {
+            if acc.num_pairs() != 0 {
+                return Ok(());
+            } else {
+                let lsn = self.wal.log_mark_half_dead(SYSTEM_TXN_ID, leaf_pid)?;
+                page::set_half_dead(&mut guard[..]);
+                let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
+                mutator.set_lsn(lsn);
+            }
+        }
+        drop(guard);
+
+        let unlink_lsn = self.wal.log_unlink_page(
+            SYSTEM_TXN_ID,
+            leaf_pid,
+            left_sibling,
+            right_sibling,
+            parent_pid,
+            remove_index,
+            keep_right_child,
+        )?;
+
+        if let Some(left) = &left_sibling {
+            let mut guard = self.pool.fetch_page_mut(*left)?;
+            let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
+            mutator.set_lsn(unlink_lsn);
+            mutator.set_rightlink(right_sibling);
+        }
+        if let Some(right) = &right_sibling {
+            let mut guard = self.pool.fetch_page_mut(*right)?;
+            let mut mutator = LeafPageMutator::<K, V>::new(&mut guard[..]);
+            mutator.set_lsn(unlink_lsn);
+            mutator.set_prev_page(left_sibling);
+        }
+        {
+            let mut guard = self.pool.fetch_page_mut(parent_pid)?;
+            let mut mutator = InternalPageMutator::<K>::new(&mut guard[..]);
+            mutator.set_lsn(unlink_lsn);
+            mutator.remove_key_at(
+                remove_index as usize,
+                if keep_right_child { Right } else { Left },
+            );
+        }
+        // snapshot that could still walk to it has drained
+        self.pending_recycle
+            .lock()
+            .unwrap()
+            .push((leaf_pid, tm.global_xmin()));
+
+        Ok(())
     }
 
     fn split_leaf_ly(

--- a/crates/storage/src/index/smo.rs
+++ b/crates/storage/src/index/smo.rs
@@ -165,6 +165,18 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         )
     }
 
+    /// Abandon a leaf we marked half-dead but cannot finish unlinking this
+    fn abandon_unlink(&self, leaf_pid: PageId) -> Result<()> {
+        let mut guard = self.pool.fetch_page_mut(leaf_pid)?;
+        if page::is_half_dead(&guard[..]) {
+            page::clear_half_dead(&mut guard[..]);
+            let image: &[u8; PAGE_SIZE] = (&guard[..]).try_into().unwrap();
+            let lsn = self.wal.log_page_compact(SYSTEM_TXN_ID, leaf_pid, image)?;
+            page::set_lsn(&mut guard[..], lsn);
+        }
+        Ok(())
+    }
+
     pub(super) fn delete_empty_leaf(
         &self,
         leaf_pid: PageId,
@@ -250,9 +262,11 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
         let mut parent_pid = entry.page_id;
 
         // Pre-check under a shared latch, moving right if the parent split
-        // after the stack was collected. This runs BEFORE the half-dead mark
-        // so bailing is still harmless: a half-dead leaf that can never be
-        // unlinked would make inserts routed to it back off forever.
+        // after the stack was collected. On a fresh sweep the leaf is not yet
+        // marked, so bailing is harmless. On crash-resume the leaf enters here
+        // ALREADY half-dead, so every bail must clear the flag (via
+        // abandon_unlink) — otherwise a leaf that can never be unlinked makes
+        // inserts routed to it back off forever.
         loop {
             let guard = self.pool.fetch_page(parent_pid)?;
             let acc = InternalPageAccessor::<K>::new(&guard[..]);
@@ -262,7 +276,8 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                 // leave a degenerate empty internal. Concurrent splits only
                 // ADD parent keys, so this pre-check cannot be invalidated.
                 if n == 0 {
-                    return Ok(());
+                    drop(guard);
+                    return self.abandon_unlink(leaf_pid);
                 }
                 break;
             }
@@ -273,7 +288,10 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                 }
                 // downlink gone, now a concurrent completer already unlinked the
                 // leaf (or it was never linked), nothing to do this sweep
-                None => return Ok(()),
+                None => {
+                    drop(guard);
+                    return self.abandon_unlink(leaf_pid);
+                }
             }
         }
 
@@ -312,8 +330,11 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                         pid = next;
                     }
                     // Chain ended before reaching the leaf — it is no longer
-                    // linked; leave it for a later sweep.
-                    None => return Ok(()),
+                    // linked. Clear the mark and leave it for a later sweep.
+                    None => {
+                        drop(guard);
+                        return self.abandon_unlink(leaf_pid);
+                    }
                 }
             },
         };
@@ -330,7 +351,9 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
             let n = acc.num_keys() as usize;
             if let Some(j) = (0..=n).find(|&i| acc.child_page_at(i) == leaf_pid) {
                 if n == 0 {
-                    return Ok(());
+                    drop(guard);
+                    drop(left_guard);
+                    return self.abandon_unlink(leaf_pid);
                 }
                 // Mapping for remove_key_at(index, ChildSide): removing child
                 // 0 keeps the right child of key 0; any other child j is the
@@ -347,7 +370,11 @@ impl<K: Key, V: Value> BTreeIndex<K, V> {
                     drop(guard);
                     parent_pid = right;
                 }
-                None => return Ok(()),
+                None => {
+                    drop(guard);
+                    drop(left_guard);
+                    return self.abandon_unlink(leaf_pid);
+                }
             }
         };
 

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -1380,3 +1380,91 @@ fn crash_victim_overflow_insert_invisible_after_reopen() {
     let all: Vec<(Vec<u8>, Vec<u8>)> = index.range(.., &reader).map(|r| r.unwrap()).collect();
     assert!(all.is_empty());
 }
+
+// ── Unlink crash recovery ─────────────────────────────────────────────
+//
+// The index does not drive page deletion yet, so the pre-unlink tree is staged
+// by hand at page level: parent = [left] "m" [dead], leaf chain left = dead.
+
+#[test]
+fn recover_unlink_rightmost_leaf_ends_chain_at_left_sibling() {
+    // Extreme case: the unlinked leaf is the rightmost one (right_sibling =
+    // None), so the LEFT block's payload carries the 0 sentinel. Replay must
+    // decode it as rightlink, None, which is also Some(0), would splice the meta page into
+    // the leaf chain.
+    let dir = tempdir().unwrap();
+    let (left_pid, dead_pid, parent_pid);
+    {
+        let disk = Arc::new(DiskManager::new(dir.path().join("test.db"), MAX_PAGE_SIZE).unwrap());
+        let wal = make_wal(dir.path());
+        let pool = make_pool(disk, wal.clone());
+
+        // Burn page 0 as a meta stand-in so no real page id collides with the
+        // no_sibling sentinel.
+        drop(pool.new_page().unwrap());
+        left_pid = pool.new_page().unwrap().page_id;
+        dead_pid = pool.new_page().unwrap().page_id;
+        parent_pid = pool.new_page().unwrap().page_id;
+
+        {
+            let mut g = pool.fetch_page_mut(left_pid).unwrap();
+            let mut b = LeafPageBuilder::<&[u8], &[u8]>::new(left_pid, &mut g[..]);
+            b.set_prev_page(None);
+            b.set_rightlink(Some(dead_pid));
+            b.finish();
+        }
+        {
+            let mut g = pool.fetch_page_mut(dead_pid).unwrap();
+            let mut b = LeafPageBuilder::<&[u8], &[u8]>::new(dead_pid, &mut g[..]);
+            b.set_prev_page(Some(left_pid));
+            b.set_rightlink(None);
+            b.finish();
+            crate::page::set_half_dead(&mut g[..]);
+        }
+        {
+            let mut g = pool.fetch_page_mut(parent_pid).unwrap();
+            let mut b = InternalPageBuilder::<&[u8]>::new(parent_pid, &mut g[..]);
+            b.push_first_child(left_pid);
+            b.push_key_and_right_child(&(&b"m"[..]), dead_pid);
+            b.finish();
+        }
+        // The pre-unlink tree is durable, page lsn 0, the splice itself is
+        // WAL-only, so recovery must redo it.
+        pool.flush_all_pages().unwrap();
+
+        let txn = 1;
+        wal.log_unlink_page(txn, dead_pid, Some(left_pid), None, parent_pid, 0, false)
+            .unwrap();
+        wal.log_commit(txn).unwrap();
+        wal.flush_up_to(wal.next_lsn()).unwrap();
+        // crash
+    }
+
+    let disk = Arc::new(DiskManager::new(dir.path().join("test.db"), MAX_PAGE_SIZE).unwrap());
+    let wal = make_wal(dir.path());
+    let pool = make_pool(disk, wal.clone());
+    let tm = Arc::new(TM::new());
+    RecoveryManager::new(pool.clone(), dir.path().join("wal"), tm)
+        .recover::<&[u8], &[u8]>()
+        .unwrap();
+
+    {
+        let g = pool.fetch_page(left_pid).unwrap();
+        let left = LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]);
+        assert_eq!(
+            left.rightlink(),
+            None,
+            "left sibling must become the end of the chain, not point at page 0"
+        );
+    }
+    {
+        let g = pool.fetch_page(parent_pid).unwrap();
+        let parent = InternalPageAccessor::<&[u8]>::new(&g[..]);
+        assert_eq!(parent.num_keys(), 0, "separator key must be removed");
+        assert_eq!(
+            parent.child_page_at(0),
+            left_pid,
+            "surviving child must be the left sibling"
+        );
+    }
+}

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -1390,8 +1390,8 @@ fn crash_victim_overflow_insert_invisible_after_reopen() {
 fn recover_unlink_rightmost_leaf_ends_chain_at_left_sibling() {
     // Extreme case: the unlinked leaf is the rightmost one (right_sibling =
     // None), so the LEFT block's payload carries the 0 sentinel. Replay must
-    // decode it as rightlink, None, which is also Some(0), would splice the meta page into
-    // the leaf chain.
+    // decode it as rightlink = None; decoding it as Some(0) would splice the
+    // meta page into the leaf chain.
     let dir = tempdir().unwrap();
     let (left_pid, dead_pid, parent_pid);
     {
@@ -1467,4 +1467,542 @@ fn recover_unlink_rightmost_leaf_ends_chain_at_left_sibling() {
             "surviving child must be the left sibling"
         );
     }
+}
+
+// ── VAC-4: vacuum-driven unlink + recycle ─────────────────────────────
+//
+// Unlike the hand-staged test above, everything below goes through the real
+// driver: `vacuum` empties the leaf, `delete_empty_leaf` writes the records,
+// the drain graduates the id, `new_page` reuses it.
+
+/// Insert keys `range` (4-byte big-endian, 40-byte values) as individually
+/// committed transactions with durable Commit records, so the rows survive
+/// the crash-recovery tests below.
+fn fill_committed(idx: &Idx, wal: &Wal, tm: &Arc<TM>, range: std::ops::Range<u32>) {
+    for i in range {
+        let k = i.to_be_bytes();
+        let v = [0xAB_u8; 40];
+        let txn = tm.begin();
+        idx.insert(&(k.as_ref()), &(v.as_ref()), &txn).unwrap();
+        wal.log_commit(txn.txn_id).unwrap();
+        tm.mark_committed(txn.txn_id);
+    }
+}
+
+fn delete_committed(idx: &Idx, wal: &Wal, tm: &Arc<TM>, keys: &[u32]) {
+    for &i in keys {
+        let k = i.to_be_bytes();
+        let txn = tm.begin();
+        idx.delete(&(k.as_ref()), &txn).unwrap();
+        wal.log_commit(txn.txn_id).unwrap();
+        tm.mark_committed(txn.txn_id);
+    }
+}
+
+/// Leaf page ids left-to-right along the sibling chain.
+fn leaf_chain(idx: &Idx, pool: &BufferPoolManager) -> Vec<PageId> {
+    let mut out = Vec::new();
+    let mut pid = idx.find_leftmost_leaf(idx.root_page_id()).unwrap();
+    loop {
+        let g = pool.fetch_page(pid).unwrap();
+        let next = LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]).rightlink();
+        drop(g);
+        out.push(pid);
+        match next {
+            Some(p) => pid = p,
+            None => return out,
+        }
+    }
+}
+
+/// Rows visible to `reader` via a full forward scan; unwraps scan errors so
+/// a broken leaf chain fails loudly instead of undercounting.
+fn count_rows(idx: &Idx, reader: &Transaction) -> usize {
+    idx.range(.., reader).fold(0, |n, r| {
+        r.unwrap();
+        n + 1
+    })
+}
+
+/// All keys physically on one leaf (live and dead), decoded back to u32.
+fn leaf_keys(pool: &BufferPoolManager, pid: PageId) -> Vec<u32> {
+    let g = pool.fetch_page(pid).unwrap();
+    let acc = LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]);
+    (0..acc.num_pairs() as usize)
+        .map(|i| u32::from_be_bytes(acc.get_key(i).try_into().unwrap()))
+        .collect()
+}
+
+/// No internal page anywhere in the file may still hold a downlink to `dead`.
+fn assert_no_downlink_to(pool: &BufferPoolManager, dead: PageId) {
+    for pid in 0..pool.next_page_id() {
+        let Ok(g) = pool.fetch_page(pid) else {
+            continue;
+        };
+        if g[0] == crate::page::INTERNAL {
+            let acc = InternalPageAccessor::<&[u8]>::new(&g[..]);
+            for i in 0..=acc.num_keys() as usize {
+                assert_ne!(
+                    acc.child_page_at(i),
+                    dead,
+                    "internal page {pid} still points at the unlinked leaf"
+                );
+            }
+        }
+    }
+}
+
+/// Builds a 3+-leaf tree, durably empties its middle leaf, then "crashes"
+/// with ONLY the MarkHalfDead record in the WAL — the exact state of a crash
+/// between the two unlink records. Returns (left, dead, right, victim keys).
+fn stage_crash_between_mark_and_unlink(dir: &Path) -> (PageId, PageId, PageId, Vec<u32>) {
+    let (pool, wal, tm, idx) = build_db(dir);
+    fill_committed(&idx, &wal, &tm, 0..240);
+    let chain = leaf_chain(&idx, &pool);
+    assert!(
+        chain.len() >= 3,
+        "staging needs >= 3 leaves, got {}",
+        chain.len()
+    );
+    let mid = chain.len() / 2;
+    let (left, dead, right) = (chain[mid - 1], chain[mid], chain[mid + 1]);
+    let victims = leaf_keys(&pool, dead);
+    delete_committed(&idx, &wal, &tm, &victims);
+
+    // Everything above is durable in both files; the mark is WAL-only (its
+    // page change never reached the data file), the unlink never happened.
+    pool.flush_all_pages().unwrap();
+    wal.log_mark_half_dead(SYSTEM_TXN_ID, dead).unwrap();
+    wal.flush_up_to(wal.next_lsn()).unwrap();
+    (left, dead, right, victims)
+    // drop = crash
+}
+
+/// Test 1: emptying a middle leaf and sweeping must splice it out of the
+/// chain and the parent, with reads over the survivors intact.
+#[test]
+fn vacuum_unlinks_emptied_middle_leaf() {
+    let dir = tempdir().unwrap();
+    let (pool, wal, tm, idx) = build_db(dir.path());
+    fill_committed(&idx, &wal, &tm, 0..240);
+
+    let chain = leaf_chain(&idx, &pool);
+    assert!(
+        chain.len() >= 3,
+        "staging needs >= 3 leaves, got {}",
+        chain.len()
+    );
+    let mid = chain.len() / 2;
+    let (left, dead, right) = (chain[mid - 1], chain[mid], chain[mid + 1]);
+    let victims = leaf_keys(&pool, dead);
+    delete_committed(&idx, &wal, &tm, &victims);
+
+    let removed = idx.vacuum(&tm).unwrap();
+    assert_eq!(removed, victims.len());
+
+    // Fully unhooked: both chain directions skip it, parent downlink gone.
+    {
+        let g = pool.fetch_page(left).unwrap();
+        assert_eq!(
+            LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]).rightlink(),
+            Some(right)
+        );
+    }
+    {
+        let g = pool.fetch_page(right).unwrap();
+        assert_eq!(
+            LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]).prev_page(),
+            Some(left)
+        );
+    }
+    assert_no_downlink_to(&pool, dead);
+    assert!(!leaf_chain(&idx, &pool).contains(&dead));
+
+    // Reads over the survivors stay correct in every access path.
+    let survivors = 240 - victims.len();
+    let reader = tm.begin();
+    assert!(
+        idx.get(&(victims[0].to_be_bytes().as_ref()), &reader)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        idx.get(&(0u32.to_be_bytes().as_ref()), &reader)
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(count_rows(&idx, &reader), survivors);
+    let bwd = idx
+        .range_backward::<std::ops::RangeFull>(.., &reader)
+        .fold(0, |n, r| {
+            r.unwrap();
+            n + 1
+        });
+    assert_eq!(bwd, survivors);
+}
+
+/// Test 2: same, but for the rightmost leaf (`right_sibling = None` arm) —
+/// its left neighbor must become the new end of the chain.
+#[test]
+fn vacuum_unlinks_emptied_rightmost_leaf() {
+    let dir = tempdir().unwrap();
+    let (pool, wal, tm, idx) = build_db(dir.path());
+    fill_committed(&idx, &wal, &tm, 0..240);
+
+    let chain = leaf_chain(&idx, &pool);
+    assert!(
+        chain.len() >= 3,
+        "staging needs >= 3 leaves, got {}",
+        chain.len()
+    );
+    let (left, dead) = (chain[chain.len() - 2], chain[chain.len() - 1]);
+    let victims = leaf_keys(&pool, dead);
+    delete_committed(&idx, &wal, &tm, &victims);
+
+    let removed = idx.vacuum(&tm).unwrap();
+    assert_eq!(removed, victims.len());
+
+    {
+        let g = pool.fetch_page(left).unwrap();
+        assert_eq!(
+            LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]).rightlink(),
+            None,
+            "left neighbor must become the end of the chain"
+        );
+    }
+    assert_no_downlink_to(&pool, dead);
+    assert_eq!(leaf_chain(&idx, &pool).last(), Some(&left));
+
+    // A backward scan starts from the rightmost leaf — the arm under test.
+    let survivors = 240 - victims.len();
+    let reader = tm.begin();
+    let bwd: Vec<_> = idx
+        .range_backward::<std::ops::RangeFull>(.., &reader)
+        .map(|r| r.unwrap())
+        .collect();
+    assert_eq!(bwd.len(), survivors);
+    assert_eq!(
+        bwd[0].0,
+        victims[0].wrapping_sub(1).to_be_bytes(),
+        "new max key must be the last survivor before the deleted range"
+    );
+}
+
+/// Test 3: a crash between MarkHalfDead and UnlinkPage leaves a flagged but
+/// wired leaf; recovery must produce a walkable tree and the next sweep must
+/// FINISH the demolition rather than restart it.
+#[test]
+fn crash_between_mark_half_dead_and_unlink_is_resumable() {
+    let dir = tempdir().unwrap();
+    let (left, dead, right, victims) = stage_crash_between_mark_and_unlink(dir.path());
+
+    let (pool, _wal, tm, idx) = reopen_db(dir.path());
+
+    // Recovery replayed the mark…
+    {
+        let g = pool.fetch_page(dead).unwrap();
+        assert!(
+            crate::page::is_half_dead(&g[..]),
+            "MarkHalfDead must replay"
+        );
+    }
+    // …and the flagged-but-wired page doesn't break a forward walk.
+    let survivors = 240 - victims.len();
+    let reader = tm.begin();
+    assert_eq!(count_rows(&idx, &reader), survivors);
+
+    // The next sweep completes the interrupted unlink.
+    let removed = idx.vacuum(&tm).unwrap();
+    assert_eq!(removed, victims.len());
+    {
+        let g = pool.fetch_page(left).unwrap();
+        assert_eq!(
+            LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]).rightlink(),
+            Some(right)
+        );
+    }
+    assert_no_downlink_to(&pool, dead);
+    let reader = tm.begin();
+    assert_eq!(count_rows(&idx, &reader), survivors);
+}
+
+/// Test 4: running recovery twice over the same WAL must be a byte-identical
+/// no-op on the data file — the LSN gate skips already-applied changes.
+#[test]
+fn double_recovery_after_mid_delete_crash_is_byte_identical() {
+    let dir = tempdir().unwrap();
+    stage_crash_between_mark_and_unlink(dir.path());
+
+    drop(reopen_db(dir.path()));
+    let first = std::fs::read(dir.path().join("test.db")).unwrap();
+    drop(reopen_db(dir.path()));
+    let second = std::fs::read(dir.path().join("test.db")).unwrap();
+    assert!(
+        first == second,
+        "double recovery must be a byte-identical no-op"
+    );
+}
+
+/// Test 5: an insert that routes to a half-dead leaf must back off and retry
+/// (writer-race guard #2), landing safely once the unlink completes.
+#[test]
+fn insert_onto_half_dead_leaf_backs_off_and_survives() {
+    let dir = tempdir().unwrap();
+    let (pool, wal, tm, idx) = build_db(dir.path());
+    fill_committed(&idx, &wal, &tm, 0..240);
+
+    let chain = leaf_chain(&idx, &pool);
+    assert!(
+        chain.len() >= 3,
+        "staging needs >= 3 leaves, got {}",
+        chain.len()
+    );
+    let dead = chain[chain.len() / 2];
+    let victims = leaf_keys(&pool, dead);
+    delete_committed(&idx, &wal, &tm, &victims);
+
+    // Stage the transient window by hand: flag set, unlink not yet applied —
+    // the gap between MarkHalfDead and UnlinkPage in a live deletion.
+    {
+        let mut g = pool.fetch_page_mut(dead).unwrap();
+        crate::page::set_half_dead(&mut g[..]);
+    }
+
+    // A key that routes squarely into the half-dead leaf's range.
+    let key = victims[victims.len() / 2];
+    let idx = Arc::new(idx);
+    let writer_idx = Arc::clone(&idx);
+    let writer_tm = Arc::clone(&tm);
+    let writer = std::thread::spawn(move || {
+        let k = key.to_be_bytes();
+        let txn = writer_tm.begin();
+        writer_idx
+            .insert(&(k.as_ref()), &(&b"survivor"[..]), &txn)
+            .unwrap();
+        writer_tm.mark_committed(txn.txn_id);
+    });
+
+    // While the flag is set and the downlink exists, the insert must spin in
+    // its back-off loop rather than write onto the doomed page.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    assert!(
+        !writer.is_finished(),
+        "insert must not land on a half-dead leaf"
+    );
+
+    // Finish the demolition; the retrying insert can now route past the leaf.
+    idx.vacuum(&tm).unwrap();
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while !writer.is_finished() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "insert never completed after the unlink"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    writer.join().unwrap();
+
+    let reader = tm.begin();
+    let got = idx.get(&(key.to_be_bytes().as_ref()), &reader).unwrap();
+    assert_eq!(got.as_deref(), Some(b"survivor".as_ref()));
+    assert!(!leaf_chain(&idx, &pool).contains(&dead));
+}
+
+/// Test 6 (issue done-when): a deleted page id must stay parked while any
+/// snapshot that could walk to it is alive, and graduate to the bitmap +
+/// allocator only after the horizon passes its stamp.
+#[test]
+fn recycle_is_horizon_gated() {
+    let dir = tempdir().unwrap();
+    let (pool, wal, tm, idx) = build_db(dir.path());
+    fill_committed(&idx, &wal, &tm, 0..240);
+
+    let chain = leaf_chain(&idx, &pool);
+    assert!(
+        chain.len() >= 3,
+        "staging needs >= 3 leaves, got {}",
+        chain.len()
+    );
+    let dead = chain[chain.len() / 2];
+    let victims = leaf_keys(&pool, dead);
+    delete_committed(&idx, &wal, &tm, &victims);
+
+    // The long-lived snapshot: begins after the deletes settle, before the
+    // unlink — it can't see the dead rows but could still walk to the page.
+    let pin = tm.begin();
+
+    // Sweep #1 unlinks the leaf and parks its id, stamped with pin's xmin.
+    assert_eq!(idx.vacuum(&tm).unwrap(), victims.len());
+    let fs_pid = *pool.free_page.lock().unwrap();
+    {
+        let g = pool.fetch_page(fs_pid).unwrap();
+        assert!(
+            crate::page::free_space::scan_free(&g[..]).is_empty(),
+            "id must stay parked while the pin lives"
+        );
+    }
+    // Allocation must still grow the file, not hand out the parked id.
+    assert_ne!(pool.new_page().unwrap().page_id, dead);
+
+    // A second sweep with the pin still open changes nothing.
+    idx.vacuum(&tm).unwrap();
+    {
+        let g = pool.fetch_page(fs_pid).unwrap();
+        assert!(crate::page::free_space::scan_free(&g[..]).is_empty());
+    }
+
+    // Finish the pin: the next sweep's horizon passes the stamp.
+    tm.mark_committed(pin.txn_id);
+    idx.vacuum(&tm).unwrap();
+    {
+        let g = pool.fetch_page(fs_pid).unwrap();
+        assert_eq!(crate::page::free_space::scan_free(&g[..]), vec![dead]);
+    }
+    assert_eq!(
+        pool.new_page().unwrap().page_id,
+        dead,
+        "the very next allocation must reuse the freed id"
+    );
+}
+
+/// Test 7: a crash after UnlinkPage but before the bitmap FPI must leak the
+/// id (never free it, never hand it out twice), leave the tree walkable, and
+/// recover idempotently.
+#[test]
+fn crash_before_bitmap_fpi_leaks_id_safely() {
+    let dir = tempdir().unwrap();
+    let (left, dead, right, victims) = {
+        let (pool, wal, tm, idx) = build_db(dir.path());
+        fill_committed(&idx, &wal, &tm, 0..240);
+        let chain = leaf_chain(&idx, &pool);
+        assert!(
+            chain.len() >= 3,
+            "staging needs >= 3 leaves, got {}",
+            chain.len()
+        );
+        let mid = chain.len() / 2;
+        let (left, dead, right) = (chain[mid - 1], chain[mid], chain[mid + 1]);
+        let victims = leaf_keys(&pool, dead);
+        delete_committed(&idx, &wal, &tm, &victims);
+
+        // One sweep: the unlink lands in the WAL, but the freed id is still
+        // parked (its stamp equals this pass's own xmin), so no bitmap FPI
+        // exists yet — exactly the crash point under test.
+        idx.vacuum(&tm).unwrap();
+        let fs_pid = *pool.free_page.lock().unwrap();
+        {
+            let g = pool.fetch_page(fs_pid).unwrap();
+            assert!(crate::page::free_space::scan_free(&g[..]).is_empty());
+        }
+        wal.flush_up_to(wal.next_lsn()).unwrap();
+        (left, dead, right, victims)
+        // crash: WAL ends after UnlinkPage, no bitmap change journaled
+    };
+
+    drop(reopen_db(dir.path()));
+    let first = std::fs::read(dir.path().join("test.db")).unwrap();
+    let (pool, _wal, tm, idx) = reopen_db(dir.path());
+    let second = std::fs::read(dir.path().join("test.db")).unwrap();
+    assert!(
+        first == second,
+        "double recovery must be a byte-identical no-op"
+    );
+
+    // The replayed unlink left a walkable, spliced tree.
+    let reader = tm.begin();
+    assert_eq!(count_rows(&idx, &reader), 240 - victims.len());
+    {
+        let g = pool.fetch_page(left).unwrap();
+        assert_eq!(
+            LeafPageAccessor::<&[u8], &[u8]>::new(&g[..]).rightlink(),
+            Some(right)
+        );
+    }
+    assert_no_downlink_to(&pool, dead);
+
+    // The id is leaked: not in the bitmap, not in the pool, never handed out.
+    let fs_pid = *pool.free_page.lock().unwrap();
+    {
+        let g = pool.fetch_page(fs_pid).unwrap();
+        assert!(
+            crate::page::free_space::scan_free(&g[..]).is_empty(),
+            "crash-lost id must leak, not resurrect as free"
+        );
+    }
+    assert!(pool.free_pool.lock().unwrap().is_empty());
+    assert_ne!(
+        pool.new_page().unwrap().page_id,
+        dead,
+        "a leaked id must never be handed out"
+    );
+}
+
+/// Test 8: once a recycled id is reused, a crash must replay the page to its
+/// NEW life — the LSN gate keeps the old life's records from resurrecting.
+#[test]
+fn recycled_page_replays_to_new_contents() {
+    let dir = tempdir().unwrap();
+    let (dead, victims, inserted) = {
+        let (pool, wal, tm, idx) = build_db(dir.path());
+        fill_committed(&idx, &wal, &tm, 0..240);
+        let chain = leaf_chain(&idx, &pool);
+        assert!(
+            chain.len() >= 3,
+            "staging needs >= 3 leaves, got {}",
+            chain.len()
+        );
+        let dead = chain[chain.len() / 2];
+        let victims = leaf_keys(&pool, dead);
+        delete_committed(&idx, &wal, &tm, &victims);
+
+        idx.vacuum(&tm).unwrap(); // unlink + park
+        let bump = tm.begin(); // move the horizon past the stamp
+        tm.mark_committed(bump.txn_id);
+        idx.vacuum(&tm).unwrap(); // graduate: bitmap + free_pool hold the id
+
+        // Grow the tree until a split's new_page pops the recycled id and the
+        // page begins its new life as a leaf full of fresh keys.
+        let mut inserted = 0u32;
+        for i in 1000u32.. {
+            fill_committed(&idx, &wal, &tm, i..i + 1);
+            inserted += 1;
+            if leaf_chain(&idx, &pool).contains(&dead) {
+                break;
+            }
+            assert!(inserted < 500, "recycled id was never handed back out");
+        }
+
+        wal.flush_up_to(wal.next_lsn()).unwrap();
+        (dead, victims, inserted)
+        // crash: the new life exists only in the WAL
+    };
+
+    let (pool, _wal, tm, idx) = reopen_db(dir.path());
+
+    // The recycled page replayed to its new life…
+    {
+        let g = pool.fetch_page(dead).unwrap();
+        assert!(!crate::page::is_half_dead(&g[..]));
+    }
+    // Its contents are whatever the split moved there (which may legitimately
+    // include pre-existing keys) — but never its old life's victim rows.
+    let new_life = leaf_keys(&pool, dead);
+    assert!(!new_life.is_empty());
+    assert!(
+        !new_life.iter().any(|k| victims.contains(k)),
+        "old-life contents resurrected on the recycled page: {new_life:?}"
+    );
+
+    // …and every surviving row is exactly where it should be.
+    let reader = tm.begin();
+    assert!(
+        idx.get(&(victims[0].to_be_bytes().as_ref()), &reader)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        count_rows(&idx, &reader),
+        240 - victims.len() + inserted as usize
+    );
 }

--- a/crates/storage/src/page/free_space.rs
+++ b/crates/storage/src/page/free_space.rs
@@ -47,19 +47,7 @@ pub fn clear_free(page: &mut [u8], pid: PageId) {
     page[byte] &= !(1 << bit);
 }
 
-/// Take one free page id out of the bitmap, or `None` when nothing is free.
-pub fn pop_free(page: &mut [u8]) -> Option<PageId> {
-    for (byte, b) in page.iter_mut().enumerate().skip(BITMAP_START) {
-        if *b != 0 {
-            let bit = b.trailing_zeros();
-            *b &= !(1 << bit);
-            return Some(((byte - BITMAP_START) as u64) * 8 + bit as u64);
-        }
-    }
-    None
-}
-
-/// Take one free page id out of the bitmap, or `None` when nothing is free.
+/// All free page ids currently set in the bitmap.
 pub fn scan_free(page: &[u8]) -> Vec<PageId> {
     let mut free = Vec::new();
     for (byte, b) in page.iter().enumerate().skip(BITMAP_START) {

--- a/crates/storage/src/page/free_space.rs
+++ b/crates/storage/src/page/free_space.rs
@@ -1,0 +1,74 @@
+//! Free-space bitmap page — tracks page ids freed by vacuum for reuse
+//!
+//! One bit per page id (`set` = free). A single 4 KB page covers
+//! ~32 k page ids; ids at or beyond `CAPACITY` are simply leaked
+//! (bounded — see issue #89)
+//!
+//! ## Layout
+//! Off  0  u8   page_type = FREE_SPACE
+//! Off  8  u64  page_id
+//! Off 16  u64  lsn
+//! Off 24  u32  checksum (CRC32)
+//! Off 32..     bitmap — bit n corresponds to page id n
+use super::{FREE_SPACE, OFF_PAGE_ID, OFF_PAGE_TYPE, PAGE_SIZE, PageId, write_u8, write_u64};
+
+/// First byte of the bitmap (everything before it is header + checksum)
+const BITMAP_START: usize = 32;
+/// Number of page ids the bitmap can track (exclusive upper bound)
+pub const CAPACITY: u64 = ((PAGE_SIZE - BITMAP_START) * 8) as u64;
+
+pub fn init(page: &mut [u8], page_id: PageId) {
+    write_u8(page, OFF_PAGE_TYPE, FREE_SPACE);
+    write_u64(page, OFF_PAGE_ID, page_id);
+}
+
+#[inline]
+pub(super) fn locate(pid: PageId) -> (usize, u8) {
+    (BITMAP_START + (pid / 8) as usize, (pid % 8) as u8)
+}
+
+/// Mark `pid` as free. Returns `false` when `pid` is beyond the bitmap's
+/// capacity — the caller just leaks that id (the bounded leak path)
+pub fn set_free(page: &mut [u8], pid: PageId) -> bool {
+    if pid >= CAPACITY {
+        return false;
+    }
+    let (byte, bit) = locate(pid);
+    page[byte] |= 1 << bit;
+    true
+}
+
+/// Mark `pid` as in use again.
+pub fn clear_free(page: &mut [u8], pid: PageId) {
+    if pid >= CAPACITY {
+        return;
+    }
+    let (byte, bit) = locate(pid);
+    page[byte] &= !(1 << bit);
+}
+
+/// Take one free page id out of the bitmap, or `None` when nothing is free.
+pub fn pop_free(page: &mut [u8]) -> Option<PageId> {
+    for (byte, b) in page.iter_mut().enumerate().skip(BITMAP_START) {
+        if *b != 0 {
+            let bit = b.trailing_zeros();
+            *b &= !(1 << bit);
+            return Some(((byte - BITMAP_START) as u64) * 8 + bit as u64);
+        }
+    }
+    None
+}
+
+/// Take one free page id out of the bitmap, or `None` when nothing is free.
+pub fn scan_free(page: &[u8]) -> Vec<PageId> {
+    let mut free = Vec::new();
+    for (byte, b) in page.iter().enumerate().skip(BITMAP_START) {
+        let mut bits = *b;
+        while bits != 0 {
+            let bit = bits.trailing_zeros();
+            free.push(((byte - BITMAP_START) as u64) * 8 + bit as u64);
+            bits &= bits - 1; // clear lowest set bit (local copy only)
+        }
+    }
+    free
+}

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -625,11 +625,12 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
             return (0, Vec::new());
         }
 
-        // 3. Preserve page metadata before clearing.
+        // 3. Preserve page metadata before clearing. 
         let high_key: Option<Vec<u8>> = acc.high_key_bytes().map(|b| b.to_vec());
         let rightlink = acc.rightlink();
         let prev_page = acc.prev_page();
         let lsn = acc.lsn();
+        let flags = read_u8(page_data, super::OFF_FLAGS);
 
         // 4. Rebuild the page using the Builder.
         let mut builder = LeafPageBuilder::<K, V>::new(page_id, page_data);
@@ -644,6 +645,7 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
 
         let mut m = builder.finish();
         m.set_lsn(lsn);
+        write_u8(page_data, super::OFF_FLAGS, flags);
 
         (dead_count, orphaned_chains)
     }

--- a/crates/storage/src/page/leaf.rs
+++ b/crates/storage/src/page/leaf.rs
@@ -625,7 +625,7 @@ impl<'a, K: Key, V: Value> LeafPageMutator<'a, K, V> {
             return (0, Vec::new());
         }
 
-        // 3. Preserve page metadata before clearing. 
+        // 3. Preserve page metadata before clearing.
         let high_key: Option<Vec<u8>> = acc.high_key_bytes().map(|b| b.to_vec());
         let rightlink = acc.rightlink();
         let prev_page = acc.prev_page();

--- a/crates/storage/src/page/meta.rs
+++ b/crates/storage/src/page/meta.rs
@@ -29,6 +29,7 @@ pub const FORMAT_VERSION: u32 = 1;
 const OFF_MAGIC: usize = 4;
 const OFF_VERSION: usize = 24;
 const OFF_ROOT: usize = 32;
+const OFF_FREE_SPACE: usize = 48;
 // 40..56 reserved (next_page_id, free_list_head) — issue #2.
 // The checksum at offset 56 is owned by `super::OFF_META_CHECKSUM` (the CRC is
 // stamped/verified centrally by the buffer pool, like leaf/internal pages).
@@ -57,4 +58,12 @@ pub fn read_root(page: &[u8]) -> Option<PageId> {
         return None;
     }
     Some(read_u64(page, OFF_ROOT))
+}
+
+pub fn set_free_space(page: &mut [u8], pid: PageId) {
+    write_u64(page, OFF_FREE_SPACE, pid);
+}
+
+pub fn read_free_space(page: &[u8]) -> PageId {
+    read_u64(page, OFF_FREE_SPACE)
 }

--- a/crates/storage/src/page/mod.rs
+++ b/crates/storage/src/page/mod.rs
@@ -6,6 +6,7 @@
 //!
 //! Shared constants, helpers, and error types live here.
 
+pub mod free_space;
 pub mod internal;
 pub mod leaf;
 pub mod meta;
@@ -35,6 +36,8 @@ pub const LEAF: u8 = 1;
 pub const INTERNAL: u8 = 2;
 /// Marker byte stored at offset 0 of metadata page
 pub const META: u8 = 3;
+/// Marker byte stored at offset 0 of the free-space bitmap page.
+pub const FREE_SPACE: u8 = 5;
 /// Marker byte stored at offset 0 of every overflow page.
 pub const OVERFLOW: u8 = 4;
 // ── Page size ─────────────────────────────────────────────────────────────────
@@ -102,6 +105,8 @@ const OFF_INT_CHECKSUM: usize = 32;
 const OFF_META_CHECKSUM: usize = 56;
 /// checksum offset for overflow page
 const OFF_OVERFLOW_CHECKSUM: usize = 44;
+/// checksum offset for the free-space bitmap page
+const OFF_FREE_SPACE_CHECKSUM: usize = 24;
 /// Byte offset of the CRC32 field for the given page-type marker, or `None` for
 /// an unrecognised type (e.g. a never-initialised, all-zero page) which carries
 /// no checksum to verify.
@@ -112,7 +117,7 @@ fn checksum_offset(page_type: u8) -> Option<usize> {
         INTERNAL => Some(OFF_INT_CHECKSUM),
         META => Some(OFF_META_CHECKSUM),
         OVERFLOW => Some(OFF_OVERFLOW_CHECKSUM),
-
+        FREE_SPACE => Some(OFF_FREE_SPACE_CHECKSUM),
         _ => None,
     }
 }

--- a/crates/storage/src/recovery/mod.rs
+++ b/crates/storage/src/recovery/mod.rs
@@ -196,7 +196,8 @@ impl RecoveryManager {
                 match d[0] {
                     UNLINK_ROLE_LEFT => {
                         let new_rightlink = u64::from_le_bytes(d[1..9].try_into().unwrap());
-                        LeafPageMutator::<K, V>::new(page).set_rightlink(Some(new_rightlink));
+                        LeafPageMutator::<K, V>::new(page)
+                            .set_rightlink((new_rightlink != 0).then_some(new_rightlink));
                     }
                     UNLINK_ROLE_RIGHT => {
                         let new_prev = u64::from_le_bytes(d[1..9].try_into().unwrap());

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -884,19 +884,19 @@ impl Wal {
         txn_id: u64,
         deleted_page_id: PageId,
         left_sibling: Option<PageId>,
-        right_sibling: PageId,
+        right_sibling: Option<PageId>,
         parent_page: PageId,
         remove_index: u16,
         keep_right_child: bool,
     ) -> Result<Lsn> {
-        let mut blocks = Vec::with_capacity(if left_sibling.is_some() { 3 } else { 2 });
+        let mut blocks = Vec::with_capacity(if left_sibling.is_some() && right_sibling.is_some() { 3 } else { 2 });
 
         let left_payload;
         if let Some(left_page) = left_sibling {
             left_payload = {
                 let mut p = Vec::with_capacity(1 + 8);
                 p.push(UNLINK_ROLE_LEFT);
-                p.extend_from_slice(&right_sibling.to_le_bytes());
+                p.extend_from_slice(&right_sibling.unwrap_or(0).to_le_bytes());
                 p
             };
             blocks.push(Block {
@@ -907,15 +907,21 @@ impl Wal {
             });
         }
 
-        let mut right_payload = Vec::with_capacity(1 + 8);
-        right_payload.push(UNLINK_ROLE_RIGHT);
-        right_payload.extend_from_slice(&left_sibling.unwrap_or(0).to_le_bytes());
-        blocks.push(Block {
-            page_id: right_sibling,
-            blk_flags: BLK_HAS_DATA,
-            fpi: None,
-            data: Some(&right_payload),
-        });
+        let right_payload;
+        if let Some(right_page) = right_sibling {
+            right_payload = {
+                let mut p = Vec::with_capacity(1 + 8);
+                p.push(UNLINK_ROLE_RIGHT);
+                p.extend_from_slice(&left_sibling.unwrap_or(0).to_le_bytes());
+                p
+            };
+            blocks.push(Block {
+                page_id: right_page,
+                blk_flags: BLK_HAS_DATA,
+                fpi: None,
+                data: Some(&right_payload),
+            });
+        }
 
         let mut parent_payload = Vec::with_capacity(1 + 2 + 1);
         parent_payload.push(UNLINK_ROLE_PARENT);
@@ -1458,7 +1464,7 @@ mod tests {
         let wal_dir = dir.path().join("unlink-page-wal");
 
         let wal = Wal::new(&wal_dir)?;
-        let lsn = wal.log_unlink_page(0, 22, Some(11), 33, 44, 2, true)?;
+        let lsn = wal.log_unlink_page(0, 22, Some(11), Some(33), 44, 2, true)?;
         wal.flush_up_to(lsn)?;
 
         let mut iter = WalIterator::new(&wal_dir).map_err(WalError::Io)?;

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -889,7 +889,11 @@ impl Wal {
         remove_index: u16,
         keep_right_child: bool,
     ) -> Result<Lsn> {
-        let mut blocks = Vec::with_capacity(if left_sibling.is_some() && right_sibling.is_some() { 3 } else { 2 });
+        let mut blocks = Vec::with_capacity(if left_sibling.is_some() && right_sibling.is_some() {
+            3
+        } else {
+            2
+        });
 
         let left_payload;
         if let Some(left_page) = left_sibling {


### PR DESCRIPTION
## Summary
Completes the vacuum sweep: emptied leaves are now spliced out of the tree (`MarkHalfDead` leading to `UnlinkPage`), their page ids are parked and later recycled through a free-space bitmap page once the horizon guarantees no snapshot can still reach them, and an autovacuum worker drives the whole sweep automatically. Also fills the `Engine::open` stubs with a `Db` handle that owns the background checkpointer and vacuum threads.

## Changes
- **Driver:** `delete_empty_leaf` in the sweep — when `compact` empties a leaf, emit `MarkHalfDead` then `UnlinkPage`, splice it out of the sibling chain and remove the parent downlink, holding one latch at a time; concurrent descents route around it via the rightlink (inserts back off from a half-dead leaf and restart).
- **Delayed recycle:** unlinked ids are parked in `pending_recycle` stamped with the current horizon; a completed sweep graduates ids whose stamp `global_xmin` has passed into the bitmap + in-memory free pool. A partial (abandoned) pass never drains or publishes.
- **Free space:** bitmap free-space page (one bit per page id, pointed to by the superblock); `new_page` pops the free pool, clears the bit, and journals the bitmap via the existing FPI path. Ids beyond bitmap capacity leak (bounded). Old databases have no bitmap pointer and simply keep bumping the high-water mark.
- **Redo arms:** LSN-gated handlers for `MarkHalfDead` and `UnlinkPage` (all three roles), idempotent under double recovery; `UnlinkPage` now supports unlinking the rightmost leaf (`right_sibling = None`).
- **Autovacuum worker:** `Db::create/open` spawn a vacuum thread triggered by a dead-version threshold (`dead_versions` counter fed at op time), swept in bounded resumable batches with cost-based nap throttling (`vacuum_paced`); `oldest_active_txn_age` surfaces a pinned `global_xmin`. The checkpointer thread rides along in the same `Db` handle with graceful `close`/`Drop` shutdown.

## Related Issue
Closes #89

## Any design changes?
The recycle redo arm is deferred (see issue discussion) — ids parked in memory at crash time leak rather than replay, which is the agreed bounded-leak tradeoff. `new_page` pops the bitmap-backed free pool directly instead of an intrusive free list.

## Checklist
- [x] Tests added/updated
- [ ] Docs updated
- [x] No breaking changes
