### PR TITLE
Feat/checkpoint procedure

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -14,7 +14,7 @@
 
 use common::{EngineError, Key, Value};
 use db_core::transaction_manager::{TransactionManager, TransactionStatus};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::RwLock;
 use storage::buffer_pool::BufferPoolManager;
@@ -51,6 +51,8 @@ where
     /// Commit and abort hold this in shared mode across their WAL append and CLOG update.
     /// Checkpoints hold it in exclusive mode while picking a redo point and snapshotting.
     pub(crate) status_guard: RwLock<()>,
+
+    pub(crate) db_dir: PathBuf,
 }
 
 impl<K, V> Engine<K, V>
@@ -89,6 +91,7 @@ where
             disk_manager,
             transaction_manager,
             status_guard: RwLock::new(()),
+            db_dir: path.to_path_buf(),
         })
     }
     /// Opens an existing database.
@@ -129,6 +132,7 @@ where
             disk_manager,
             transaction_manager,
             status_guard: RwLock::new(()),
+            db_dir: path.to_path_buf(),
         })
     }
 
@@ -196,11 +200,14 @@ where
         )?;
 
         self.wal.flush_up_to(lsn)?;
-        
+
         //flush all dirty pages to buffer_pool
         self.buffer_pool.flush_all_pages()?;
 
-        // Notify buffer pool of the new checkpoint redo point for recovery optimization
+        // atomically write the superblock so recovery can find this checkpoint.
+        self.disk_manager
+            .atomic_write_file(&self.superblock_path, &lsn.to_le_bytes())?;
+
         self.buffer_pool.update_checkpoint_redo_point(redo_point);
 
         Ok(redo_point)

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -66,6 +66,25 @@ where
     /// writes the initial metadata/root pages. Creating over an existing
     /// database returns [`EngineError::AlreadyExists`].
     pub fn create(dir_path: impl AsRef<Path>) -> Result<Engine<K, V>, EngineError> {
+        Self::create_with_wal(dir_path, |wal_dir| Ok(Arc::new(Wal::new(wal_dir)?)))
+    }
+
+    /// Like [`Engine::create`], but with a custom WAL segment size. Test-only
+    /// hook so segment-boundary/reclaim behavior can be exercised without
+    /// writing `WAL_SEGMENT_SIZE` bytes per segment.
+    pub fn create_with_wal_segment_size(
+        dir_path: impl AsRef<Path>,
+        wal_segment_size: u64,
+    ) -> Result<Engine<K, V>, EngineError> {
+        Self::create_with_wal(dir_path, move |wal_dir| {
+            Ok(Arc::new(Wal::with_segment_size(wal_dir, wal_segment_size)?))
+        })
+    }
+
+    fn create_with_wal(
+        dir_path: impl AsRef<Path>,
+        make_wal: impl FnOnce(&Path) -> Result<Arc<Wal>, EngineError>,
+    ) -> Result<Engine<K, V>, EngineError> {
         let path = dir_path.as_ref();
         std::fs::create_dir_all(path)?;
         let exist = path.join("data.db").exists();
@@ -75,7 +94,7 @@ where
         // initialize disk manager
         let disk_manager = Arc::new(DiskManager::new(path.join("data.db"), PAGE_SIZE)?);
         // initialize WAL shared by the index and buffer pool.
-        let wal = Arc::new(Wal::new(path.join("wal"))?);
+        let wal = make_wal(&path.join("wal"))?;
         let buffer_pool = Arc::new(BufferPoolManager::new(
             Arc::clone(&disk_manager),
             Arc::clone(&wal),
@@ -118,6 +137,7 @@ where
             Arc::clone(&buffer_pool),
             path.join("wal"),
             Arc::clone(&transaction_manager),
+            path.join("checkpoint.superblock"),
         );
         recovery.recover::<K, V>()?;
 
@@ -210,6 +230,12 @@ where
 
         self.buffer_pool.update_checkpoint_redo_point(redo_point);
 
+        // Step 5: reclaim WAL segments now fully covered by this committed
+        // checkpoint. Non-fatal: the checkpoint itself is already durable.
+        if let Err(e) = self.wal.reclaim_segments_below(redo_point) {
+            tracing::warn!("WAL segment reclaim failed after checkpoint: {:?}", e);
+        }
+
         Ok(redo_point)
     }
 
@@ -299,6 +325,11 @@ where
     /// A `false` from the pacer abandons the pass: no drain, no horizon publish.
     pub fn vacuum_paced(&self, pacer: impl FnMut(usize) -> bool) -> Result<usize, EngineError> {
         Ok(self.index.vacuum_paced(&self.transaction_manager, pacer)?)
+    }
+
+    /// Current vacuum horizon (exposed for tests and observability).
+    pub fn vacuum_horizon(&self) -> u64 {
+        self.transaction_manager.vacuum_horizon()
     }
 
     /// Flushes all dirty pages to disk (used for tests and clean shutdown).

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -51,8 +51,8 @@ where
     /// Commit and abort hold this in shared mode across their WAL append and CLOG update.
     /// Checkpoints hold it in exclusive mode while picking a redo point and snapshotting.
     pub(crate) status_guard: RwLock<()>,
-
-    pub(crate) db_dir: PathBuf,
+    /// Path to the database directory (needed to write the superblock).
+    pub(crate) superblock_path: PathBuf,
 }
 
 impl<K, V> Engine<K, V>
@@ -91,7 +91,7 @@ where
             disk_manager,
             transaction_manager,
             status_guard: RwLock::new(()),
-            db_dir: path.to_path_buf(),
+            superblock_path: path.join("checkpoint.superblock"),
         })
     }
     /// Opens an existing database.
@@ -132,7 +132,7 @@ where
             disk_manager,
             transaction_manager,
             status_guard: RwLock::new(()),
-            db_dir: path.to_path_buf(),
+            superblock_path: path.join("checkpoint.superblock"),
         })
     }
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -196,6 +196,9 @@ where
         )?;
 
         self.wal.flush_up_to(lsn)?;
+        
+        //flush all dirty pages to buffer_pool
+        self.buffer_pool.flush_all_pages()?;
 
         // Notify buffer pool of the new checkpoint redo point for recovery optimization
         self.buffer_pool.update_checkpoint_redo_point(redo_point);

--- a/crates/engine/src/proptests.rs
+++ b/crates/engine/src/proptests.rs
@@ -1232,9 +1232,14 @@ fn raw_reopen_db(dir: &Path) -> (Arc<BufferPoolManager>, Arc<Wal>, Arc<RawTM>, R
     let wal = Arc::new(Wal::new(dir.join("wal")).unwrap());
     let pool = Arc::new(BufferPoolManager::new(disk, wal.clone()));
     let tm = Arc::new(RawTM::new());
-    RecoveryManager::new(pool.clone(), dir.join("wal"), tm.clone())
-        .recover::<&[u8], &[u8]>()
-        .unwrap();
+    RecoveryManager::new(
+        pool.clone(),
+        dir.join("wal"),
+        tm.clone(),
+        dir.join("checkpoint.superblock"),
+    )
+    .recover::<&[u8], &[u8]>()
+    .unwrap();
     let index = BTreeIndex::open(pool.clone(), wal.clone()).unwrap();
     (pool, wal, tm, index)
 }

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -34,7 +34,7 @@ where
             return Ok(());
         }
         //Starting the RwLock which will be active until the its dropped
-        // Ignore poison: lock holds no data, and doing this ensures checkpoint panics never crash user commits.
+        // Ignore poison: lock holds no data, and doing this ensures checkpoint panics never crash user commit
         let _guard = self.status_guard.read().unwrap_or_else(|e| e.into_inner());
 
         let lsn_res = self.wal.log_commit(txn.txn_id);

--- a/crates/engine/src/txn.rs
+++ b/crates/engine/src/txn.rs
@@ -33,8 +33,7 @@ where
             self.transaction_manager.mark_committed(txn.txn_id);
             return Ok(());
         }
-        //Starting the RwLock which will be active until the its dropped
-        // Ignore poison: lock holds no data, and doing this ensures checkpoint panics never crash user commit
+        // Held until dropped at end of scope, so commit and checkpoint never run concurrently.
         let _guard = self.status_guard.read().unwrap_or_else(|e| e.into_inner());
 
         let lsn_res = self.wal.log_commit(txn.txn_id);
@@ -170,7 +169,6 @@ impl<K: Key, V: Value> Drop for TxnHandle<'_, K, V> {
 }
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use std::sync::Arc;

--- a/crates/engine/tests/checkpoint.rs
+++ b/crates/engine/tests/checkpoint.rs
@@ -2,6 +2,14 @@ use engine::Engine;
 use storage::wal::{WalIterator, WalRecordType};
 use tempfile::TempDir;
 
+fn superblock_path(dir: &TempDir) -> std::path::PathBuf {
+    dir.path().join("checkpoint.superblock")
+}
+
+fn segment_count(dir: &TempDir) -> usize {
+    std::fs::read_dir(dir.path().join("wal")).unwrap().count()
+}
+
 type TestEngine = Engine<&'static [u8], &'static [u8]>;
 
 fn fresh_engine() -> (TempDir, TestEngine) {
@@ -179,4 +187,183 @@ fn test_checkpoint_recovery() {
         v4, None,
         "k4 should be aborted as a ghost transaction crash victim"
     );
+}
+
+/// Leaks a formatted key/value pair to get `'static` byte slices for `TestEngine`.
+fn static_kv(i: u64) -> (&'static [u8], &'static [u8]) {
+    let key = format!("key-{i:06}").into_bytes().leak() as &'static [u8];
+    let value = format!("val-{i:06}").into_bytes().leak() as &'static [u8];
+    (key, value)
+}
+
+#[test]
+fn test_checkpoint_durability_survives_eviction() {
+    let (dir, engine) = fresh_engine();
+
+    // Enough distinct keys to overflow the 80-frame pool and force evictions
+    // (and their now-unsynced page writes) well before the checkpoint runs.
+    const N: u64 = 2000;
+    let mut kvs = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        let (k, v) = static_kv(i);
+        engine.insert(&k, &v).unwrap();
+        kvs.push((k, v));
+    }
+
+    engine.checkpoint().expect("Checkpoint failed");
+    drop(engine);
+
+    let engine = TestEngine::open(dir.path()).expect("Reopen failed");
+    for (k, v) in kvs {
+        assert_eq!(
+            engine.get(&k).unwrap(),
+            Some(v.to_vec()),
+            "key {k:?} missing after reopen"
+        );
+    }
+}
+
+#[test]
+fn test_checkpoint_reclaims_wal_segments_and_recovers() {
+    let dir = TempDir::new().unwrap();
+    // Small segments so a modest workload spans many of them (must still fit
+    // multi-FPI split records, which run past 8 KB).
+    let engine = TestEngine::create_with_wal_segment_size(dir.path(), 64 * 1024).unwrap();
+
+    // Aborted ghost: its only WAL records will live in reclaimed segments.
+    let mut aborted = engine.begin();
+    aborted
+        .insert(&b"ghost-key".as_slice(), &b"ghost-val".as_slice())
+        .unwrap();
+    drop(aborted); // drop aborts
+
+    const N: u64 = 2000;
+    let mut kvs = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        let (k, v) = static_kv(i);
+        engine.insert(&k, &v).unwrap();
+        kvs.push((k, v));
+    }
+
+    let segments_before = segment_count(&dir);
+    assert!(
+        segments_before > 2,
+        "workload should span multiple segments, got {segments_before}"
+    );
+
+    // Clean pool -> redo_point advances past the old segments; checkpoint reclaims them.
+    engine.flush_all_pages().unwrap();
+    engine.checkpoint().expect("Checkpoint failed");
+
+    let segments_after = segment_count(&dir);
+    assert!(
+        segments_after < segments_before,
+        "checkpoint should reclaim old segments ({segments_before} -> {segments_after})"
+    );
+
+    // "Crash" and recover.
+    drop(engine);
+    let engine = TestEngine::open(dir.path()).expect("Recovery failed");
+
+    for (k, v) in &kvs {
+        assert_eq!(engine.get(k).unwrap(), Some(v.to_vec()));
+    }
+    // Ghost's WAL records were reclaimed; pinned_aborted seeding must hide it.
+    assert_eq!(
+        engine.get(&b"ghost-key".as_slice()).unwrap(),
+        None,
+        "aborted ghost must stay invisible after its WAL records were reclaimed"
+    );
+}
+
+#[test]
+fn test_recovery_ignores_checkpoint_without_superblock() {
+    let dir = TempDir::new().unwrap();
+    let engine = TestEngine::create(dir.path()).unwrap();
+
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    engine.checkpoint().expect("Checkpoint failed");
+    engine.insert(&b"k2".as_slice(), &b"v2".as_slice()).unwrap();
+    drop(engine);
+
+    // Simulate a crash between the checkpoint record (step 2) and the
+    // superblock write (step 4): the record exists but is not committed.
+    std::fs::remove_file(superblock_path(&dir)).unwrap();
+
+    let engine = TestEngine::open(dir.path()).expect("Recovery failed");
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
+    assert_eq!(engine.get(&b"k2".as_slice()).unwrap(), Some(b"v2".to_vec()));
+}
+
+#[test]
+fn test_recovery_falls_back_on_corrupt_superblock() {
+    let dir = TempDir::new().unwrap();
+    let engine = TestEngine::create(dir.path()).unwrap();
+
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    engine.checkpoint().expect("Checkpoint failed");
+    drop(engine);
+
+    // Wrong size.
+    std::fs::write(superblock_path(&dir), b"junk").unwrap();
+    let engine = TestEngine::open(dir.path()).expect("Recovery failed");
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
+    drop(engine);
+
+    // Right size, garbage LSN (no matching checkpoint record).
+    std::fs::write(superblock_path(&dir), u64::MAX.to_le_bytes()).unwrap();
+    let engine = TestEngine::open(dir.path()).expect("Recovery failed");
+    assert_eq!(engine.get(&b"k1".as_slice()).unwrap(), Some(b"v1".to_vec()));
+}
+
+#[test]
+fn test_recovery_seeds_vacuum_horizon_from_checkpoint() {
+    let dir = TempDir::new().unwrap();
+    let engine = TestEngine::create(dir.path()).unwrap();
+
+    engine.insert(&b"k1".as_slice(), &b"v1".as_slice()).unwrap();
+    engine.delete(&b"k1".as_slice()).unwrap();
+    engine.vacuum().expect("Vacuum failed"); // full sweep publishes a horizon
+
+    let horizon = engine.vacuum_horizon();
+    assert!(horizon > 0, "vacuum should have published a horizon");
+
+    engine.checkpoint().expect("Checkpoint failed");
+    drop(engine);
+
+    let engine = TestEngine::open(dir.path()).expect("Recovery failed");
+    assert_eq!(
+        engine.vacuum_horizon(),
+        horizon,
+        "recovery should seed the vacuum horizon from the checkpoint"
+    );
+}
+
+#[test]
+fn test_checkpoint_durability_with_clean_pool() {
+    let (dir, engine) = fresh_engine();
+
+    const N: u64 = 2000;
+    let mut kvs = Vec::with_capacity(N as usize);
+    for i in 0..N {
+        let (k, v) = static_kv(i);
+        engine.insert(&k, &v).unwrap();
+        kvs.push((k, v));
+    }
+
+    // Flush every dirty page ahead of the checkpoint, so the pool holds zero
+    // dirty frames when checkpoint() runs. Only an unconditional fsync makes
+    // the evicted/flushed pages durable in this case.
+    engine.flush_all_pages().unwrap();
+    engine.checkpoint().expect("Checkpoint failed");
+    drop(engine);
+
+    let engine = TestEngine::open(dir.path()).expect("Reopen failed");
+    for (k, v) in kvs {
+        assert_eq!(
+            engine.get(&k).unwrap(),
+            Some(v.to_vec()),
+            "key {k:?} missing after reopen"
+        );
+    }
 }

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -247,17 +247,14 @@ impl BufferPoolManager {
 
     /// Flushes all dirty pages in the buffer pool to disk.
     ///
-    /// Each shard writes its dirty pages first, then performs one data-file
-    /// sync for that shard. This preserves WAL-before-page while avoiding an
-    /// `fdatasync` per dirty page.
-    ///
     /// # Errors
     ///
     /// * Returns [`BufferPoolError::InternalError`] if a disk I/O error occurs.
     pub fn flush_all_pages(&self) -> Result<()> {
         for shard in &self.shards {
-            shard.flush_all_pages()?;
+            shard.flush_all_pages_no_sync()?;
         }
+        self.shards[0].disk_manager.sync_data()?;
         Ok(())
     }
 
@@ -337,15 +334,6 @@ impl BufferPoolManager {
     pub fn advance_next_page_id(&self, target_id: u64) {
         let mut id = self.next_page_id.lock().unwrap();
         *id = max(*id, target_id);
-    }
-
-    /// Updates the last_checkpoint_redo_point for all shards.
-    pub fn update_checkpoint_redo_point(&self, redo_point: u64) {
-        for shard in &self.shards {
-            shard
-                .last_checkpoint_redo_point
-                .store(redo_point, std::sync::atomic::Ordering::Relaxed);
-        }
     }
 
     /// Returns the min rec_lsn among all the frame by comparing minimun lsn of the shards

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -5,6 +5,7 @@ use crate::wal::Wal;
 use common::{BufferPoolError, MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
 use std::cmp::max;
 use std::sync::{Arc, Mutex};
+use std::sync::atomic::Ordering::Release;
 
 pub type Result<T> = std::result::Result<T, BufferPoolError>;
 
@@ -354,5 +355,12 @@ impl BufferPoolManager {
             .iter()
             .filter_map(|shard| shard.inner.lock().unwrap().min_rec_lsn)
             .min()
+    }
+
+    /// Notifies every shard of new checkpoint redo point
+    pub fn update_checkpoint_redo_point(&self , redo_point:Lsn) {
+        for shard in &self.shards {
+            shard.last_checkpoint_redo_point.store(redo_point,Release);
+        }
     }
 }

--- a/crates/storage/src/buffer_pool/manager.rs
+++ b/crates/storage/src/buffer_pool/manager.rs
@@ -4,8 +4,8 @@ use crate::page::{Lsn, PAGE_SIZE, PageId};
 use crate::wal::Wal;
 use common::{BufferPoolError, MAX_FRAMES, NUM_SHARDS, SHARD_MASK};
 use std::cmp::max;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::Ordering::Release;
+use std::sync::{Arc, Mutex};
 
 pub type Result<T> = std::result::Result<T, BufferPoolError>;
 
@@ -357,10 +357,10 @@ impl BufferPoolManager {
             .min()
     }
 
-    /// Notifies every shard of new checkpoint redo point
-    pub fn update_checkpoint_redo_point(&self , redo_point:Lsn) {
+    /// Notifies every shard of new checkpoint redo
+    pub fn update_checkpoint_redo_point(&self, redo_point: Lsn) {
         for shard in &self.shards {
-            shard.last_checkpoint_redo_point.store(redo_point,Release);
+            shard.last_checkpoint_redo_point.store(redo_point, Release);
         }
     }
 }

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -252,9 +252,11 @@ impl BufferPoolShard {
 
             if is_dirty && old_page_id != INVALID_FRAME_ID {
                 drop(inner);
-                self.flush_page(old_page_id)?;
+                // Data-file durability is no longer this path's job: the checkpoint's
+                // single batched fsync covers it, so eviction skips sync_data here.
+                self.flush_page_without_sync(old_page_id)?;
                 inner = self.inner.lock().unwrap();
-                continue; // need to re-check the table now as someone might have loaded this frame while we were flushing 
+                continue; // need to re-check the table now as someone might have loaded this frame while we were flushing
             }
 
             if old_page_id != INVALID_FRAME_ID {
@@ -365,8 +367,8 @@ impl BufferPoolShard {
         Ok(true)
     }
 
-    pub fn flush_all_pages(&self) -> Result<()> {
-        let mut written_pages = Vec::new();
+    /// Writes every dirty frame in this shard to disk without syncing.
+    pub fn flush_all_pages_no_sync(&self) -> Result<()> {
         let n_frames = self.pages.len();
         for frame_id in 0..n_frames {
             let (pid, is_dirty) = {
@@ -374,22 +376,10 @@ impl BufferPoolShard {
                 let meta = &inner.metadata[frame_id];
                 (meta.page_id, meta.is_dirty)
             };
-            if is_dirty && pid != INVALID_FRAME_ID && self.flush_page_without_sync(pid)? {
-                written_pages.push(pid);
+            if is_dirty && pid != INVALID_FRAME_ID {
+                self.flush_page_without_sync(pid)?;
             }
         }
-        if !written_pages.is_empty()
-            && let Err(e) = self.disk_manager.sync_data()
-        {
-            let mut inner = self.inner.lock().unwrap();
-            for pid in written_pages {
-                if let Some(&frame_id) = inner.page_table.get(&pid) {
-                    inner.metadata[frame_id].is_dirty = true;
-                }
-            }
-            return Err(e.into());
-        }
-
         Ok(())
     }
 

--- a/crates/storage/src/buffer_pool/shard.rs
+++ b/crates/storage/src/buffer_pool/shard.rs
@@ -460,7 +460,7 @@ impl BufferPoolShard {
     /// returns 'true' if the FPI is to be attached with WAL record
     /// page_lsn_before <= redo_point ensures that this is the first change in page after the last checkpoint
     pub fn mark_dirty(&self, page_id: u64, lsn: Lsn, page_lsn_before: Lsn) -> bool {
-        let redo_point = self.last_checkpoint_redo_point.load(Ordering::Relaxed);
+        let redo_point = self.last_checkpoint_redo_point.load(Ordering::Acquire);
         let mut inner = self.inner.lock().unwrap();
 
         if let Some(&frame_id) = inner.page_table.get(&page_id) {

--- a/crates/storage/src/index/tests.rs
+++ b/crates/storage/src/index/tests.rs
@@ -73,9 +73,14 @@ fn reopen_db(dir: &Path) -> (Arc<BufferPoolManager>, Arc<Wal>, Arc<TM>, Idx) {
     let wal = make_wal(dir);
     let pool = make_pool(disk, wal.clone());
     let tm = Arc::new(TM::new());
-    RecoveryManager::new(pool.clone(), dir.join("wal"), tm.clone())
-        .recover::<&[u8], &[u8]>()
-        .unwrap();
+    RecoveryManager::new(
+        pool.clone(),
+        dir.join("wal"),
+        tm.clone(),
+        dir.join("checkpoint.superblock"),
+    )
+    .recover::<&[u8], &[u8]>()
+    .unwrap();
     let index = BTreeIndex::open(pool.clone(), wal.clone()).unwrap();
     (pool, wal, tm, index)
 }
@@ -1444,9 +1449,14 @@ fn recover_unlink_rightmost_leaf_ends_chain_at_left_sibling() {
     let wal = make_wal(dir.path());
     let pool = make_pool(disk, wal.clone());
     let tm = Arc::new(TM::new());
-    RecoveryManager::new(pool.clone(), dir.path().join("wal"), tm)
-        .recover::<&[u8], &[u8]>()
-        .unwrap();
+    RecoveryManager::new(
+        pool.clone(),
+        dir.path().join("wal"),
+        tm,
+        dir.path().join("checkpoint.superblock"),
+    )
+    .recover::<&[u8], &[u8]>()
+    .unwrap();
 
     {
         let g = pool.fetch_page(left_pid).unwrap();

--- a/crates/storage/src/recovery/mod.rs
+++ b/crates/storage/src/recovery/mod.rs
@@ -11,6 +11,7 @@
 //! may still be redone, but MVCC visibility hides them through the rebuilt CLOG.
 
 use std::collections::HashSet;
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -37,51 +38,95 @@ pub struct RecoveryManager {
     pool: Arc<BufferPoolManager>,
     wal_dir: PathBuf,
     tm: Arc<TransactionManager>,
+    superblock_path: PathBuf,
+}
+
+/// Result of reading `<db_dir>/checkpoint.superblock`.
+enum SuperblockState {
+    /// No superblock file — fresh DB or pre-superblock DB. Stay silent.
+    Missing,
+    /// Present but wrong size / unreadable — warn and fall back.
+    Invalid,
+    Valid(crate::page::Lsn),
 }
 
 impl RecoveryManager {
     /// Creates a recovery manager over a WAL segment directory.
     ///
     /// `wal_dir` must be the same directory used by the live [`crate::wal::Wal`]
-    /// manager, usually `<db>/wal`.
+    /// manager, usually `<db>/wal`. `superblock_path` is `<db_dir>/checkpoint.superblock`.
     pub fn new(
         pool: Arc<BufferPoolManager>,
         wal_dir: PathBuf,
         tm: Arc<TransactionManager>,
+        superblock_path: PathBuf,
     ) -> Self {
-        Self { pool, wal_dir, tm }
+        Self {
+            pool,
+            wal_dir,
+            tm,
+            superblock_path,
+        }
+    }
+
+    /// Reads and validates the superblock file (8-byte LE checkpoint LSN).
+    fn read_superblock(&self) -> SuperblockState {
+        match std::fs::read(&self.superblock_path) {
+            Ok(bytes) if bytes.len() == 8 => {
+                SuperblockState::Valid(u64::from_le_bytes(bytes.try_into().unwrap()))
+            }
+            Ok(_) => SuperblockState::Invalid,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => SuperblockState::Missing,
+            Err(_) => SuperblockState::Invalid,
+        }
     }
 
     /// Replay the WAL in LSN order: rebuild the CLOG, mark crash victims, restore
     /// the txn-id allocator, and redo page changes. Idempotent (LSN-gated).
     pub fn recover<K: Key, V: Value>(&self) -> Result<()> {
-        // PASS 1: Find the latest valid Checkpoint record
+        // PASS 1: Find the checkpoint record named by the superblock.
         let mut checkpoint_opt: Option<crate::wal::CheckpointData> = None;
 
-        {
-            let mut iter = WalIterator::new(&self.wal_dir).map_err(WalError::Io)?;
-            while let Some(r) = iter.next_record() {
-                let record = r?;
-                if record.entry_type == WalRecordType::Checkpoint {
-                    match record.parse_checkpoint() {
-                        Ok(data) => {
-                            checkpoint_opt = Some(data);
+        match self.read_superblock() {
+            SuperblockState::Valid(target_lsn) => {
+                let mut iter = WalIterator::new(&self.wal_dir).map_err(WalError::Io)?;
+                let mut found = false;
+                while let Some(r) = iter.next_record() {
+                    let record = r?;
+                    if record.entry_type == WalRecordType::Checkpoint && record.lsn == target_lsn {
+                        found = true;
+                        match record.parse_checkpoint() {
+                            Ok(data) => checkpoint_opt = Some(data),
+                            Err(e) => {
+                                tracing::warn!(
+                                    "corrupt checkpoint record at superblock LSN {}: {:?}; falling back to full replay",
+                                    target_lsn,
+                                    e
+                                );
+                            }
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                "Warning: corrupt checkpoint at LSN {}: {:?}",
-                                record.lsn,
-                                e
-                            );
-                        }
+                        break;
                     }
                 }
+                if !found {
+                    tracing::warn!(
+                        "superblock names checkpoint LSN {} but no matching record was found in the WAL; falling back to full replay",
+                        target_lsn
+                    );
+                }
             }
+            SuperblockState::Invalid => {
+                tracing::warn!(
+                    "checkpoint superblock is missing or malformed; falling back to full replay"
+                );
+            }
+            SuperblockState::Missing => {} // fresh DB / pre-superblock DB: stay silent.
         }
 
-        // Seed CLOG from checkpoint (if found)
+        // Seed CLOG and vacuum horizon from checkpoint (if found).
         if let Some(ref ckpt) = checkpoint_opt {
             self.tm.seed_clog_from_checkpoint(&ckpt.pinned_aborted);
+            self.tm.publish_vacuum_horizon(ckpt.vacuum_horizon);
         }
 
         // Determine redo starting point and initial watermarks
@@ -105,15 +150,6 @@ impl RecoveryManager {
             while let Some(r) = iter.next_record() {
                 let record = r?;
 
-                // TODO: Skip records below the redo point once checkpoint flushes pages
-                // Currently, checkpoints don't flush dirty pages (DESIGN.md step 3), so
-                // skipping WAL records below the redo point would lose data. We must replay
-                // all records until page flushing is implemented.
-                // if record.lsn < redo_point {
-                //     continue;
-                // }
-                let _ = redo_point; // silence unused warning
-
                 // Track all txn IDs seen in record headers
                 if record.txn_id != 0 {
                     seen.insert(record.txn_id);
@@ -125,13 +161,25 @@ impl RecoveryManager {
                     max_page_id = max_page_id.max(block.page_id);
                 }
 
-                // Apply the record
+                // Records below redo_point were already flushed + fsynced by the
+                // checkpoint (Phase 1); still scan them (above) but skip page redo.
+                // Commit/Abort are cheap CLOG updates, not page I/O — always applied.
+                let below_redo_point = record.lsn < redo_point;
+
                 match record.entry_type {
                     WalRecordType::Commit => self.tm.mark_committed(record.txn_id),
                     WalRecordType::Abort => self.tm.mark_aborted(record.txn_id),
                     WalRecordType::Checkpoint => {} // skip checkpoint records in redo
-                    WalRecordType::OverflowFree => self.redo_overflow_free(&record)?,
-                    _ => self.redo_record::<K, V>(&record)?,
+                    WalRecordType::OverflowFree => {
+                        if !below_redo_point {
+                            self.redo_overflow_free(&record)?;
+                        }
+                    }
+                    _ => {
+                        if !below_redo_point {
+                            self.redo_record::<K, V>(&record)?;
+                        }
+                    }
                 }
             }
         }

--- a/crates/storage/src/wal.rs
+++ b/crates/storage/src/wal.rs
@@ -53,7 +53,7 @@
 
 use crc32fast::Hasher;
 use std::collections::VecDeque;
-use std::fs::{File, OpenOptions, create_dir_all, metadata, read_dir};
+use std::fs::{self, File, OpenOptions, create_dir_all, metadata, read_dir};
 use std::io::{self, BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -860,6 +860,12 @@ impl Wal {
         Self::new_with_buffer_capacity(path, WAL_BUFFER_CAPACITY)
     }
 
+    /// Opens (or creates) a WAL directory with a custom segment size,
+    /// test helper only
+    pub fn with_segment_size(path: impl AsRef<Path>, segment_size: u64) -> Result<Self> {
+        Self::new_with_options(path, WAL_BUFFER_CAPACITY, segment_size)
+    }
+
     fn new_with_buffer_capacity(path: impl AsRef<Path>, buffer_capacity: usize) -> Result<Self> {
         Self::new_with_options(path, buffer_capacity, WAL_SEGMENT_SIZE)
     }
@@ -1515,6 +1521,59 @@ impl Wal {
             }
         }
     }
+
+    /// Deletes WAL segments that are entirely below `redo_point`, returning
+    /// how many were deleted.
+    ///
+    /// A segment is entirely below `redo_point` iff the first record LSN of
+    /// the *next* segment is `<= redo_point` (LSNs are monotonic across
+    /// segments). The active (highest-index) segment is never deleted, and an
+    /// unreadable/empty next-segment head stops reclaim at that point
+    /// (conservative — never deletes speculatively).
+    pub fn reclaim_segments_below(&self, redo_point: Lsn) -> Result<usize> {
+        // Lock the writer only to snapshot a consistent segment list + the
+        // active segment index; deletion itself doesn't touch the append path.
+        let (dir, active_index) = {
+            let writer = self.shared.writer.lock().unwrap();
+            (writer.layout.dir.clone(), writer.segment_index)
+        };
+
+        let segments = list_segments(&dir).map_err(WalError::Io)?;
+        let mut deleted = 0;
+
+        for i in 0..segments.len() {
+            let (index, path) = &segments[i];
+            if *index >= active_index {
+                break; // never delete the active segment
+            }
+            let Some((_, next_path)) = segments.get(i + 1) else {
+                break; // no next-segment head to check — stop conservatively
+            };
+            match first_record_lsn(next_path) {
+                Some(next_first_lsn) if next_first_lsn <= redo_point => {
+                    fs::remove_file(path).map_err(WalError::Io)?;
+                    deleted += 1;
+                }
+                _ => break, // segments are LSN-monotonic: nothing further is eligible either
+            }
+        }
+
+        if deleted > 0 {
+            let dir_file = File::open(&dir).map_err(WalError::Io)?;
+            dir_file.sync_all().map_err(WalError::Io)?;
+        }
+
+        Ok(deleted)
+    }
+}
+
+/// Reads the LSN (first 8 bytes) of the first record in a segment file.
+/// Returns `None` if the file is empty, too short, or unreadable.
+fn first_record_lsn(path: &Path) -> Option<Lsn> {
+    let mut file = File::open(path).ok()?;
+    let mut buf = [0u8; 8];
+    file.read_exact(&mut buf).ok()?;
+    Some(Lsn::from_le_bytes(buf))
 }
 
 #[cfg(test)]
@@ -1848,6 +1907,75 @@ mod tests {
         let reopened = Wal::new_with_options(&wal_dir, 1024, 64)?;
         assert_eq!(reopened.next_lsn(), 6);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_reclaim_segments_below_boundary() -> Result<()> {
+        let dir = tempdir().map_err(WalError::Io)?;
+        let wal_dir = dir.path().join("reclaim-wal");
+        // 28-byte commit records, segment_size=64 -> 2 records/segment.
+        let wal = Wal::new_with_options(&wal_dir, 1024, 64)?;
+        for txn_id in 0..5 {
+            wal.log_commit(txn_id)?;
+        }
+        wal.flush_up_to(5)?;
+
+        // Segments: [1: lsn 1,2] [2: lsn 3,4] [3: lsn 5] (active).
+        assert_eq!(list_segments(&wal_dir).map_err(WalError::Io)?.len(), 3);
+
+        // redo_point == segment 2's first lsn (3) -> segment 1 is entirely below, deleted.
+        let deleted = wal.reclaim_segments_below(3)?;
+        assert_eq!(deleted, 1);
+        let remaining = list_segments(&wal_dir).map_err(WalError::Io)?;
+        assert_eq!(remaining.len(), 2);
+        assert_eq!(remaining[0].0, 2);
+        assert_eq!(remaining[1].0, 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reclaim_segments_below_keeps_segment_above_boundary() -> Result<()> {
+        let dir = tempdir().map_err(WalError::Io)?;
+        let wal_dir = dir.path().join("reclaim-wal-2");
+        let wal = Wal::new_with_options(&wal_dir, 1024, 64)?;
+        for txn_id in 0..5 {
+            wal.log_commit(txn_id)?;
+        }
+        wal.flush_up_to(5)?;
+
+        // redo_point == 2, segment 2's first lsn is 3 > 2 -> segment 1 kept.
+        let deleted = wal.reclaim_segments_below(2)?;
+        assert_eq!(deleted, 0);
+        assert_eq!(list_segments(&wal_dir).map_err(WalError::Io)?.len(), 3);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reclaim_never_deletes_active_segment() -> Result<()> {
+        let dir = tempdir().map_err(WalError::Io)?;
+        let wal_dir = dir.path().join("reclaim-wal-3");
+        let wal = Wal::new_with_options(&wal_dir, 1024, 64)?;
+        wal.log_commit(1)?;
+        wal.flush_up_to(1)?;
+
+        // Only one (active) segment exists; a huge redo_point must not delete it.
+        let deleted = wal.reclaim_segments_below(u64::MAX)?;
+        assert_eq!(deleted, 0);
+        assert_eq!(list_segments(&wal_dir).map_err(WalError::Io)?.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reclaim_on_empty_dir_is_noop() -> Result<()> {
+        let dir = tempdir().map_err(WalError::Io)?;
+        let wal_dir = dir.path().join("reclaim-wal-4");
+        let wal = Wal::new(&wal_dir)?;
+        let deleted = wal.reclaim_segments_below(1000)?;
+        assert_eq!(deleted, 0);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Wires up the final steps of the checkpointing procedure (flushing pages and atomic superblock writes) and ensures FPI generation stays in sync across buffer pool shards.
## Changes
- Added `superblock_path` to `Engine` to pre-compute the path once at startup, avoiding heap allocation churn during background checkpoints.
- Added step 3 to `checkpoint()`: flushed all dirty pages to disk via `buffer_pool.flush_all_pages()`.
- Added step 4 to `checkpoint()`: atomically wrote the new LSN to `checkpoint.superblock` using `disk_manager`.
- Added `update_checkpoint_redo_point` to `BufferPoolManager` and called it in `checkpoint()` to push the new checkpoint to shards for correct FPI generation.
- removes fsync on eviction of pages 
- added a helper to fsync all pages at once 
- used that helper in checkpoint to flush all pages 
- adds a `reclaim_segments_below` function which deletes segments below redo point 
- adds crash recovery and durability tests for checkpoint on recovery 

## Related Issue
Closes #95 #96 #97
## Any design changes?
Added 'superblock_path' field to 'Engine' to precompute the path at startup
## Checklist
- [x] Tests added/updated
- [x] Docs updated
- [x] No breaking changes